### PR TITLE
Integration of the HGC eg ID

### DIFF
--- a/DataFormats/Phase2L1ParticleFlow/interface/PFCluster.h
+++ b/DataFormats/Phase2L1ParticleFlow/interface/PFCluster.h
@@ -50,8 +50,14 @@ namespace l1t
           bool isEM() const { return hwQual() == 1; }
           void setIsEM(bool isEM) { setHwQual(isEM ? 1 : 0); }
 
+          float egVsPionMVAOut() const { return egVsPionMVAOut_; }
+          void setEgVsPionMVAOut(float egVsPionMVAOut) { egVsPionMVAOut_ = egVsPionMVAOut; }
+          
+          float egVsPUMVAOut() const { return egVsPUMVAOut_; }
+          void setEgVsPUMVAOut(float egVsPUMVAOut) { egVsPUMVAOut_ = egVsPUMVAOut; }
+
       private:
-          float hOverE_, ptError_;
+          float hOverE_, ptError_, egVsPionMVAOut_, egVsPUMVAOut_;
           ConstituentsAndFractions constituents_;
   };
   

--- a/DataFormats/Phase2L1ParticleFlow/src/classes_def.xml
+++ b/DataFormats/Phase2L1ParticleFlow/src/classes_def.xml
@@ -1,6 +1,8 @@
 <lcgdict>
                       
-  <class name="l1t::PFCluster" ClassVersion="3">
+  <class name="l1t::PFCluster" ClassVersion="5">
+        <version ClassVersion="5" checksum="1668592434"/>
+        <version ClassVersion="4" checksum="387028836"/>
         <version ClassVersion="3" checksum="2630618461"/>
   </class> 
   <class name="l1t::PFClusterCollection"/>

--- a/L1Trigger/Phase2L1ParticleFlow/BuildFile.xml
+++ b/L1Trigger/Phase2L1ParticleFlow/BuildFile.xml
@@ -5,6 +5,11 @@
 <use name="FastSimulation/BaseParticlePropagator"/>
 <use name="FastSimulation/Particle"/>
 <use name="DataFormats/ParticleFlowReco"/>
+
+<use   name="L1Trigger/L1THGCal"/>
+<use   name="CommonTools/Utils"/>
+<use   name="CommonTools/MVAUtils"/>
+<use   name="roottmva"/>
 <export>
   <lib name="1"/>
 </export>

--- a/L1Trigger/Phase2L1ParticleFlow/interface/HGC3DClusterEgID.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/HGC3DClusterEgID.h
@@ -1,0 +1,94 @@
+#ifndef L1Trigger_Phase2L1ParticleFlow_HGC3DClusterEgID_h
+#define L1Trigger_Phase2L1ParticleFlow_HGC3DClusterEgID_h
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/L1THGCal/interface/HGCalMulticluster.h"
+#include "DataFormats/Phase2L1ParticleFlow/interface/PFCluster.h"
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+#include "CommonTools/Utils/interface/StringObjectFunction.h"
+#include "CommonTools/MVAUtils/interface/TMVAZipReader.h"
+
+#include "TMVA/Factory.h"
+#include "TMVA/Reader.h"
+
+#include <vector>
+#include <cmath>
+
+namespace l1tpf {
+    class HGC3DClusterEgID { 
+        public:
+            HGC3DClusterEgID(const edm::ParameterSet & pset) :
+                isPUFilter_(pset.getParameter<bool>("isPUFilter")),
+                preselection_(pset.getParameter<std::string>("preselection")),
+                method_(pset.getParameter<std::string>("method")),
+                weightsFile_(pset.getParameter<std::string>("weightsFile")),
+                reader_(new TMVA::Reader()),
+                wp_(pset.getParameter<std::string>("wp"))
+            {
+                // first create all the variables
+                for (const auto & psvar : pset.getParameter<std::vector<edm::ParameterSet>>("variables")) {
+                    variables_.emplace_back(psvar.getParameter<std::string>("name"), psvar.getParameter<std::string>("value"));
+                }
+                for (const auto & psvar : pset.getParameter<std::vector<edm::ParameterSet>>("spectators")) {
+                    spectators_.emplace_back(psvar.getParameter<std::string>("name"), psvar.getParameter<std::string>("value"));
+                }
+            }
+            
+            void prepareTMVA() {
+                // Declare the variables
+                for (auto & var : variables_) var.declare(*reader_);
+                for (auto & var : spectators_) var.declareSpectator(*reader_);
+                // then read the weights
+                if (weightsFile_[0] != '/' && weightsFile_[0] != '.') {
+                    weightsFile_ = edm::FileInPath(weightsFile_).fullPath();
+                }
+                reco::details::loadTMVAWeights(&*reader_, method_, weightsFile_);
+            }
+            
+            float passID(l1t::HGCalMulticluster c, l1t::PFCluster &cpf) {
+                if (preselection_(c)) {
+                    for (auto & var : variables_) var.fill(c);
+                    for (auto & var : spectators_) var.fill(c);
+                    float mvaOut = reader_->EvaluateMVA(method_);
+                    if(isPUFilter_) cpf.setEgVsPUMVAOut(mvaOut);
+                    else cpf.setEgVsPionMVAOut(mvaOut);
+                    return (mvaOut > wp_(c) ? 1 : 0);
+                }
+                else {
+                    if(isPUFilter_) cpf.setEgVsPUMVAOut(-100.0);
+                    else cpf.setEgVsPionMVAOut(-100.0);
+                    return 0;
+                }
+            }
+            
+            std::string method() {
+                return method_;
+            }
+        private:
+            class Var {
+                public:
+                    Var(const std::string & name, const std::string & expr) : 
+                        name_(name), expr_(expr) {}
+                    void declare(TMVA::Reader & r) { r.AddVariable(name_, &val_); }
+                    void declareSpectator(TMVA::Reader & r) { r.AddSpectator(name_, &val_); }
+                    void fill(const l1t::HGCalMulticluster & c) { val_ = expr_(c); }
+                private:
+                    std::string name_;
+                    StringObjectFunction<l1t::HGCalMulticluster> expr_;
+                    float val_;
+            };
+
+            bool isPUFilter_;
+            StringCutObjectSelector<l1t::HGCalMulticluster> preselection_;
+            std::vector<Var> variables_, spectators_;
+            std::string method_, weightsFile_;
+            std::unique_ptr<TMVA::Reader> reader_;
+            StringObjectFunction<l1t::HGCalMulticluster> wp_;
+    }; //class
+}; //namespace
+
+#endif

