### PR TITLE
[L1PF_10_6_X] Add dump and COE File Output

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/interface/COEFile.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/COEFile.h
@@ -1,0 +1,42 @@
+#ifndef L1Trigger_Phase2L1ParticleFlow_CoeFile_h
+#define L1Trigger_Phase2L1ParticleFlow_CoeFile_h
+
+// system include files
+#include <vector>
+#include <string>
+#include <numeric>
+#include <boost/dynamic_bitset.hpp>
+#include <boost/multiprecision/cpp_int.hpp> 
+
+// user include files
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/Phase2L1ParticleFlow/interface/PFCandidate.h"
+#include "L1Trigger/Phase2L1ParticleFlow/interface/DiscretePFInputs.h"
+#include "L1Trigger/Phase2L1ParticleFlow/interface/Region.h"
+
+namespace l1tpf_impl {
+	class COEFile {
+
+		public:
+			COEFile(const edm::ParameterSet&) ;
+			~COEFile();
+
+			void close() { fclose(file); }
+			template<typename T>
+			bool getBit(T value, unsigned bit) { return (value >> bit) & 1; }
+			bool is_open() { return (file != nullptr); }
+			void writeHeaderToFile();
+			void writeTracksToFile(const std::vector<Region>& regions, bool print = false);
+
+		protected:
+			FILE *file;
+			std::string coeFileName, bset_string_;
+			unsigned int ntracksmax, phiSlices;
+			static constexpr unsigned int tracksize = 96;
+			boost::dynamic_bitset<> bset_;
+			const std::vector<uint32_t> track_word_block_sizes = {14,1,12,16,12,13,4,3,7,14};
+			int debug_;
+	};
+} // namespace
+
+#endif

