### PR TITLE
Switch off ecalPriority in the linking in the HGCal

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/python/l1ParticleFlow_cff.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1ParticleFlow_cff.py
@@ -167,6 +167,7 @@ l1pfProducerHGCal = l1pfProducer.clone(
     ),
 )
 l1pfProducerHGCal.linking.trackCaloDR = 0.1 # more precise cluster positions
+l1pfProducerHGCal.linking.ecalPriority = False
 l1pfProducerHGCalNoTK = l1pfProducerHGCal.clone(regions = cms.VPSet(
     cms.PSet(
         etaBoundaries = cms.vdouble(-3,-2.5),


### PR DESCRIPTION
Switch off ecalPriority in the linking in the HGCal, as it was intended to be.
With ecalPriority off, PF will produce at most a single neutral particle for each calo cluster.
Output multiplicity of neutrals is reduced, and performance of jet, HT, MET triggers is unaffected.