--- a/L1Trigger/Phase2L1ParticleFlow/python/pfClustersFromHGC3DClusters_cfi.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/pfClustersFromHGC3DClusters_cfi.py
@@ -4,9 +4,44 @@ pfClustersFromHGC3DClusters = cms.EDProducer("PFClusterProducerFromHGC3DClusters
     src = cms.InputTag("hgcalBackEndLayer2Producer","HGCalBackendLayer2Processor3DClustering"),
     corrector = cms.string("L1Trigger/Phase2L1ParticleFlow/data/hadcorr_HGCal3D_TC.root"),
     correctorEmfMax = cms.double(1.125),
-    emId  = cms.string("hOverE < 0.3 && hOverE >= 0"),
+    preEmId  = cms.string("hOverE >= 0"),
+    emVsPionID = cms.PSet(
+        isPUFilter = cms.bool(False),
+        preselection = cms.string(""),
+        method = cms.string(""), # "" to be disabled
+        variables = cms.VPSet(
+            cms.PSet(name = cms.string("eta"), value = cms.string("eta()")),
+            cms.PSet(name = cms.string("coreShowerLength"), value = cms.string("coreShowerLength()")),
+            cms.PSet(name = cms.string("maxLayer"), value = cms.string("maxLayer()")),
+            cms.PSet(name = cms.string("hOverE"), value = cms.string("hOverE()")),
+            cms.PSet(name = cms.string("sigmaZZ"), value = cms.string("sigmaZZ()")),
+        ),
+        spectators = cms.VPSet( #Dummy variables, they don't participate in the weights but they need to be there
+            cms.PSet(name = cms.string("genpt"), value = cms.string("pt()")),
+            cms.PSet(name = cms.string("genid"), value = cms.string("pdgId()")),
+        ),
+        weightsFile = cms.string("/eos/cms/store/cmst3/user/evourlio/PF_L1_SelectionWeights/PhotonVsChargedPion/MVAnalysis_BDT.weights.xml"),
+        wp = cms.string("-0.02")
+    ),
+    emVsPUID = cms.PSet(
+        isPUFilter = cms.bool(True),
+        preselection = cms.string(""),
+        method = cms.string(""), # "" to be disabled
+        variables = cms.VPSet(
+            cms.PSet(name = cms.string("eta"), value = cms.string("eta()")),
+            cms.PSet(name = cms.string("coreShowerLength"), value = cms.string("coreShowerLength()")),
+            cms.PSet(name = cms.string("maxLayer"), value = cms.string("maxLayer()")),
+            cms.PSet(name = cms.string("sigmaPhiPhiTot"), value = cms.string("sigmaPhiPhiTot()")),
+        ),
+        spectators = cms.VPSet( #Dummy variables, they don't participate in the weights but they need to be there
+            cms.PSet(name = cms.string("genpt"), value = cms.string("pt()")),
+            cms.PSet(name = cms.string("genid"), value = cms.string("pdgId()")),
+        ),
+        weightsFile = cms.string("/eos/cms/store/cmst3/user/evourlio/PF_L1_SelectionWeights/PhotonPionVsPU/MVAnalysis_BDT.weights.xml"),
+        wp = cms.string("-0.02")
+    ),
     emOnly = cms.bool(False),
-    etMin = cms.double(1.0), 
+    etMin = cms.double(1.0),
     resol = cms.PSet(
         etaBins = cms.vdouble( 1.900,  2.200,  2.500,  2.800,  2.950),
         offset  = cms.vdouble( 2.889,  3.215,  3.238,  2.979,  3.333),

--- a/L1Trigger/Phase2L1ParticleFlow/src/HGC3DClusterEgID.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/HGC3DClusterEgID.cc
@@ -1,0 +1,1 @@
+#include "L1Trigger/Phase2L1ParticleFlow/interface/HGC3DClusterEgID.h"


### PR DESCRIPTION
This pull request contains the integration of the HGC eg IDs (vs. Charged Pions and vs. PU) into PF:
- PFCluster class updated to save the MVA output of the selections.
- HGC3DClusterEgID class created in order to set up and apply the MVA selection.
- PFClusterProducerFromHGC3DClusters.cc and pfClustersFromHGC3DClusters_cfi.py updated to include the IDs.