--- a/L1Trigger/Phase2L1ParticleFlow/interface/DiscretePFInputs.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/DiscretePFInputs.h
@@ -76,10 +76,10 @@ namespace l1tpf_impl {
       const l1t::PFTrack *src;
 
 #ifdef L1Trigger_Phase2L1ParticleFlow_DiscretePFInputs_MORE
-      static constexpr float INVPT_SCALE   = 2E4;    // 1%/pt @ 100 GeV is 2 bits 
-      static constexpr float VTX_PHI_SCALE = 1/2.5E-6; // 5 micro rad is 2 bits
-      static constexpr float VTX_ETA_SCALE = 1/1E-5;   // no idea, but assume it's somewhat worse than phi
-      static constexpr float Z0_SCALE      = 20;     // 1mm is 2 bits
+      static constexpr float INVPT_SCALE   = 2E4;      // 1%/pt @ 100 GeV is 2 bits 
+      static constexpr float VTX_PHI_SCALE = 1/1.6E-3; // 5 micro rad is 2 bits
+      static constexpr float VTX_ETA_SCALE = 1/1E-4;   // no idea, but assume it's somewhat worse than phi
+      static constexpr float Z0_SCALE      = 20;       // 1mm is 2 bits
       static constexpr int32_t VTX_ETA_1p3 = 1.3 * InputTrack::VTX_ETA_SCALE;
 
       // filling from floating point

--- a/L1Trigger/Phase2L1ParticleFlow/interface/DiscretePFInputsIO.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/DiscretePFInputsIO.h
@@ -88,9 +88,16 @@ namespace l1tpf_impl {
         m.src = nullptr;
     }
 
+    void writeToFile(const float & pug, FILE * file) {
+        fwrite(&pug, sizeof(float), 1, file);
+    }
+    void readFromFile(float & pug, FILE *file) {
+        fread(&pug, sizeof(float), 1, file);
+    }
+
     template<typename T>
     void writeManyToFile(const std::vector<T> & objs, FILE *file) {
-        uint32_t number = objs.size(); 
+        uint32_t number = objs.size();
         fwrite(&number, 4, 1, file);
         for (uint32_t i = 0; i < number; ++i) writeToFile(objs[i], file);
     }
@@ -99,7 +106,7 @@ namespace l1tpf_impl {
     void readManyFromFile(std::vector<T> & objs, FILE *file) {
         uint32_t number;
         fread(&number, 4, 1, file);
-        objs.resize(number); 
+        objs.resize(number);
         for (uint32_t i = 0; i < number; ++i) readFromFile(objs[i], file);
     }
 

--- a/L1Trigger/Phase2L1ParticleFlow/python/l1ParticleFlow_cff.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1ParticleFlow_cff.py
@@ -131,13 +131,13 @@ l1pfProducerHGCal = l1pfProducer.clone(
     trackRegionMode = cms.string("atCalo"),
     regions = cms.VPSet(
         cms.PSet(
-            etaBoundaries = cms.vdouble(-3,-1.5),
+            etaBoundaries = cms.vdouble(-2.5,-1.5),
             phiSlices = cms.uint32(1),
             etaExtra = cms.double(0.3),
             phiExtra = cms.double(0.0)
         ),
         cms.PSet(
-            etaBoundaries = cms.vdouble(1.5,3.0),
+            etaBoundaries = cms.vdouble(1.5,2.5),
             phiSlices = cms.uint32(1),
             etaExtra = cms.double(0.3),
             phiExtra = cms.double(0.0)
@@ -145,10 +145,25 @@ l1pfProducerHGCal = l1pfProducer.clone(
     ),
 )
 l1pfProducerHGCal.linking.trackCaloDR = 0.1 # more precise cluster positions
+l1pfProducerHGCalNoTK = l1pfProducerHGCal.clone(regions = cms.VPSet(
+    cms.PSet(
+        etaBoundaries = cms.vdouble(-3,-2.5),
+        phiSlices = cms.uint32(1),
+        etaExtra = cms.double(0.3),
+        phiExtra = cms.double(0.0)
+    ),
+    cms.PSet(
+        etaBoundaries = cms.vdouble(2.5,3),
+        phiSlices = cms.uint32(1),
+        etaExtra = cms.double(0.3),
+        phiExtra = cms.double(0.0)
+    ),
+))
 
 l1ParticleFlow_pf_hgcal = cms.Sequence(
     pfTracksFromL1TracksHGCal +   
-    l1pfProducerHGCal
+    l1pfProducerHGCal +
+    l1pfProducerHGCalNoTK
 )
 
 
@@ -204,11 +219,29 @@ l1ParticleFlow_pf_hf = cms.Sequence(
 )
 
 
+# PF in the TSA Region
+l1pfProducerTSA = l1pfProducerBarrel.clone(
+    trackRegionMode = cms.string("atVertex"),
+    regions = cms.VPSet(
+        cms.PSet(
+            etaBoundaries = cms.vdouble(-3,3),
+            phiSlices = cms.uint32(18),
+            etaExtra = cms.double(0.0),
+            phiExtra = cms.double(0.0)
+        ),
+    ),
+)
+l1ParticleFlow_pf_tsa = cms.Sequence(
+    pfTracksFromL1TracksBarrel +
+    l1pfProducerTSA
+)
+
 # Merging all outputs
 l1pfCandidates = cms.EDProducer("L1TPFCandMultiMerger",
     pfProducers = cms.VInputTag(
         cms.InputTag("l1pfProducerBarrel"), 
         cms.InputTag("l1pfProducerHGCal"),
+        cms.InputTag("l1pfProducerHGCalNoTK"),
         cms.InputTag("l1pfProducerHF")
     ),
     labelsToMerge = cms.vstring("Calo", "TK", "TKVtx", "PF", "Puppi"),

--- a/L1Trigger/Phase2L1ParticleFlow/src/COEFile.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/COEFile.cc
@@ -1,0 +1,87 @@
+#include "L1Trigger/Phase2L1ParticleFlow/interface/COEFile.h"
+
+using namespace l1tpf_impl;
+
+COEFile::COEFile(const edm::ParameterSet& iConfig)  :
+	file(nullptr),
+	coeFileName(iConfig.getUntrackedParameter<std::string>("coeFileName", "")),
+	bset_string_(""),
+	ntracksmax(iConfig.getUntrackedParameter<unsigned int>("ntracksmax")),
+	phiSlices(iConfig.getParameter<std::vector<edm::ParameterSet>>("regions")[0].getParameter<uint32_t>("phiSlices")),
+	debug_(iConfig.getUntrackedParameter<int>("debug",0))
+{
+	file = fopen(coeFileName.c_str(), "w");
+	writeHeaderToFile();
+	bset_.resize(tracksize);
+}
+
+void COEFile::writeHeaderToFile() {
+	char depth_width[256];
+	sprintf(depth_width, "; of depth=%i, and width=%i. In this case, values are specified\n",ntracksmax,tracksize*phiSlices);
+	std::vector<std::string> vheader = {"; Sample memory initialization file for Dual Port Block Memory,\n",
+										"; v3.0 or later.\n",
+										"; Board: VCU118\n",
+										"; tmux: 1\n",
+										";\n",
+										"; This .COE file specifies the contents for a block memory\n",
+										std::string(depth_width),
+										"; in binary format.\n",
+										"memory_initialization_radix=2;\n",
+										"memory_initialization_vector=\n"};
+	for (uint32_t i=0; i<vheader.size(); ++i) fprintf(file, vheader[i].c_str());
+}
+
+void COEFile::writeTracksToFile(const std::vector<Region>& regions, bool print) {
+	PropagatedTrack current_track;
+	bool has_track = false;
+	for (unsigned int irow = 0; irow < ntracksmax; irow++) {
+		for (unsigned int icol = 0; icol < regions.size(); icol++) {
+			if (regions[icol].track.size()<=irow) has_track = false;
+			else has_track = true;
+
+			if (has_track) {
+				// select the track that will be converted to a bit string
+				current_track = regions[icol].track[irow];
+
+				// convert the values in a PropogatedTrack to a 96-bit track word
+				for (unsigned int iblock=0; iblock<track_word_block_sizes.size(); iblock++) {
+					for (unsigned int ibit=0; ibit<track_word_block_sizes[iblock]; ibit++) {
+						int offset = std::accumulate(track_word_block_sizes.begin(), track_word_block_sizes.begin()+iblock, 0);
+						switch(iblock) {
+							case 0 : bset_.set(ibit+offset,getBit<uint16_t>(current_track.hwPt,ibit)); break;
+							case 1 : bset_.set(ibit+offset,current_track.hwCharge); break;
+							case 2 : bset_.set(ibit+offset,getBit<uint16_t>(current_track.hwVtxPhi,ibit)); break;
+							case 3 : bset_.set(ibit+offset,getBit<uint16_t>(current_track.hwVtxEta,ibit)); break;
+							case 4 : bset_.set(ibit+offset,getBit<uint16_t>(current_track.hwZ0,ibit)); break;
+							case 5 : bset_.set(ibit+offset,0); break;
+							case 6 : bset_.set(ibit+offset,getBit<uint16_t>(current_track.hwChi2,ibit)); break;
+							case 7 : bset_.set(ibit+offset,0); break;
+							case 8 : bset_.set(ibit+offset,getBit<uint16_t>(current_track.hwStubs,ibit)); break;
+							case 9 : bset_.set(ibit+offset,0); break;
+						}
+					}
+				}
+
+				// print the track word to the COE file
+				boost::to_string(bset_,bset_string_);
+				fprintf(file, "%s", bset_string_.c_str());
+
+				// print some debugging information
+				if (debug_ && print && irow==0 && icol==0) {
+					printf("l1t::PFTrack (pT,eta,phi) [float] = (%f,%f,%f)\n",current_track.src->p4().Pt(),current_track.src->p4().Eta(),current_track.src->p4().Phi());
+					printf("l1t::PFTrack (pT,eta,phi) [int] = (%i,%i,%i)\n",current_track.src->hwPt(),current_track.src->hwEta(),current_track.src->hwPhi());
+					printf("l1tpf_impl::PropagatedTrack (1/pT,eta,phi) [int,10] = (%i,%i,%i)\n",current_track.hwPt,current_track.hwVtxEta,current_track.hwVtxPhi);
+					printf("l1tpf_impl::PropagatedTrack (1/pT,eta,phi) [int,2] = (%s,%s,%s)\n",std::bitset<16>(current_track.hwPt).to_string().c_str(),std::bitset<32>(current_track.hwVtxEta).to_string().c_str(),std::bitset<32>(current_track.hwVtxPhi).to_string().c_str());
+					printf("bitset = %s\n",bset_string_.c_str());
+				}
+			}
+			else {
+				bset_.reset();
+				boost::to_string(bset_,bset_string_);
+				fprintf(file, "%s", bset_string_.c_str());
+			}
+		}
+		fprintf(file, (irow==ntracksmax-1) ? ";\n" : ",\n");
+	}
+}
+

--- a/L1Trigger/Phase2L1ParticleFlow/src/COEFile.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/COEFile.cc
@@ -68,6 +68,7 @@ void COEFile::writeTracksToFile(const std::vector<Region>& regions, bool print) 
 
 				// print some debugging information
 				if (debug_ && print && irow==0 && icol==0) {
+					printf("region: eta=[%f,%f] phi=%f+/-%f\n",regions[icol].etaMin,regions[icol].etaMax,regions[icol].phiCenter,regions[icol].phiHalfWidth);
 					printf("l1t::PFTrack (pT,eta,phi) [float] = (%f,%f,%f)\n",current_track.src->p4().Pt(),current_track.src->p4().Eta(),current_track.src->p4().Phi());
 					printf("l1t::PFTrack (pT,eta,phi) [int] = (%i,%i,%i)\n",current_track.src->hwPt(),current_track.src->hwEta(),current_track.src->hwPhi());
 					printf("l1tpf_impl::PropagatedTrack (1/pT,eta,phi) [int,10] = (%i,%i,%i)\n",current_track.hwPt,current_track.hwVtxEta,current_track.hwVtxPhi);

--- a/L1Trigger/Phase2L1ParticleFlow/test/BuildFile.xml
+++ b/L1Trigger/Phase2L1ParticleFlow/test/BuildFile.xml
@@ -1,5 +1,5 @@
 <bin name = "testOutputFiles" file="testOutputFiles.cpp">
-	<flags TEST_RUNNER_CMD="cd $(CMSSW_BASE)/src/L1Trigger/Phase2L1ParticleFlow/test; testOutputFiles Phase2L1ParticleFlowOutput.root trackerRegion_alltracks_sectors_1x18_TTbar_PU200.dump trackerRegion_alltracks_sectors_1x18_TTbar_PU200.coe 18"/>
+	<flags TEST_RUNNER_CMD="cd $(CMSSW_BASE)/src/L1Trigger/Phase2L1ParticleFlow/test; testOutputFiles Phase2L1ParticleFlowOutput.root trackerRegion_alltracks_sectors_2x9_TTbar_PU200.dump trackerRegion_alltracks_sectors_2x9_TTbar_PU200.coe 0 0 9 -3 0 3"/>
 	<use name="root"/>
 	<use name="FWCore/FWLite"/>
 	<use name="FWCore/Utilities"/>

--- a/L1Trigger/Phase2L1ParticleFlow/test/BuildFile.xml
+++ b/L1Trigger/Phase2L1ParticleFlow/test/BuildFile.xml
@@ -1,0 +1,9 @@
+<bin name = "testOutputFiles" file="testOutputFiles.cpp">
+	<flags TEST_RUNNER_CMD="cd $(CMSSW_BASE)/src/L1Trigger/Phase2L1ParticleFlow/test; testOutputFiles Phase2L1ParticleFlowOutput.root trackerRegion_alltracks_sectors_1x18_TTbar_PU200.dump trackerRegion_alltracks_sectors_1x18_TTbar_PU200.coe 18"/>
+	<use name="root"/>
+	<use name="FWCore/FWLite"/>
+	<use name="FWCore/Utilities"/>
+	<use name="DataFormats/FWLite"/>
+	<use name="DataFormats/Phase2L1ParticleFlow"/>
+	<use name="L1Trigger/Phase2L1ParticleFlow"/>
+</bin>

--- a/L1Trigger/Phase2L1ParticleFlow/test/testOutputFiles.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/test/testOutputFiles.cpp
@@ -1,0 +1,455 @@
+// STL includes
+#include <cstdio>
+#include <iostream>
+#include <iomanip>
+#include <string>
+#include <stdexcept>
+#include <sstream>
+#include <fstream>
+#include <limits>
+#include <vector>
+#include <map>
+#include <utility>
+#include <math.h>
+#include <bitset>
+
+// ROOT includes
+#include "TROOT.h"
+#include "TSystem.h"
+#include "TFile.h"
+#include "TTree.h"
+#include "TLorentzVector.h"
+
+// CMSSW includes
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/FWLite/interface/Handle.h"
+#include "DataFormats/FWLite/interface/Run.h"
+#include "DataFormats/FWLite/interface/LuminosityBlock.h"
+#include "DataFormats/FWLite/interface/Event.h"
+#include "DataFormats/Phase2L1ParticleFlow/interface/PFTrack.h"
+#include "L1Trigger/Phase2L1ParticleFlow/interface/DiscretePFInputsIO.h"
+
+#define NTEST 64
+#define REPORT_EVERY_N 50
+#define NTRACKS_PER_SECTOR 110
+#define NBITS_PER_TRACK 96
+static unsigned int N_IN_SECTORS(0);
+static std::vector<float> SECTOR_BOUNDARIES;
+
+typedef l1tpf_impl::InputRegion Region;
+typedef std::pair<int,int> SectorTrackIndex;
+typedef std::map<SectorTrackIndex,TLorentzVector*> TrackMap;
+
+struct Event {
+	uint32_t run, lumi; uint64_t event;
+	float z0, genZ0;
+	std::vector<float> puGlobals; // [float] alphaCMed, alphaCRms, alphaFMed, alphaFRms
+	std::vector<Region> regions;
+	
+	Event() : run(0), lumi(0), event(0), z0(0.), regions() {}
+	bool readFromFile(FILE *fRegionDump) {
+		if (!fread(&run, sizeof(uint32_t), 1, fRegionDump)) return false;
+		fread(&lumi, sizeof(uint32_t), 1, fRegionDump);
+		fread(&event, sizeof(uint64_t), 1, fRegionDump);
+		l1tpf_impl::readManyFromFile(regions, fRegionDump); 
+		fread(&z0, sizeof(float), 1, fRegionDump);
+		fread(&genZ0, sizeof(float), 1, fRegionDump);
+		l1tpf_impl::readManyFromFile(puGlobals, fRegionDump);
+		return true;
+	}
+};
+
+TLorentzVector* makeTLorentzVectorPtEtaPhiE(float pt, float eta, float phi, float e) {
+	TLorentzVector* v = new TLorentzVector();
+	v->SetPtEtaPhiE(pt,eta,phi,e);
+	return v;
+}
+
+/*
+ * Convert a bitset to a signed int64_t.
+ * std::bitset has built-ins for ulong and ullong.
+ */
+template <size_t N, class = std::enable_if_t<(N > 0 && N < 64)>>
+int64_t to_int64_from_bitset(const std::bitset<N>& b) {
+	int const shift = 64 - N;
+	return (((int64_t)b.to_ullong() << shift) >> shift);
+}
+
+/*
+ * Generic implementation to search if a given value exists in a map or not.
+ * Adds all the keys with given value in the vector
+ */
+template<typename K, typename V, typename T>
+bool findAllInRegion(std::vector<K> & vec, std::map<K, V> mapOfElemen, T value) {
+	bool bResult = false;
+	auto it = mapOfElemen.begin();
+	// Iterate through the map
+	while(it != mapOfElemen.end())
+	{
+		// Check if value of this entry matches with given value
+		if(it->first.first == value)
+		{
+			// Yes found
+			bResult = true;
+			// Push the key in given map
+			vec.push_back(it->first);
+		}
+		// Go to next entry in map
+		it++;
+	}
+	return bResult;
+}
+
+TrackMap get_tracks_from_root_file(fwlite::Event& ev, int entry = 0, bool print = false) {
+	TrackMap tracks_root, tracks_tmp;
+
+	// go to the event under test
+	if (!ev.to(entry)) {
+		std::cerr << "ERROR::testDumpFile::get_tracks_from_root_file Unable to load the event at entry " << entry << std::endl;
+		assert(ev.to(entry));
+	}
+	if (print) printf("ROOT::Run %u, lumi %u, event %llu \n", ev.getRun().id().run(), ev.getLuminosityBlock().id().luminosityBlock(), ev.eventAuxiliary().id().event());
+
+	edm::InputTag trackLabel ("pfTracksFromL1TracksBarrel");
+	edm::Handle< std::vector<l1t::PFTrack>> h_track;
+	ev.getByLabel(trackLabel, h_track);
+	assert( h_track.isValid() );
+
+	int ntrackstotal(0);
+	auto kTrackEnd = h_track->end();
+	for (auto trackIter = h_track->begin(); trackIter != kTrackEnd; ++trackIter) {
+		if (trackIter->pt() <= 2.0 || trackIter->nStubs() < 4 || trackIter->normalizedChi2() >= 15.0) continue;
+		int sector_index = (std::lower_bound(SECTOR_BOUNDARIES.begin(), SECTOR_BOUNDARIES.end(), trackIter->phi())-SECTOR_BOUNDARIES.begin())-1;
+		tracks_tmp[std::make_pair(sector_index,ntrackstotal)] = makeTLorentzVectorPtEtaPhiE(trackIter->pt(),trackIter->eta(),trackIter->phi(),trackIter->pt());
+		//if (print) printf("\t\t Track %u (pT,eta,phi): (%.4f,%.4f,%.4f)\n", ntrackstotal, trackIter->pt(), trackIter->eta(), trackIter->phi());
+		ntrackstotal++;
+	}
+	for (unsigned int is = 0; is < N_IN_SECTORS; ++is) {
+		std::vector<SectorTrackIndex> tracks_in_sector;
+		findAllInRegion<SectorTrackIndex,TLorentzVector*,int>(tracks_in_sector,tracks_tmp,is);
+		if (print) printf("\tFound region %u [%0.2f,%0.2f] with %lu tracks\n", is, SECTOR_BOUNDARIES[is], SECTOR_BOUNDARIES[is+1], tracks_in_sector.size());
+		for (unsigned int it=0; it<tracks_in_sector.size(); it++) {
+			if (print) printf("\t\t Track %u (pT,eta,phi): (%.4f,%.4f,%.4f)\n", it, tracks_tmp[tracks_in_sector[it]]->Pt(), tracks_tmp[tracks_in_sector[it]]->Eta(), tracks_tmp[tracks_in_sector[it]]->Phi());
+			tracks_root[std::make_pair(is,it)] = tracks_tmp[tracks_in_sector[it]];
+		}
+	}
+	if (print) {
+		printf("\t================================= \n");
+		printf("\tTotal tracks %u \n\n", ntrackstotal);
+	}
+
+	return tracks_root;
+}
+
+std::map<std::pair<int,int>,TLorentzVector*> get_tracks_from_dump_file(FILE *dfile_ = nullptr, bool print = false) {
+	std::map<std::pair<int,int>,TLorentzVector*> tracks_dump;
+	Event event_;
+
+	if (feof(dfile_)) {
+		std::cerr << "ERROR::testDumpFile::get_tracks_from_dump_file We have already reached the end of the dump file" << std::endl;
+		assert(!feof(dfile_));
+	}
+	if (!event_.readFromFile(dfile_)) {
+		std::cerr << "ERROR::testDumpFile::get_tracks_from_dump_file Something went wrong reading from the dump file" << std::endl; 
+		assert(event_.readFromFile(dfile_));
+	}
+	if (event_.regions.size() != N_IN_SECTORS) {
+		printf("ERROR::testDumpFile::get_tracks_from_dump_file Mismatching number of input regions: %lu\n", event_.regions.size());
+		assert(event_.regions.size() == N_IN_SECTORS);
+	}
+	if (print) printf("Dump::Run %u, lumi %u, event %lu, regions %lu \n", event_.run, event_.lumi, event_.event, event_.regions.size());
+
+	unsigned int ntrackstotal(0);
+	float maxabseta(0), maxz(0), minz(0);
+
+	int pv_gen   = round(event_.genZ0 * l1tpf_impl::InputTrack::Z0_SCALE);
+	int pv_cmssw = round(event_.z0    * l1tpf_impl::InputTrack::Z0_SCALE);
+
+	for (unsigned int is = 0; is < N_IN_SECTORS; ++is) {
+		const Region & r = event_.regions[is];
+		if (print) printf("\tRead region %u [%0.2f,%0.2f] with %lu tracks\n", is, r.phiCenter-r.phiHalfWidth, r.phiCenter+r.phiHalfWidth, r.track.size());
+		ntrackstotal+=r.track.size();
+		for (unsigned int it=0; it<r.track.size(); it++) {
+			tracks_dump[std::make_pair(is,it)] = makeTLorentzVectorPtEtaPhiE(r.track[it].floatVtxPt(),r.track[it].floatVtxEta(),r.track[it].floatVtxPhi(),r.track[it].floatVtxPt());
+			if(abs(r.track[it].hwVtxEta) > maxabseta) maxabseta = abs(r.track[it].hwVtxEta);
+			if(r.track[it].hwZ0 > maxz) maxz = r.track[it].hwZ0;
+			if(r.track[it].hwZ0 < minz) minz = r.track[it].hwZ0;
+			if (print) printf("\t\t Track %u (pT,eta,phi): (%.4f,%.4f,%.4f)\n", it, r.track[it].floatVtxPt(), r.track[it].floatVtxEta(), r.track[it].floatVtxPhi());
+		}
+	}
+
+	if (print) {
+		printf("\t================================= \n");
+		printf("\tTotal tracks %u \n", ntrackstotal);
+		printf("\tMax abs(eta) %.2f [hw units] \n", maxabseta);
+		printf("\tMax abs(eta) %.4f \n", maxabseta/l1tpf_impl::InputTrack::VTX_ETA_SCALE);
+		printf("\t[Min,max] track z0 [%.2f,%.2f] [hw units] \n", minz, maxz);
+		printf("\t[Min,max] track z0 [%.2f,%.2f] [cm] \n", minz/l1tpf_impl::InputTrack::Z0_SCALE, maxz/l1tpf_impl::InputTrack::Z0_SCALE);
+		printf("\tPV (GEN) %u \n", pv_gen);
+		printf("\tPV (CMSSW) %u \n\n", pv_cmssw);
+	}
+
+	return tracks_dump;
+}
+
+std::map<std::pair<int,int>,TLorentzVector*> get_tracks_from_coe_file(std::ifstream &cfile_, bool print = false, bool debug = false) {
+	std::map<std::pair<int,int>,TLorentzVector*> tracks_coe;
+	std::string bset_string_;
+	int ntrackstotal(0);
+	bool skip(false);
+
+	// check that we haven't reached the end of the file (i.e. there a more events to be read out)
+	if (cfile_.eof()) {
+		std::cerr << "ERROR::testDumpFile::get_tracks_from_coe_file We have already reached the end of the coe file" << std::endl;
+		assert(!cfile_.eof());
+	}
+	if (print) printf("COE::Run \"unknown\", lumi \"unknown\", event \"unknown\", regions %u? \n", N_IN_SECTORS);
+
+	// read the lines one by one
+	for (unsigned int iline=0; iline<NTRACKS_PER_SECTOR; iline++) {
+		bset_string_.resize(NBITS_PER_TRACK);
+		for (unsigned int isector=0; isector<N_IN_SECTORS; isector++) {
+			cfile_.read(&bset_string_[0],96);
+			std::bitset<NBITS_PER_TRACK> bset_(bset_string_);
+			if (bset_.none()) {
+				skip = true;
+				continue;
+			}
+			else {
+				skip = false;
+			}
+
+			std::bitset<14> hwPt; std::bitset<16> hwVtxEta; std::bitset<12> hwVtxPhi;
+			for (int i=14-1; i>=0; i--) {hwPt.set(i,bset_[i]);}
+			for (int i=12-1; i>=0; i--) {hwVtxPhi.set(i,bset_[i+15]);}
+			for (int i=16-1; i>=0; i--) {hwVtxEta.set(i,bset_[i+27]);}
+			float hwVtxPt_f = (float(hwPt.to_ulong()) / l1tpf_impl::CaloCluster::PT_SCALE);
+			float hwVtxEta_f = float(to_int64_from_bitset(hwVtxEta)) / l1tpf_impl::InputTrack::VTX_ETA_SCALE;
+			float hwVtxPhi_f = float(to_int64_from_bitset(hwVtxPhi)) / l1tpf_impl::InputTrack::VTX_PHI_SCALE;
+
+			if (debug) {
+				std::cout << "bset_string_ = " << bset_string_ << std::endl;
+				std::cout << "\thwPt (0b) = " << std::flush; for (int i=14-1; i>=0; i--) {std::cout << bset_[i] << std::flush;} std::cout << std::endl;
+				std::cout << "\thwVtxPhi (0b) = " << std::flush; for (int i=12-1; i>=0; i--) {std::cout << bset_[i+15] << std::flush;} std::cout << std::endl;
+				std::cout << "\thwVtxEta (0b) = " << std::flush; for (int i=16-1; i>=0; i--) {std::cout << bset_[i+27] << std::flush;} std::cout << std::endl;
+				std::cout << "\thwPt (int) = " << hwPt.to_ulong() << std::endl;
+				std::cout << "\thwVtxPhi (int) = " << to_int64_from_bitset(hwVtxPhi) << std::endl;
+				std::cout << "\thwVtxEta (int) = " << to_int64_from_bitset(hwVtxEta) << std::endl;
+				std::cout << "\thwVtxPt_f (float) = " << hwVtxPt_f << std::endl;
+				std::cout << "\thwVtxPhi_f (float) = " << hwVtxPhi_f << std::endl;
+				std::cout << "\thwVtxEta_f (float) = " << hwVtxEta_f << std::endl;
+			}
+
+			if (bset_.any()) {
+				ntrackstotal++;
+				tracks_coe[std::make_pair(isector,iline)] = makeTLorentzVectorPtEtaPhiE(hwVtxPt_f,hwVtxEta_f,hwVtxPhi_f,hwVtxPt_f);
+				//if (print) printf("\t\t Track %u (pT,eta,phi): (%.4f,%.4f,%.4f)\n", it, hwPt_f, hwVtxEta_f, hwVtxPhi_f);
+			}
+		}
+
+		// remove the trailing character
+		bset_string_.resize(2);
+		cfile_.read(&bset_string_[0],2);
+		if (debug && !skip) std::cout << "bset_string_ = " << bset_string_ << std::endl;
+		if (bset_string_!=",\n" && bset_string_!=";\n") {
+			std::cerr << "ERROR::testDumpFile::get_tracks_from_coe_file Something went wrong reading line " << 11+iline << " of the COE file"  << std::endl
+					  << "\tThe line should have ended with \',<newline>\' or \';<newline>\', but instead ended with \'" << bset_string_ << "\'" << std::endl;
+			assert(bset_string_!="," || bset_string_!=";");
+		}
+
+	}
+	for (unsigned int is = 0; is < N_IN_SECTORS; ++is) {
+		std::vector<SectorTrackIndex> tracks_in_sector;
+		findAllInRegion<SectorTrackIndex,TLorentzVector*,int>(tracks_in_sector,tracks_coe,is);
+		if (print) printf("\tRead region %u [%0.2f,%0.2f] with %lu tracks\n", is, SECTOR_BOUNDARIES[is], SECTOR_BOUNDARIES[is+1], tracks_in_sector.size());
+		for (unsigned int it=0; it<tracks_in_sector.size(); it++) {
+			if (print) printf("\t\t Track %u (pT,eta,phi): (%.4f,%.4f,%.4f)\n", it, tracks_coe[tracks_in_sector[it]]->Pt(), tracks_coe[tracks_in_sector[it]]->Eta(), tracks_coe[tracks_in_sector[it]]->Phi());
+		}
+	}
+
+	if (print) {
+		printf("\t================================= \n");
+		printf("\tTotal tracks %u \n\n", ntrackstotal);
+	}
+
+	return tracks_coe;
+}
+
+std::ifstream& GotoLine(std::ifstream& file, unsigned int num){
+	file.seekg(std::ios::beg);
+	for(unsigned int i=0; i < num - 1; ++i){
+		file.ignore(std::numeric_limits<std::streamsize>::max(),'\n');
+	}
+	return file;
+}
+
+bool compare_lv_with_tolerance(TLorentzVector a, TLorentzVector b, const std::vector<float>& tolerance = {0,0,0,0}) {
+	/*
+	Example (Tolerance = 0.0005):
+		Track from ROOT file: pt=16.3452797
+		InputTrack::INVPT_SCALE = 2E4
+		std::numeric_limits<uint16_t>::max() = 65535
+		hwInvpt = std::min<double>(round(1/pt  * InputTrack::INVPT_SCALE), std::numeric_limits<uint16_t>::max()) = 1224.0000
+		floatVtxPt() = 1/(float(hwInvpt) / InputTrack::INVPT_SCALE) = 16.339869
+		So loss of precision comes from rounding
+		Difference is DeltaPt=0.00541114807
+	*/
+	if (abs(a.Pt()-b.Pt())>tolerance[0] || abs(a.Eta()-b.Eta())>tolerance[1] || abs(a.Phi()-b.Phi())>tolerance[2] || abs(a.E()-b.E())>tolerance[3]) {
+		std::cerr<<std::setprecision(9);
+		std::cerr << std::endl << "\tMismatching " << std::flush;
+		if (abs(a.Pt()-b.Pt())>tolerance[0]) std::cerr << "pT! " << a.Pt() << " vs " << b.Pt() << " where DeltaPt=" << abs(a.Pt()-b.Pt()) << " and epsilon=" << tolerance[0] << std::endl;
+		else if (abs(a.Eta()-b.Eta())>tolerance[1]) std::cerr << "eta! " << a.Eta() << " vs " << b.Eta() << " where DeltaEta=" << abs(a.Eta()-b.Eta()) << " and epsilon=" << tolerance[1] << std::endl;
+		else if (abs(a.Phi()-b.Phi())>tolerance[2]) std::cerr << "phi! " << a.Phi() << " vs " << b.Phi() << " where DeltaPhi=" << abs(a.Phi()-b.Phi()) << " and epsilon=" << tolerance[2] << std::endl;
+		else if (abs(a.E()-b.E())>tolerance[3]) std::cerr << "E! " << a.E() << " vs " << b.E() << " where DeltaE=" << abs(a.E()-b.E()) << " and epsilon=" << tolerance[3] << std::endl;
+		return false;
+	}
+	return true;
+}
+
+bool compare_maps(TrackMap ref, TrackMap test) {
+	TLorentzVector tlv;
+	for (auto it=ref.begin(); it!=ref.end(); it++) {
+		if (test.find(it->first)==test.end()) {
+			std::cerr << std::endl << "\tERROR::compare_maps Can't find the test track with (sector,index)=(" << it->first.first << "," << it->first.second << ")" << std::endl;
+			return false;
+		}
+		tlv = *(test.find(it->first)->second);
+		// The pT tolerance should be 1.0/l1tpf_impl::CaloCluster::PT_SCALE, but because of the rounding this is not true and the actual resolution isn't always as good
+		// Instead, we will use max(1% of the pT of the reference TLorentzVector,0.25)
+		// We use the max statement because at low pT, the 1% definition doesn't hold anymore. This wouldn't be a problem if 1/pT were encoded rather than pT.
+		if (!compare_lv_with_tolerance(*(it->second),tlv,{float(std::max(it->second->Pt()*1E-2,1.0/l1tpf_impl::CaloCluster::PT_SCALE)),1.0/l1tpf_impl::InputTrack::VTX_ETA_SCALE,1.0/l1tpf_impl::InputTrack::VTX_PHI_SCALE,float(std::max(it->second->Pt()*1E-2,1.0/l1tpf_impl::CaloCluster::PT_SCALE))})) {
+			std::cerr << std::endl << "\tERROR::compare_maps Can't find the test track with TLorentzVector (" << it->second->Pt() << "," << it->second->Eta() << "," << it->second->Phi() << "," << it->second->E() << ")" << std::endl
+					  << "\t\tInstead found (" << tlv.Pt() << "," << tlv.Eta() << "," << tlv.Phi() << "," << tlv.E() << ") at the position (sector,index)=(" << it->first.first << "," << it->first.second << ")" << std::endl;
+			return false;
+		}
+	}
+	return true;
+}
+
+int main(int argc, char *argv[]) {
+
+	// store some programatic information
+	std::stringstream usage;
+	usage << "usage: " << argv[0] << " <filename>.root <filename>.dump <filename>.coe <nregions>";
+
+	// load framework libraries
+	gSystem->Load("libFWCoreFWLite");
+	FWLiteEnabler::enable();
+
+	// argc should be 5 for correct execution
+	// We print argv[0] assuming it is the program name
+	if ( argc != 5 ) {
+		std::cerr << "ERROR::testDumpFile " << argc << " arguments provided" << std::endl;
+		for (int i=0; i<argc; i++) {
+			std::cerr << "\tArgument " << i << ": " << argv[i] << std::endl;
+		}
+		std::cerr << usage.str() << std::endl;
+		return -1;
+	}
+
+	// assign the command-line parameters to variables
+	std::string filename_root = argv[1];
+	std::string filename_dump = argv[2];
+	std::string filename_coe = argv[3];
+	std::string sectors = argv[argc-1];
+	try {
+		std::size_t pos;
+		N_IN_SECTORS = std::stoi(sectors, &pos);
+		if (pos < sectors.size()) {
+			std::cerr << "Trailing characters after number: " << sectors << '\n';
+		}
+	} catch (std::invalid_argument const &ex) {
+		std::cerr << "Invalid number: " << sectors << std::endl;
+		return -2;
+	} catch (std::out_of_range const &ex) {
+		std::cerr << "Number out of range: " << sectors << std::endl;
+		return -3;
+	}
+	// divide the detector into N_IN_SECTORS phi sectors from [-pi,pi]
+	float sector_size = 2.*M_PI/N_IN_SECTORS;
+	for (unsigned int isec=0; isec<N_IN_SECTORS; isec++) {
+		SECTOR_BOUNDARIES.push_back(-M_PI+(isec*sector_size));
+	}
+	SECTOR_BOUNDARIES.push_back(M_PI);
+
+	// check the filenames
+	if (filename_root.find(".root")==std::string::npos)	{
+		std::cerr << "ERROR::testDumpFile Filename 1 must be a ROOT (.root) file" << std::endl << usage.str() << std::endl;
+		return -4;
+	}
+	else if (filename_dump.find(".dump")==std::string::npos) {
+		std::cerr << "ERROR::testDumpFile Filename 2 must be a binary (.dump) file" << std::endl << usage.str() << std::endl;
+		return -5;
+	}
+	else if (filename_coe.find(".coe")==std::string::npos) {
+		std::cerr << "ERROR::testDumpFile Filename 3 must be a COE (.coe) file" << std::endl << usage.str() << std::endl;
+		return -6;
+	}
+
+	// report the program configuraion
+	std::cout << "Configuration:" << std::endl
+			  << "==============" << std::endl
+			  << "Number of tests (events): " << NTEST << std::endl
+			  << "Report every N tests: " << REPORT_EVERY_N << std::endl
+			  << "Number of sectors (in phi): " << N_IN_SECTORS << std::endl
+			  << "Sector boundaries: [" << std::flush;
+	for (unsigned int isector=0; isector<SECTOR_BOUNDARIES.size(); isector++) {
+		std::cout << SECTOR_BOUNDARIES[isector] << std::flush;
+		if (isector<SECTOR_BOUNDARIES.size()-1) std::cout << "," << std::flush;
+	}
+	std::cout << "]" << std::endl
+			  << "Number of tracks per sector: " << NTRACKS_PER_SECTOR << std::endl
+			  << "Number of bits per track: " << NBITS_PER_TRACK << std::endl
+			  << "==============" << std::endl << std::endl;
+
+	// open the files for testing
+	TFile* rfile_ = TFile::Open(filename_root.c_str(),"READ");
+	if (!rfile_) {
+		std::cerr << "ERROR::testDumpFile Cannot open '" << filename_root << "'" << std::endl;
+		return -7;
+	}
+	fwlite::Event rfileentry_(rfile_);
+	FILE *dfile_(fopen(filename_dump.c_str(),"rb"));
+	if (!dfile_) {
+		std::cerr << "ERROR::testDumpFile Cannot read '" << filename_dump << "'" << std::endl;
+		return -8;
+	}
+	std::ifstream cfile_(filename_coe);
+	if (!cfile_) {
+		std::cerr << "ERROR::testDumpFile Cannot read '" << filename_coe << "'" << std::endl;
+		return -9;
+	}
+	GotoLine(cfile_, 11); //Skip the header of the COE file
+
+	TrackMap tracks_root, tracks_dump, tracks_coe;
+
+	// run the tests for multiple events
+	for (int test = 1; test <= NTEST; ++test) {
+		if (test%REPORT_EVERY_N == 1) std::cout << "Doing test " << test << " ... " << std::endl;
+
+		tracks_root = get_tracks_from_root_file(rfileentry_,test-1,test==1);
+		tracks_dump = get_tracks_from_dump_file(dfile_,test==1);
+		tracks_coe  = get_tracks_from_coe_file(cfile_,test==1);
+
+		if (test%REPORT_EVERY_N == 1) std::cout << "Comparing the ROOT tracks to the dump tracks in event " << test << " ... " << std::flush;
+		if (!compare_maps(tracks_root,tracks_dump)) return -10;
+		if (test%REPORT_EVERY_N == 1) std::cout << "DONE" << std::endl;
+
+		if (test%REPORT_EVERY_N == 1) std::cout << "Comparing the ROOT tracks to the coe tracks in event " << test << " ... " << std::flush;
+		if (!compare_maps(tracks_root,tracks_coe))  return -11;
+		if (test%REPORT_EVERY_N == 1) std::cout << "DONE" << std::endl << std::endl;
+	}
+
+	std::cout << std::endl << "The dump and coe outputs match the ROOT outputs for all events!" << std::endl;
+	return 0;
+}
+
+/*
+USE:
+g++ -I/uscms_data/d2/aperloff/YOURWORKINGAREA/TSABoard/slc7/CMSSW_10_6_0_pre4/src/L1Trigger/Phase2L1ParticleFlow/interface/ -O0 -g3 -Wall -std=c++0x -c -fmessage-length=0 testDumpFile.cpp
+g++ -o testDumpFile testDumpFile.o
+./testDumpFile trackerRegion_alltracks_sectors_1x18_TTbar_PU200.dump 18
+
+scram b runtests
+*/


### PR DESCRIPTION
This PR is intended to re-add the ability to save binary (.dump) files which contain the discretized and regionized PF event information. It also adds the ability to save a COE file with just the track information.

In order to accomplish the task of adding the COE file with the 96-bit track word definition, the Xilinx ap_int and ap_fixed headers were also added to the PR. As far as I'm aware all of the licensing issues have been taken care of, but if someone has a comment or concern about this, now would be a good time to address this. On a more technical side, I put the files in the place that made the most logical sense to me. That doesn't mean it's the best/right place to put them. I'm open to suggestions. Also, in many places the Xilinx headers don't follow the CMS coding rules and therefore generate many warnings. I think we will have to edit the files to conform with the CMS rules before this could be merged into the official CMSSW repo.