### PR TITLE
first implementation of tkMuon in PF

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/interface/RegionMapper.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/RegionMapper.h
@@ -6,6 +6,10 @@
 #include "DataFormats/Math/interface/deltaPhi.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkMuonParticle.h"    
+#include "DataFormats/L1TrackTrigger/interface/L1TkMuonParticleFwd.h" 
+
 #include <unordered_map>
 
 namespace l1tpf_impl { 
@@ -17,6 +21,7 @@ namespace l1tpf_impl {
         // add object, without tracking references
         void addTrack( const l1t::PFTrack & t ) ;
         void addMuon( const l1t::Muon & t );
+        void addMuon( const l1t::L1TkMuonParticle & t );
         void addCalo( const l1t::PFCluster & t ); 
         void addEmCalo( const l1t::PFCluster & t ); 
 

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TPFProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TPFProducer.cc
@@ -155,12 +155,10 @@ L1TPFProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
     
     /// ------ READ MUONS ----
-
     /// ------- first check that not more than one version of muons (standaloneMu or trackerMu) is set to be used in l1pflow
     if (useStandaloneMuons_ && useTrackerMuons_) {
         throw cms::Exception("Configuration", "setting useStandaloneMuons=True && useTrackerMuons=True is not to be done, as it would duplicate all muons\n");
     }
-
 
     if(useStandaloneMuons_) {
 	edm::Handle<l1t::MuonBxCollection> muons;
@@ -171,7 +169,6 @@ L1TPFProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     	    l1regions_.addMuon(mu, l1t::PFCandidate::MuonRef(muons, muons->key(it)));
     	}
     }
-
 
     if(useTrackerMuons_) {
         edm::Handle<l1t::L1TkMuonParticleCollection> muons;

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TPFProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TPFProducer.cc
@@ -153,8 +153,16 @@ L1TPFProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
         }
     }
 
+    
     /// ------ READ MUONS ----
-    if(useStandaloneMuons_ && !useTrackerMuons_) {
+
+    /// ------- first check that not more than one version of muons (standaloneMu or trackerMu) is set to be used in l1pflow
+    if (useStandaloneMuons_ && useTrackerMuons_) {
+        throw cms::Exception("Configuration", "setting useStandaloneMuons=True && useTrackerMuons=True is not to be done, as it would duplicate all muons\n");
+    }
+
+
+    if(useStandaloneMuons_) {
 	edm::Handle<l1t::MuonBxCollection> muons;
     	iEvent.getByToken(muCands_, muons);
     	for (auto it = muons->begin(0), ed = muons->end(0); it != ed; ++it) {
@@ -164,10 +172,8 @@ L1TPFProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     	}
     }
 
-    // typedef std::vector< L1TkMuonParticle > L1TkMuonParticleCollection ; 
 
-
-    if(!useStandaloneMuons_ && useTrackerMuons_) {
+    if(useTrackerMuons_) {
         edm::Handle<l1t::L1TkMuonParticleCollection> muons;
     	iEvent.getByToken(tkMuCands_, muons);
     	for (auto it = muons->begin(), ed = muons->end(); it != ed; ++it) {

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TPFProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TPFProducer.cc
@@ -23,6 +23,8 @@
 #include "L1Trigger/Phase2L1ParticleFlow/interface/PuppiAlgo.h"
 #include "L1Trigger/Phase2L1ParticleFlow/interface/LinearizedPuppiAlgo.h"
 
+#include "DataFormats/L1TrackTrigger/interface/L1TkMuonParticle.h"    
+#include "DataFormats/L1TrackTrigger/interface/L1TkMuonParticleFwd.h" 
 //--------------------------------------------------------------------------------------------------
 class L1TPFProducer : public edm::stream::EDProducer<> {
     public:
@@ -31,6 +33,9 @@ class L1TPFProducer : public edm::stream::EDProducer<> {
     private:
         int debug_;
 
+        bool useStandaloneMuons_;
+        bool useTrackerMuons_;
+
         bool hasTracks_;
         edm::EDGetTokenT<l1t::PFTrackCollection> tkCands_;
         float trkPt_, trkMaxChi2_;
@@ -38,7 +43,8 @@ class L1TPFProducer : public edm::stream::EDProducer<> {
         l1tpf_impl::PUAlgoBase::VertexAlgo vtxAlgo_;  
         edm::EDGetTokenT<std::vector<l1t::Vertex>> extVtx_;
 
-        edm::EDGetTokenT<l1t::MuonBxCollection> muCands_;
+        edm::EDGetTokenT<l1t::MuonBxCollection> muCands_; // standalone muons
+        edm::EDGetTokenT<l1t::L1TkMuonParticleCollection> tkMuCands_;         // tk muons
 
         std::vector<edm::EDGetTokenT<l1t::PFClusterCollection>> emCands_;
         std::vector<edm::EDGetTokenT<l1t::PFClusterCollection>> hadCands_;
@@ -48,6 +54,7 @@ class L1TPFProducer : public edm::stream::EDProducer<> {
         l1tpf_impl::RegionMapper l1regions_;
         std::unique_ptr<l1tpf_impl::PFAlgoBase> l1pfalgo_;
         std::unique_ptr<l1tpf_impl::PUAlgoBase> l1pualgo_;
+
 
         // region of interest debugging
         float debugEta_, debugPhi_, debugR_;
@@ -60,12 +67,15 @@ class L1TPFProducer : public edm::stream::EDProducer<> {
 //
 L1TPFProducer::L1TPFProducer(const edm::ParameterSet& iConfig):
     debug_(iConfig.getUntrackedParameter<int>("debug",0)),
+    useStandaloneMuons_(iConfig.getParameter<bool>("useStandaloneMuons")),
+    useTrackerMuons_(iConfig.getParameter<bool>("useTrackerMuons")),
     hasTracks_(!iConfig.getParameter<edm::InputTag>("tracks").label().empty()),
     tkCands_(hasTracks_ ? consumes<l1t::PFTrackCollection>(iConfig.getParameter<edm::InputTag>("tracks")) : edm::EDGetTokenT<l1t::PFTrackCollection>()),
     trkPt_(iConfig.getParameter<double>("trkPtCut")),
     trkMaxChi2_(iConfig.getParameter<double>("trkMaxChi2")),
     trkMinStubs_(iConfig.getParameter<unsigned>("trkMinStubs")),
     muCands_(consumes<l1t::MuonBxCollection>(iConfig.getParameter<edm::InputTag>("muons"))),
+    tkMuCands_(consumes<l1t::L1TkMuonParticleCollection>(iConfig.getParameter<edm::InputTag>("tkMuons"))),
     emPtCut_(iConfig.getParameter<double>("emPtCut")),
     hadPtCut_(iConfig.getParameter<double>("hadPtCut")),
     l1regions_(iConfig),
@@ -144,12 +154,27 @@ L1TPFProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     }
 
     /// ------ READ MUONS ----
-    edm::Handle<l1t::MuonBxCollection> muons;
-    iEvent.getByToken(muCands_, muons);
-    for (auto it = muons->begin(0), ed = muons->end(0); it != ed; ++it) {
-        const l1t::Muon & mu = *it;
-        if (debugR_ > 0 && deltaR(mu.eta(),mu.phi(),debugEta_,debugPhi_) > debugR_) continue;
-        l1regions_.addMuon(mu, l1t::PFCandidate::MuonRef(muons, muons->key(it)));
+    if(useStandaloneMuons_ && !useTrackerMuons_) {
+	edm::Handle<l1t::MuonBxCollection> muons;
+    	iEvent.getByToken(muCands_, muons);
+    	for (auto it = muons->begin(0), ed = muons->end(0); it != ed; ++it) {
+    	    const l1t::Muon & mu = *it;
+    	    if (debugR_ > 0 && deltaR(mu.eta(),mu.phi(),debugEta_,debugPhi_) > debugR_) continue;
+    	    l1regions_.addMuon(mu, l1t::PFCandidate::MuonRef(muons, muons->key(it)));
+    	}
+    }
+
+    // typedef std::vector< L1TkMuonParticle > L1TkMuonParticleCollection ; 
+
+
+    if(!useStandaloneMuons_ && useTrackerMuons_) {
+        edm::Handle<l1t::L1TkMuonParticleCollection> muons;
+    	iEvent.getByToken(tkMuCands_, muons);
+    	for (auto it = muons->begin(), ed = muons->end(); it != ed; ++it) {
+    	    const l1t::L1TkMuonParticle & mu = *it;
+    	    if (debugR_ > 0 && deltaR(mu.eta(),mu.phi(),debugEta_,debugPhi_) > debugR_) continue;
+    	    l1regions_.addMuon(mu);  // FIXME add a l1t::PFCandidate::MuonRef
+    	}
     }
 
     // ------ READ CALOS -----

--- a/L1Trigger/Phase2L1ParticleFlow/python/l1pfProducer_cfi.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1pfProducer_cfi.py
@@ -5,6 +5,10 @@ from math import sqrt
 l1pfProducer = cms.EDProducer("L1TPFProducer",
      tracks = cms.InputTag('pfTracksFromL1Tracks'),
      muons = cms.InputTag('simGmtStage2Digis',),
+     tkMuons = cms.InputTag('L1TkMuons'),
+     # type of muons to be used in PF (if both are set to true, none will be used)
+     useStandaloneMuons = cms.bool(True), 
+     useTrackerMuons = cms.bool(False),
      emClusters = cms.VInputTag(cms.InputTag('pfClustersFromHGC3DClustersEM'), cms.InputTag('pfClustersFromL1EGClusters')),
      hadClusters = cms.VInputTag(cms.InputTag('pfClustersFromCombinedCalo:calibrated')),
      emPtCut  = cms.double(0.5),

--- a/L1Trigger/Phase2L1ParticleFlow/python/l1pfProducer_cfi.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1pfProducer_cfi.py
@@ -6,7 +6,7 @@ l1pfProducer = cms.EDProducer("L1TPFProducer",
      tracks = cms.InputTag('pfTracksFromL1Tracks'),
      muons = cms.InputTag('simGmtStage2Digis',),
      tkMuons = cms.InputTag('L1TkMuons'),
-     # type of muons to be used in PF (if both are set to true, none will be used)
+     # type of muons to be used in PF (enable only one at a time)
      useStandaloneMuons = cms.bool(True), 
      useTrackerMuons = cms.bool(False),
      emClusters = cms.VInputTag(cms.InputTag('pfClustersFromHGC3DClustersEM'), cms.InputTag('pfClustersFromL1EGClusters')),

--- a/L1Trigger/Phase2L1ParticleFlow/src/RegionMapper.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/RegionMapper.cc
@@ -89,6 +89,21 @@ void RegionMapper::addMuon( const l1t::Muon &mu ) {
         }
     } 
 }
+
+
+void RegionMapper::addMuon( const l1t::L1TkMuonParticle &mu) {
+    // now let's be optimistic and make things very simple
+    // we don't propagate anything
+    for (Region &r : regions_) {
+        if (r.contains(mu.eta(), mu.phi())) {
+            Muon prop;
+            prop.fill(mu.pt(), r.localEta(mu.eta()), r.localPhi(mu.phi()), mu.charge(), mu.hwQual());
+            r.muon.push_back(prop);
+        }
+    } 
+}
+
+
 void RegionMapper::addMuon( const l1t::Muon &mu, l1t::PFCandidate::MuonRef ref ) {
     addMuon(mu);
     muonRefMap_[&mu] = ref;


### PR DESCRIPTION
This PR implements the ability to

1) deactivate Muons in L1PF
2) use track matched muons from L1TkMuonParticle

This is controlled with the python configurable boolean flags (**useStandaloneMuons**, **useTrackerMuons**) in **l1pfProducer_cfi.py**. 


