### PR TITLE
Support for running the HLS PF algorithm in CMSSW

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/BuildFile.xml
+++ b/L1Trigger/Phase2L1ParticleFlow/BuildFile.xml
@@ -13,3 +13,4 @@
 <export>
   <lib name="1"/>
 </export>
+<flags ADD_SUBDIR="1"/>

--- a/L1Trigger/Phase2L1ParticleFlow/interface/BitwisePFAlgo.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/BitwisePFAlgo.h
@@ -1,0 +1,22 @@
+#ifndef L1Trigger_Phase2L1ParticleFlow_BitwisePFAlgo_h
+#define L1Trigger_Phase2L1ParticleFlow_BitwisePFAlgo_h
+
+#include "L1Trigger/Phase2L1ParticleFlow/interface/PFAlgoBase.h"
+
+struct pfalgo_config;
+
+namespace l1tpf_impl { 
+class BitwisePFAlgo : public PFAlgoBase {
+    public:
+        BitwisePFAlgo( const edm::ParameterSet& ) ;
+        ~BitwisePFAlgo() ;
+        virtual void runPF(Region &r) const override;
+
+    protected:
+        enum AlgoChoice { algo3, algo2hgc } algo_;
+        pfalgo_config * config_;
+  };
+
+} // end namespace
+
+#endif

--- a/L1Trigger/Phase2L1ParticleFlow/interface/PFAlgo3.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/PFAlgo3.h
@@ -18,7 +18,7 @@ class PFAlgo3 : public PFAlgoBase {
         float emHadSubtractionPtSlope_;
         TkCaloLinkMetric tkCaloLinkMetric_;
         bool caloReLinkStep_; float caloReLinkDr_, caloReLinkThreshold_;
-        bool rescaleTracks_, sumTkCaloErr2_, ecalPriority_, trackEmUseAlsoTrackSigma_, emCaloUseAlsoCaloSigma_;
+        bool rescaleTracks_, sumTkCaloErr2_, ecalPriority_, trackEmUseAlsoTrackSigma_, trackEmMayUseCaloMomenta_, emCaloUseAlsoCaloSigma_;
         unsigned int tightTrackMinStubs_; float tightTrackMaxChi2_, tightTrackMaxInvisiblePt_;
         enum GoodTrackStatus { GoodTK_Calo_TkPt=0, GoodTK_Calo_TkCaloPt=1, GoodTk_Calo_CaloPt=2, GoodTK_NoCalo=3 };
         enum BadTrackStatus { BadTK_NoCalo=1 };

--- a/L1Trigger/Phase2L1ParticleFlow/interface/Region.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/Region.h
@@ -24,7 +24,7 @@ namespace l1tpf_impl {
     static const char * outputTypeName(int outputType) ;
 
     unsigned int nInput(InputType type) const ;
-    unsigned int nOutput(OutputType type, bool puppi) const ;
+    unsigned int nOutput(OutputType type, bool puppi, bool fiducial=true) const ;
 
     // global coordinates
     bool contains(float eta, float phi) const { 

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TPFProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TPFProducer.cc
@@ -22,6 +22,7 @@
 #include "L1Trigger/Phase2L1ParticleFlow/interface/PFAlgoBase.h"
 #include "L1Trigger/Phase2L1ParticleFlow/interface/PFAlgo3.h"
 #include "L1Trigger/Phase2L1ParticleFlow/interface/PFAlgo2HGC.h"
+#include "L1Trigger/Phase2L1ParticleFlow/interface/BitwisePFAlgo.h"
 #include "L1Trigger/Phase2L1ParticleFlow/interface/PuppiAlgo.h"
 #include "L1Trigger/Phase2L1ParticleFlow/interface/LinearizedPuppiAlgo.h"
 #include "L1Trigger/Phase2L1ParticleFlow/interface/DiscretePFInputsIO.h"
@@ -126,8 +127,8 @@ L1TPFProducer::L1TPFProducer(const edm::ParameterSet& iConfig):
         l1pfalgo_.reset(new l1tpf_impl::PFAlgo3(iConfig));
     } else if (algo == "PFAlgo2HGC") {
         l1pfalgo_.reset(new l1tpf_impl::PFAlgo2HGC(iConfig));
-    } else if (algo == "BitwisePF") { // FIXME add back
-        throw cms::Exception("Configuration", "FIXME: recover Bitwise PF");
+    } else if (algo == "BitwisePFAlgo") {
+        l1pfalgo_.reset(new l1tpf_impl::BitwisePFAlgo(iConfig));
     } else throw cms::Exception("Configuration", "Unsupported PFAlgo");
 
     const std::string & pualgo = iConfig.getParameter<std::string>("puAlgo");

--- a/L1Trigger/Phase2L1ParticleFlow/python/l1pfProducer_cfi.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1pfProducer_cfi.py
@@ -36,6 +36,7 @@ l1pfProducer = cms.EDProducer("L1TPFProducer",
         # track -> em linking configurables
         trackEmDR   = cms.double(0.04), # 1 Ecal crystal size is 0.02, and ~2 cm in HGCal is ~0.007
         trackEmUseAlsoTrackSigma = cms.bool(True), # also use the track uncertainty for electron linking
+        trackEmMayUseCaloMomenta = cms.bool(True), # use calo momenta for 1 emcalo to 1 track match electrons 
         # em -> calo linking configurables
         emCaloDR    = cms.double(0.10),    # 1 Hcal tower size is ~0.09
         caloEmPtMinFrac = cms.double(0.5), # Calo object must have an EM Et at least half of that of the EM cluster to allow linking

--- a/L1Trigger/Phase2L1ParticleFlow/src/BitwisePFAlgo.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/BitwisePFAlgo.cc
@@ -1,0 +1,135 @@
+#include "L1Trigger/Phase2L1ParticleFlow/interface/BitwisePFAlgo.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+//#define REG_HGCal
+#include "ref/pfalgo2hgc_ref.h"
+#include "ref/pfalgo3_ref.h"
+#include "utils/DiscretePF2Firmware.h"
+#include "utils/Firmware2DiscretePF.h"
+
+using namespace l1tpf_impl;
+
+BitwisePFAlgo::BitwisePFAlgo( const edm::ParameterSet & iConfig ) :
+    PFAlgoBase(iConfig), config_(nullptr)
+{
+    const edm::ParameterSet & bitwiseConfig = iConfig.getParameter<edm::ParameterSet>("bitwiseConfig");
+    const std::string & algo = iConfig.getParameter<std::string>("bitwiseAlgo");
+    debug_ = iConfig.getUntrackedParameter<int>("debugBitwisePFAlgo", iConfig.getUntrackedParameter<int>("debug", 0));
+    if (algo == "pfalgo3") {
+        algo_ = algo3;
+        config_ = new pfalgo3_config(
+                        bitwiseConfig.getParameter<uint32_t>("NTRACK"),
+                        bitwiseConfig.getParameter<uint32_t>("NEMCALO"),
+                        bitwiseConfig.getParameter<uint32_t>("NCALO"),
+                        bitwiseConfig.getParameter<uint32_t>("NMU"),
+                        bitwiseConfig.getParameter<uint32_t>("NPHOTON"),
+                        bitwiseConfig.getParameter<uint32_t>("NSELCALO"),
+                        bitwiseConfig.getParameter<uint32_t>("NALLNEUTRAL"),
+                        bitwiseConfig.getParameter<uint32_t>("DR2MAX_TK_MU"),
+                        bitwiseConfig.getParameter<uint32_t>("DR2MAX_TK_EM"),
+                        bitwiseConfig.getParameter<uint32_t>("DR2MAX_EM_CALO"),
+                        bitwiseConfig.getParameter<uint32_t>("DR2MAX_TK_CALO"),
+                        bitwiseConfig.getParameter<uint32_t>("TK_MAXINVPT_LOOSE"),
+                        bitwiseConfig.getParameter<uint32_t>("TK_MAXINVPT_TIGHT"));
+        pfalgo3_ref_set_debug(debug_);
+    } else if (algo == "pfalgo2hgc") {
+        algo_ = algo2hgc;
+        config_ = new pfalgo_config(
+                        bitwiseConfig.getParameter<uint32_t>("NTRACK"),
+                        bitwiseConfig.getParameter<uint32_t>("NCALO"),
+                        bitwiseConfig.getParameter<uint32_t>("NMU"),
+                        bitwiseConfig.getParameter<uint32_t>("NSELCALO"),
+                        bitwiseConfig.getParameter<uint32_t>("DR2MAX_TK_MU"),
+                        bitwiseConfig.getParameter<uint32_t>("DR2MAX_TK_CALO"),
+                        bitwiseConfig.getParameter<uint32_t>("TK_MAXINVPT_LOOSE"),
+                        bitwiseConfig.getParameter<uint32_t>("TK_MAXINVPT_TIGHT"));
+        pfalgo2hgc_ref_set_debug(debug_);
+    } else {
+        throw cms::Exception("Configuration", "Unsupported bitwiseAlgo "+algo);
+    }
+}
+
+BitwisePFAlgo::~BitwisePFAlgo() {
+    switch (algo_) {
+        case algo3: 
+            delete (static_cast<pfalgo3_config *>(config_));
+            break;
+        default:
+            delete config_;
+    }
+    config_ = nullptr;
+}
+
+void BitwisePFAlgo::runPF(Region &r) const {
+    initRegion(r);
+
+    std::unique_ptr<HadCaloObj[]> calo(new HadCaloObj[config_->nCALO]);
+    std::unique_ptr<TkObj[]> track(new TkObj[config_->nTRACK]);
+    std::unique_ptr<MuObj[]> mu(new MuObj[config_->nMU]);
+    std::unique_ptr<PFChargedObj[]> outch(new PFChargedObj[config_->nTRACK]);
+    std::unique_ptr<PFNeutralObj[]> outne(new PFNeutralObj[config_->nSELCALO]);
+    std::unique_ptr<PFChargedObj[]> outmu(new PFChargedObj[config_->nMU]);
+
+    dpf2fw::convert(config_->nTRACK, r.track, track.get());
+    dpf2fw::convert(config_->nCALO, r.calo, calo.get());
+    dpf2fw::convert(config_->nMU, r.muon, mu.get());
+
+
+    if (debug_) {
+        printf("BitwisePF\nBitwisePF region eta [ %+5.2f , %+5.2f ], phi [ %+5.2f , %+5.2f ], fiducial eta [ %+5.2f , %+5.2f ], phi [ %+5.2f , %+5.2f ], algo = %d\n", r.etaMin - r.etaExtra, r.etaMax + r.etaExtra, r.phiCenter-r.phiHalfWidth-r.phiExtra, r.phiCenter+r.phiHalfWidth+r.phiExtra, r.etaMin, r.etaMax, r.phiCenter-r.phiHalfWidth, r.phiCenter+r.phiHalfWidth, int(algo_) );
+        printf("BitwisePF \t N(track) %3lu   N(em) %3lu   N(calo) %3lu   N(mu) %3lu\n", r.track.size(), r.emcalo.size(), r.calo.size(), r.muon.size());
+        for (int itk = 0, ntk = r.track.size(); itk < ntk; ++itk) {
+            const auto & tk = r.track[itk]; 
+            printf("BitwisePF \t track %3d: pt %7.2f +- %5.2f  vtx eta %+5.2f  vtx phi %+5.2f  calo eta %+5.2f  calo phi %+5.2f  fid %1d  calo ptErr %7.2f stubs %2d chi2 %7.1f\n", 
+                                itk, tk.floatPt(), tk.floatPtErr(), tk.floatVtxEta(), tk.floatVtxPhi(), tk.floatEta(), tk.floatPhi(), int(r.fiducialLocal(tk.floatEta(), tk.floatPhi())), tk.floatCaloPtErr(), int(tk.hwStubs), tk.hwChi2*0.1f);
+        }
+        for (int iem = 0, nem = r.emcalo.size(); iem < nem; ++iem) {
+            const auto & em = r.emcalo[iem];
+            printf("BitwisePF \t EM    %3d: pt %7.2f +- %5.2f  vtx eta %+5.2f  vtx phi %+5.2f  calo eta %+5.2f  calo phi %+5.2f  fid %1d  calo ptErr %7.2f\n", 
+                                iem, em.floatPt(), em.floatPtErr(), em.floatEta(), em.floatPhi(), em.floatEta(), em.floatPhi(), int(r.fiducialLocal(em.floatEta(), em.floatPhi())), em.floatPtErr());
+        } 
+        for (int ic = 0, nc = r.calo.size(); ic < nc; ++ic) {
+            auto & calo = r.calo[ic]; 
+            printf("BitwisePF \t calo  %3d: pt %7.2f +- %5.2f  vtx eta %+5.2f  vtx phi %+5.2f  calo eta %+5.2f  calo phi %+5.2f  fid %1d  calo ptErr %7.2f em pt %7.2f \n", 
+                                ic, calo.floatPt(), calo.floatPtErr(), calo.floatEta(), calo.floatPhi(), calo.floatEta(), calo.floatPhi(), int(r.fiducialLocal(calo.floatEta(), calo.floatPhi())), calo.floatPtErr(), calo.floatEmPt());
+        }
+        for (int im = 0, nm = r.muon.size(); im < nm; ++im) {
+            auto & mu = r.muon[im]; 
+            printf("BitwisePF \t muon  %3d: pt %7.2f           vtx eta %+5.2f  vtx phi %+5.2f  calo eta %+5.2f  calo phi %+5.2f  fid %1d \n", 
+                                im, mu.floatPt(), mu.floatEta(), mu.floatPhi(), mu.floatEta(), mu.floatPhi(), int(r.fiducialLocal(mu.floatEta(), mu.floatPhi())));
+        }
+    }
+    switch (algo_) {
+        case algo3: {
+            pfalgo3_config * config3 = static_cast<pfalgo3_config *>(config_);
+            std::unique_ptr<EmCaloObj[]> emcalo(new EmCaloObj[config3->nEMCALO]);
+            std::unique_ptr<PFNeutralObj[]> outpho(new PFNeutralObj[config3->nPHOTON]);
+
+            dpf2fw::convert(config3->nEMCALO, r.emcalo, emcalo.get());
+            pfalgo3_ref(*config3, emcalo.get(), calo.get(), track.get(), mu.get(), outch.get(), outpho.get(), outne.get(), outmu.get());
+
+            fw2dpf::convert(config3->nTRACK, outch.get(), r.track, r.pf); // FIXME works only with a 1-1 mapping
+            fw2dpf::convert(config3->nPHOTON, outpho.get(), r.pf);
+            fw2dpf::convert(config3->nSELCALO, outne.get(), r.pf);
+            }
+            break;
+        case algo2hgc: {
+            pfalgo2hgc_ref(*config_, calo.get(), track.get(), mu.get(), outch.get(), outne.get(), outmu.get());
+            fw2dpf::convert(config_->nTRACK, outch.get(), r.track, r.pf); // FIXME works only with a 1-1 mapping
+            fw2dpf::convert(config_->nSELCALO, outne.get(), r.pf);
+            }
+            break;
+    };
+
+    if (debug_) {
+        printf("BitwisePF \t Output N(ch) %3u/%3u   N(nh) %3u/%3u   N(ph) %3u/%u   [all/fiducial]\n", 
+                    r.nOutput(l1tpf_impl::Region::charged_type,false,false), r.nOutput(l1tpf_impl::Region::charged_type,false,true), 
+                    r.nOutput(l1tpf_impl::Region::neutral_hadron_type,false,false), r.nOutput(l1tpf_impl::Region::neutral_hadron_type,false,true), 
+                    r.nOutput(l1tpf_impl::Region::photon_type,false,false), r.nOutput(l1tpf_impl::Region::photon_type,false,true));
+        for (int ipf = 0, npf = r.pf.size(); ipf < npf; ++ipf) {
+            const auto & pf = r.pf[ipf]; 
+            printf("BitwisePF \t pf    %3d: pt %7.2f pid %d   vtx eta %+5.2f  vtx phi %+5.2f  calo eta %+5.2f  calo phi %+5.2f  fid %1d\n", 
+                                ipf, pf.floatPt(), int(pf.hwId), pf.floatVtxEta(), pf.floatVtxPhi(), pf.floatEta(), pf.floatPhi(), int(r.fiducialLocal(pf.floatEta(), pf.floatPhi())));
+        }
+    }
+}

--- a/L1Trigger/Phase2L1ParticleFlow/src/PFAlgo3.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/PFAlgo3.cc
@@ -40,6 +40,7 @@ PFAlgo3::PFAlgo3( const edm::ParameterSet & iConfig ) :
 
     drMatchEm_ = linkcfg.getParameter<double>("trackEmDR");
     trackEmUseAlsoTrackSigma_ = linkcfg.getParameter<bool>("trackEmUseAlsoTrackSigma");
+    trackEmMayUseCaloMomenta_ = linkcfg.getParameter<bool>("trackEmMayUseCaloMomenta");
     emCaloUseAlsoCaloSigma_ = linkcfg.getParameter<bool>("emCaloUseAlsoCaloSigma");
     ptMinFracMatchEm_ = linkcfg.getParameter<double>("caloEmPtMinFrac");
     drMatchEmHad_ = linkcfg.getParameter<double>("emCaloDR");
@@ -62,27 +63,27 @@ void PFAlgo3::runPF(Region &r) const {
     /// ------------- first step (can all go in parallel) ----------------
 
     if (debug_) {
-        printf("PFAlgo3\nPFAlgo3 region Eta [ %+5.2f , %+5.2f ],  Phi [ %+5.2f , %+5.2f ] \n", r.etaMin, r.etaMax, r.phiCenter-r.phiHalfWidth, r.phiCenter+r.phiHalfWidth );
+        printf("PFAlgo3\nPFAlgo3 region eta [ %+5.2f , %+5.2f ], phi [ %+5.2f , %+5.2f ], fiducial eta [ %+5.2f , %+5.2f ], phi [ %+5.2f , %+5.2f ]\n", r.etaMin - r.etaExtra, r.etaMax + r.etaExtra, r.phiCenter-r.phiHalfWidth-r.phiExtra, r.phiCenter+r.phiHalfWidth+r.phiExtra, r.etaMin, r.etaMax, r.phiCenter-r.phiHalfWidth, r.phiCenter+r.phiHalfWidth);
         printf("PFAlgo3 \t N(track) %3lu   N(em) %3lu   N(calo) %3lu   N(mu) %3lu\n", r.track.size(), r.emcalo.size(), r.calo.size(), r.muon.size());
         for (int itk = 0, ntk = r.track.size(); itk < ntk; ++itk) {
             const auto & tk = r.track[itk]; 
-            printf("PFAlgo3 \t track %3d: pt %7.2f +- %5.2f  vtx eta %+5.2f  vtx phi %+5.2f  calo eta %+5.2f  calo phi %+5.2f calo ptErr %7.2f stubs %2d chi2 %7.1f\n", 
-                                itk, tk.floatPt(), tk.floatPtErr(), tk.floatVtxEta(), tk.floatVtxPhi(), tk.floatEta(), tk.floatPhi(), tk.floatCaloPtErr(), int(tk.hwStubs), tk.hwChi2*0.1f);
+            printf("PFAlgo3 \t track %3d: pt %7.2f +- %5.2f  vtx eta %+5.2f  vtx phi %+5.2f  calo eta %+5.2f  calo phi %+5.2f  fid %1d  calo ptErr %7.2f stubs %2d chi2 %7.1f\n", 
+                                itk, tk.floatPt(), tk.floatPtErr(), tk.floatVtxEta(), tk.floatVtxPhi(), tk.floatEta(), tk.floatPhi(), int(r.fiducialLocal(tk.floatEta(), tk.floatPhi())), tk.floatCaloPtErr(), int(tk.hwStubs), tk.hwChi2*0.1f);
         }
         for (int iem = 0, nem = r.emcalo.size(); iem < nem; ++iem) {
             const auto & em = r.emcalo[iem];
-            printf("PFAlgo3 \t EM    %3d: pt %7.2f +- %5.2f  vtx eta %+5.2f  vtx phi %+5.2f  calo eta %+5.2f  calo phi %+5.2f calo ptErr %7.2f\n", 
-                                iem, em.floatPt(), em.floatPtErr(), em.floatEta(), em.floatPhi(), em.floatEta(), em.floatPhi(), em.floatPtErr());
+            printf("PFAlgo3 \t EM    %3d: pt %7.2f +- %5.2f  vtx eta %+5.2f  vtx phi %+5.2f  calo eta %+5.2f  calo phi %+5.2f  fid %1d  calo ptErr %7.2f\n", 
+                                iem, em.floatPt(), em.floatPtErr(), em.floatEta(), em.floatPhi(), em.floatEta(), em.floatPhi(), int(r.fiducialLocal(em.floatEta(), em.floatPhi())), em.floatPtErr());
         } 
         for (int ic = 0, nc = r.calo.size(); ic < nc; ++ic) {
             auto & calo = r.calo[ic]; 
-            printf("PFAlgo3 \t calo  %3d: pt %7.2f +- %5.2f  vtx eta %+5.2f  vtx phi %+5.2f  calo eta %+5.2f  calo phi %+5.2f calo ptErr %7.2f em pt %7.2f \n", 
-                                ic, calo.floatPt(), calo.floatPtErr(), calo.floatEta(), calo.floatPhi(), calo.floatEta(), calo.floatPhi(), calo.floatPtErr(), calo.floatEmPt());
+            printf("PFAlgo3 \t calo  %3d: pt %7.2f +- %5.2f  vtx eta %+5.2f  vtx phi %+5.2f  calo eta %+5.2f  calo phi %+5.2f  fid %1d  calo ptErr %7.2f em pt %7.2f \n", 
+                                ic, calo.floatPt(), calo.floatPtErr(), calo.floatEta(), calo.floatPhi(), calo.floatEta(), calo.floatPhi(), int(r.fiducialLocal(calo.floatEta(), calo.floatPhi())), calo.floatPtErr(), calo.floatEmPt());
         }
         for (int im = 0, nm = r.muon.size(); im < nm; ++im) {
             auto & mu = r.muon[im]; 
-            printf("PFAlgo3 \t muon  %3d: pt %7.2f           vtx eta %+5.2f  vtx phi %+5.2f  calo eta %+5.2f  calo phi %+5.2f \n", 
-                                im, mu.floatPt(), mu.floatEta(), mu.floatPhi(), mu.floatEta(), mu.floatPhi());
+            printf("PFAlgo3 \t muon  %3d: pt %7.2f           vtx eta %+5.2f  vtx phi %+5.2f  calo eta %+5.2f  calo phi %+5.2f  fid %1d \n", 
+                                im, mu.floatPt(), mu.floatEta(), mu.floatPhi(), mu.floatEta(), mu.floatPhi(), int(r.fiducialLocal(mu.floatEta(), mu.floatPhi())));
         }
 
     }
@@ -313,7 +314,7 @@ void PFAlgo3::emtk_algo(Region & r, const std::vector<int> & tk2em, const std::v
             auto & p = addTrackToPF(r, tk);
             p.cluster.src = em.src;
             // FIXME to check if this is useful
-            if (em2ntk[tk2em[itk]] == 1 && em.hwFlags == 1) {
+            if (trackEmMayUseCaloMomenta_ && em2ntk[tk2em[itk]] == 1 && em.hwFlags == 1) {
                 if (em.floatPtErr() < em2sumtkpterr[tk2em[itk]]) {
                     p.setFloatPt(em.floatPt());
                 }
@@ -374,7 +375,7 @@ void PFAlgo3::link_tk2calo(Region & r, std::vector<int> & tk2calo) const {
         if (debug_) printf("PFAlgo3 \t track %3d (pt %7.2f) to be matched to calo, min pT %7.2f\n", itk, tk.floatPt(), minCaloPt );
         for (int ic = 0, nc = r.calo.size(); ic < nc; ++ic) {
             auto & calo = r.calo[ic]; 
-            if (calo.used || calo.floatPt() < minCaloPt) continue;
+            if (calo.used || calo.floatPt() <= minCaloPt) continue;
             float dr = floatDR(tk, calo), dq;
             switch (tkCaloLinkMetric_) {
                 case BestByDR:
@@ -431,7 +432,7 @@ void PFAlgo3::unlinkedtk_algo(Region & r, const std::vector<int> & tk2calo) cons
     for (int itk = 0, ntk = r.track.size(); itk < ntk; ++itk) {
         auto & tk = r.track[itk]; 
         if (tk2calo[itk] != -1 || tk.muonLink || tk.used) continue;
-        float maxPt = (tk.hwStubs >= tightTrackMinStubs_ && tk.hwChi2 > 0.1*tightTrackMaxChi2_) ? tightTrackMaxInvisiblePt_ : maxInvisiblePt_;
+        float maxPt = (tk.hwStubs >= tightTrackMinStubs_ && tk.hwChi2 < 10*tightTrackMaxChi2_) ? tightTrackMaxInvisiblePt_ : maxInvisiblePt_;
         if (tk.floatPt() < maxPt) {
             if (debug_) printf("PFAlgo3 \t track %3d (pt %7.2f) not matched to calo, kept as charged hadron\n", itk, tk.floatPt());
             auto &p = addTrackToPF(r, tk);

--- a/L1Trigger/Phase2L1ParticleFlow/src/Region.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/Region.cc
@@ -39,11 +39,11 @@ unsigned int l1tpf_impl::Region::nInput(InputType type) const {
     return 9999;
 }
 
-unsigned int l1tpf_impl::Region::nOutput(OutputType type, bool usePuppi) const {
+unsigned int l1tpf_impl::Region::nOutput(OutputType type, bool usePuppi, bool fiducial) const {
     unsigned int ret = 0;
     for (const auto &p : (usePuppi ? puppi : pf)) {
         if (p.hwPt <= 0) continue;
-        if (!fiducialLocal(p.floatEta(), p.floatPhi())) continue;
+        if (fiducial && !fiducialLocal(p.floatEta(), p.floatPhi())) continue;
         switch(type) {
             case any_type: ret++; break;
             case charged_type: if (p.intCharge() != 0) ret++; break;

--- a/L1Trigger/Phase2L1ParticleFlow/src/RegionMapper.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/RegionMapper.cc
@@ -192,7 +192,13 @@ std::unique_ptr<l1t::PFCandidateCollection> RegionMapper::fetchCalo(float ptMin,
                 reco::Particle::PolarLorentzVector p4(p.floatPt(), r.globalEta(p.floatEta()), r.globalPhi(p.floatPhi()), 0.13f);
                 l1t::PFCandidate::Kind kind = (p.isEM || emcalo) ? l1t::PFCandidate::Photon : l1t::PFCandidate::NeutralHadron;
                 ret->emplace_back( kind, 0, p4 );
-            }
+                if (p.src) {
+                    auto match = clusterRefMap_.find(p.src);
+                    if (match == clusterRefMap_.end()) {
+                        throw cms::Exception("CorruptData") << "Invalid cluster pointer in cluster pt " << p4.pt() << " eta " << p4.eta() << " phi " << p4.phi();
+                    }
+                    ret->back().setPFCluster(match->second);
+                }            }
         }
     }
     return ret;

--- a/L1Trigger/Phase2L1ParticleFlow/src/firmware/ap_int_fake.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/firmware/ap_int_fake.h
@@ -1,0 +1,85 @@
+template<typename T>
+class bitref_ {
+    public:
+        bitref_(T & number, const int nbit) : num_(number), bit_(nbit) {}
+        operator bool() const { return (num_ & (1 << bit_)); }
+        bitref_ & operator=(bool value) {
+            if (value) num_ |=  (1 << bit_);
+            else       num_ &= ~(1 << bit_); 
+            return *this;
+        }
+    private:
+        T & num_;
+        const int bit_;
+};
+
+template<unsigned int N, typename T=int> class ap_int {
+    public:
+        typedef T base_type;
+        enum { width = N };
+
+        ap_int(T value=0) : value_(mask(value)) { /*printf("ap_int<%u>(%d) = { value_ = %d; }\n", N, value, value_);*/ }
+
+        template<unsigned int M> 
+        ap_int(const ap_int<M,T> & other) { value_ = mask(other.value_); }
+
+        //template<unsigned int M> 
+        //ap_int<N,T> & operator=(const ap_int<M,T> & other) { value_ = mask(other.value_); return *this; }
+
+        operator T() const { return value_; }
+
+        static T mask(T value) { return (value >= 0 ? value & pos_mask() : value | neg_mask()); }
+        static T pos_mask() { return (1 << (N-1))-1; }
+        static T neg_mask() { return    ~pos_mask(); }
+
+        ap_int<N,T> & operator+=(int i) { value_ = mask(value_ + i); return *this; }
+        ap_int<N,T> & operator-=(int i) { value_ = mask(value_ - i); return *this; }
+
+        bool operator[](int i) const { return value_ & (1 << i); }
+        bitref_<T> operator[](int i) { return bitref_<T>(value_, i); }
+
+        ap_int<N,T> operator<<(int i) const { return ap_int<N,T>(value_ << i); }
+        ap_int<N,T> operator>>(int i) const { return ap_int<N,T>(value_ >> i); }
+    private:
+        T value_;
+};
+
+template<unsigned int N, unsigned int M, typename T>
+inline int operator+ (const ap_int<N,T> & a, const ap_int<M,T> &b ) { return T(a)+T(b); }
+template<unsigned int N, unsigned int M, typename T>
+inline int operator- (const ap_int<N,T> & a, const ap_int<M,T> &b ) { return T(a)-T(b); }
+template<unsigned int N, unsigned int M, typename T>
+inline int operator* (const ap_int<N,T> & a, const ap_int<M,T> &b ) { return T(a)*T(b); }
+
+template<unsigned int N, typename T=unsigned> class ap_uint {
+    public:
+        typedef T base_type;
+
+        ap_uint(const T &value=0) : value_(value & mask()) {}
+
+        template<unsigned int M>
+        ap_uint(const ap_uint<M,T> & other) { value_ = (other & mask()); }
+
+        operator T() const { return value_; }
+
+        static T mask() { return (1 << N)-1; }
+
+        ap_uint<N,T> & operator+=(unsigned i) { value_ = mask() & (value_ + i); return *this;  }
+        ap_uint<N,T> & operator-=(unsigned i) { value_ = mask() & (value_ - i); return *this;  }
+
+        bool operator[](int i) const { return value_ & (1 << i); }
+        bitref_<T> operator[](int i) { return bitref_<T>(value_, i); }
+
+        ap_uint<N,T> operator<<(int i) const { return ap_uint<N,T>(value_ << i); }
+        ap_uint<N,T> operator>>(int i) const { return ap_uint<N,T>(value_ >> i); }
+    private:
+        T value_;
+};
+
+template<unsigned int N, unsigned int M, typename T>
+inline int operator+ (const ap_uint<N,T> & a, const ap_uint<M,T> &b ) { return T(a)+T(b); }
+template<unsigned int N, unsigned int M, typename T>
+inline int operator- (const ap_uint<N,T> & a, const ap_uint<M,T> &b ) { return T(a)-T(b); }
+template<unsigned int N, unsigned int M, typename T>
+inline int operator* (const ap_uint<N,T> & a, const ap_uint<M,T> &b ) { return T(a)*T(b); }
+

--- a/L1Trigger/Phase2L1ParticleFlow/src/firmware/data.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/firmware/data.h
@@ -1,0 +1,193 @@
+#ifndef FIRMWARE_DATA_H
+#define FIRMWARE_DATA_H
+
+#ifndef CMSSW_GIT_HASH
+  #include <ap_int.h>
+#else
+  // until ap_int is in a CMSSW release we can use
+  #include "ap_int_fake.h"
+#endif
+
+typedef ap_int<16> pt_t;
+typedef ap_int<10>  etaphi_t;
+typedef ap_int<5>  vtx_t;
+typedef ap_uint<3>  particleid_t;
+typedef ap_int<10> z0_t;  // 40cm / 0.1
+typedef ap_uint<14> tk2em_dr_t;
+typedef ap_uint<14> tk2calo_dr_t;
+typedef ap_uint<10> em2calo_dr_t;
+typedef ap_uint<13> tk2calo_dq_t;
+
+enum PID { PID_Charged=0, PID_Neutral=1, PID_Photon=2, PID_Electron=3, PID_Muon=4 };
+
+// DEFINE MULTIPLICITIES
+#if defined(REG_HGCal)
+    #define NTRACK 25
+    #define NCALO 20
+    #define NMU 4
+    #define NSELCALO 15
+    #define NALLNEUTRALS NSELCALO
+    // dummy
+    #define NEMCALO 1
+    #define NPHOTON NEMCALO
+    // not used but must be there because used in header files
+    #define NNEUTRALS 1
+//--------------------------------
+#elif defined(REG_HGCalNoTK)
+    #define NCALO 12
+    #define NNEUTRALS 8
+    #define NALLNEUTRALS NCALO
+    // dummy
+    #define NMU 1
+    #define NTRACK 1
+    #define NEMCALO 1
+    #define NPHOTON NEMCALO
+    #define NSELCALO 1
+//--------------------------------
+#elif defined(REG_HF)
+    #define NCALO 18
+    #define NNEUTRALS 10
+    #define NALLNEUTRALS NCALO
+    // dummy
+    #define NMU 1
+    #define NTRACK 1
+    #define NEMCALO 1
+    #define NPHOTON NEMCALO
+    #define NSELCALO 1
+//--------------------------------
+#else // BARREL
+   #ifndef REG_Barrel
+     #ifndef CMSSW_GIT_HASH
+       #warning "No region defined, assuming it's barrel (#define REG_Barrel to suppress this)"
+     #endif
+   #endif
+   #if defined(BOARD_MP7)
+       #warning "MP7 NOT SUPPORTED ANYMORE"
+       #define NTRACK 14
+       #define NCALO 10
+       #define NMU 2
+       #define NEMCALO 10
+       #define NPHOTON NEMCALO
+       #define NSELCALO 10
+       #define NALLNEUTRALS (NPHOTON+NSELCALO)
+       #define NNEUTRALS 15
+   #elif defined(BOARD_CTP7)
+       #error "NOT SUPPORTED ANYMORE"
+   #elif defined(BOARD_KU15P)
+       #define NTRACK 14
+       #define NCALO 10
+       #define NMU 2
+       #define NEMCALO 10
+       #define NPHOTON NEMCALO
+       #define NSELCALO 10
+       #define NALLNEUTRALS (NPHOTON+NSELCALO)
+       #define NNEUTRALS 15
+   #elif defined(BOARD_VCU118)
+       #define NTRACK 22
+       #define NCALO 15
+       #define NEMCALO 13
+       #define NMU 2
+       #define NPHOTON NEMCALO
+       #define NSELCALO 10
+       #define NALLNEUTRALS (NPHOTON+NSELCALO)
+       #define NNEUTRALS 25
+   #else
+       #define NTRACK 22
+       #define NCALO 15
+       #define NEMCALO 13
+       #define NMU 2
+       #define NPHOTON NEMCALO
+       #define NSELCALO 10
+       #define NALLNEUTRALS (NPHOTON+NSELCALO)
+       #define NNEUTRALS 25
+   #endif
+
+#endif // region
+
+#if defined(BOARD_MP7)
+    #define PACKING_DATA_SIZE 32
+    #define PACKING_NCHANN    72
+#elif defined(BOARD_KU15P)
+    #define PACKING_DATA_SIZE 64
+    #define PACKING_NCHANN    42
+#elif defined(BOARD_VCU118)
+    #define PACKING_DATA_SIZE 64
+    #define PACKING_NCHANN    96
+#elif defined(BOARD_APD1)
+    #define PACKING_DATA_SIZE 64
+    #define PACKING_NCHANN    96
+#endif
+
+
+struct CaloObj {
+	pt_t hwPt;
+	etaphi_t hwEta, hwPhi; // relative to the region center, at calo
+};
+struct HadCaloObj : public CaloObj {
+	pt_t hwEmPt;
+   	bool hwIsEM;
+};
+inline void clear(HadCaloObj & c) {
+    c.hwPt = 0; c.hwEta = 0; c.hwPhi = 0; c.hwEmPt = 0; c.hwIsEM = 0; 
+}
+
+struct EmCaloObj {
+	pt_t hwPt, hwPtErr;
+	etaphi_t hwEta, hwPhi; // relative to the region center, at calo
+};
+inline void clear(EmCaloObj & c) {
+    c.hwPt = 0; c.hwPtErr = 0; c.hwEta = 0; c.hwPhi = 0; 
+}
+
+struct TkObj {
+	pt_t hwPt, hwPtErr;
+	etaphi_t hwEta, hwPhi; // relative to the region center, at calo
+	z0_t hwZ0;
+	bool hwTightQuality;
+};
+inline void clear(TkObj & c) {
+    c.hwPt = 0; c.hwPtErr = 0; c.hwEta = 0; c.hwPhi = 0; c.hwZ0 = 0; c.hwTightQuality = 0;
+}
+
+struct MuObj {
+	pt_t hwPt, hwPtErr;
+	etaphi_t hwEta, hwPhi; // relative to the region center, at vtx(?)
+};
+inline void clear(MuObj & c) {
+    c.hwPt = 0; c.hwPtErr = 0; c.hwEta = 0; c.hwPhi = 0; 
+}
+
+
+struct PFChargedObj {
+	pt_t hwPt;
+	etaphi_t hwEta, hwPhi; // relative to the region center, at calo
+	particleid_t hwId;
+	z0_t hwZ0;
+};
+inline void clear(PFChargedObj & c) {
+    c.hwPt = 0; c.hwEta = 0; c.hwPhi = 0; c.hwId = 0; c.hwZ0 = 0;
+}
+
+struct PFNeutralObj {
+	pt_t hwPt;
+	etaphi_t hwEta, hwPhi; // relative to the region center, at calo
+	particleid_t hwId;
+	pt_t hwPtPuppi;
+};
+inline void clear(PFNeutralObj & c) {
+    c.hwPt = 0; c.hwEta = 0; c.hwPhi = 0; c.hwId = 0; c.hwPtPuppi = 0;
+}
+
+//TMUX
+#define NETA_TMUX 2
+#define NPHI_TMUX 1
+/* #define TMUX_IN 36 */
+/* #define TMUX_OUT 18 */
+#define TMUX_IN 18
+#define TMUX_OUT 6
+#define NTRACK_TMUX (NTRACK*TMUX_OUT*NETA_TMUX*NPHI_TMUX)
+#define NCALO_TMUX (NCALO*TMUX_OUT*NETA_TMUX*NPHI_TMUX)
+#define NEMCALO_TMUX (NEMCALO*TMUX_OUT*NETA_TMUX*NPHI_TMUX)
+#define NMU_TMUX (NMU*TMUX_OUT*NETA_TMUX*NPHI_TMUX)
+
+#endif

--- a/L1Trigger/Phase2L1ParticleFlow/src/firmware/pfalgo2hgc.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/firmware/pfalgo2hgc.h
@@ -1,0 +1,28 @@
+#ifndef FIRMWARE_PFALGO2HGC_H
+#define FIRMWARE_PFALGO2HGC_H
+
+#ifndef REG_HGCal
+  #ifndef CMSSW_GIT_HASH
+    #warning "REG_HGCal is not #defined, but this algorithm has only been tested there"
+  #endif
+#endif
+
+#include "pfalgo_common.h"
+
+void pfalgo2hgc(const HadCaloObj calo[NCALO], const TkObj track[NTRACK], const MuObj mu[NMU], PFChargedObj outch[NTRACK], PFNeutralObj outne[NSELCALO], PFChargedObj outmu[NMU]) ;
+
+#if defined(PACKING_DATA_SIZE) && defined(PACKING_NCHANN)
+void packed_pfalgo2hgc(const ap_uint<PACKING_DATA_SIZE> input[PACKING_NCHANN], ap_uint<PACKING_DATA_SIZE> output[PACKING_NCHANN]) ;
+void pfalgo2hgc_pack_in(const HadCaloObj calo[NCALO], const TkObj track[NTRACK], const MuObj mu[NMU], ap_uint<PACKING_DATA_SIZE> input[PACKING_NCHANN]) ;
+void pfalgo2hgc_unpack_in(const ap_uint<PACKING_DATA_SIZE> input[PACKING_NCHANN], HadCaloObj calo[NCALO], TkObj track[NTRACK], MuObj mu[NMU]) ;
+void pfalgo2hgc_pack_out(const PFChargedObj outch[NTRACK], const PFNeutralObj outne[NSELCALO], const PFChargedObj outmu[NMU], ap_uint<PACKING_DATA_SIZE> output[PACKING_NCHANN]) ;
+void pfalgo2hgc_unpack_out(const ap_uint<PACKING_DATA_SIZE> output[PACKING_NCHANN], PFChargedObj outch[NTRACK], PFNeutralObj outne[NSELCALO], PFChargedObj outmu[NMU]) ;
+#endif
+
+#ifndef CMSSW_GIT_HASH
+#define PFALGO_DR2MAX_TK_CALO 525
+#define PFALGO_TK_MAXINVPT_LOOSE    40
+#define PFALGO_TK_MAXINVPT_TIGHT    80
+#endif
+
+#endif

--- a/L1Trigger/Phase2L1ParticleFlow/src/firmware/pfalgo3.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/firmware/pfalgo3.h
@@ -1,0 +1,33 @@
+#ifndef FIRMWARE_PFALGO3_H
+#define FIRMWARE_PFALGO3_H
+
+#ifndef REG_Barrel
+  #ifndef CMSSW_GIT_HASH
+    #warning "REG_Barrel not defined in PFALGO3: not validated"
+  #endif
+#endif
+
+#include "pfalgo_common.h"
+
+void pfalgo3(const EmCaloObj emcalo[NEMCALO], const HadCaloObj hadcalo[NCALO], const TkObj track[NTRACK], const MuObj mu[NMU], PFChargedObj outch[NTRACK], PFNeutralObj outpho[NPHOTON], PFNeutralObj outne[NSELCALO], PFChargedObj outmu[NMU]) ;
+
+#if defined(PACKING_DATA_SIZE) && defined(PACKING_NCHANN)
+void packed_pfalgo3(const ap_uint<PACKING_DATA_SIZE> input[PACKING_NCHANN], ap_uint<PACKING_DATA_SIZE> output[PACKING_NCHANN]) ;
+void pfalgo3_pack_in(const EmCaloObj emcalo[NEMCALO], const HadCaloObj hadcalo[NCALO], const TkObj track[NTRACK], const MuObj mu[NMU], ap_uint<PACKING_DATA_SIZE> input[PACKING_NCHANN]) ;
+void pfalgo3_unpack_in(const ap_uint<PACKING_DATA_SIZE> input[PACKING_NCHANN], EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj track[NTRACK], MuObj mu[NMU]) ;
+void pfalgo3_pack_out(const PFChargedObj outch[NTRACK], const PFNeutralObj outpho[NPHOTON], const PFNeutralObj outne[NSELCALO], const PFChargedObj outmu[NMU], ap_uint<PACKING_DATA_SIZE> output[PACKING_NCHANN]) ;
+void pfalgo3_unpack_out(const ap_uint<PACKING_DATA_SIZE> output[PACKING_NCHANN], PFChargedObj outch[NTRACK], PFNeutralObj outpho[NPHOTON], PFNeutralObj outne[NSELCALO], PFChargedObj outmu[NMU]) ;
+#endif
+
+
+void pfalgo3_set_debug(bool debug);
+
+#ifndef CMSSW_GIT_HASH
+#define PFALGO_DR2MAX_TK_CALO 1182
+#define PFALGO_DR2MAX_EM_CALO 525
+#define PFALGO_DR2MAX_TK_EM   84
+#define PFALGO_TK_MAXINVPT_LOOSE    40
+#define PFALGO_TK_MAXINVPT_TIGHT    80
+#endif
+
+#endif

--- a/L1Trigger/Phase2L1ParticleFlow/src/firmware/pfalgo_common.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/firmware/pfalgo_common.h
@@ -1,0 +1,16 @@
+#ifndef FIRMWARE_PFALGO_COMMON_H
+#define FIRMWARE_PFALGO_COMMON_H
+
+#include "data.h"
+
+inline int dr2_int(etaphi_t eta1, etaphi_t phi1, etaphi_t eta2, etaphi_t phi2) {
+    ap_int<etaphi_t::width+1> deta = (eta1-eta2);
+    ap_int<etaphi_t::width+1> dphi = (phi1-phi2);
+    return deta*deta + dphi*dphi;
+}
+
+#ifndef CMSSW_GIT_HASH
+#define PFALGO_DR2MAX_TK_MU 2101
+#endif
+
+#endif

--- a/L1Trigger/Phase2L1ParticleFlow/src/ref/pfalgo2hgc_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/ref/pfalgo2hgc_ref.cpp
@@ -1,0 +1,137 @@
+#include "pfalgo2hgc_ref.h"
+
+#ifndef CMSSW_GIT_HASH
+  #include "../DiscretePFInputs.h"
+#else
+  #include "../../interface/DiscretePFInputs.h"
+#endif
+
+#include "../utils/Firmware2DiscretePF.h"
+#include <cmath>
+#include <cstdio>
+#include <algorithm>
+#include <memory>
+
+
+int g_pfalgo2hgc_debug_ref_ = 0;
+
+void pfalgo2hgc_ref_set_debug(int debug) { g_pfalgo2hgc_debug_ref_ = debug; }
+
+void pfalgo2hgc_ref(const pfalgo_config &cfg, const HadCaloObj calo[/*cfg.nCALO*/], const TkObj track[/*cfg.nTRACK*/], const MuObj mu[/*cfg.nMU*/], PFChargedObj outch[/*cfg.nTRACK*/], PFNeutralObj outne[/*cfg.nSELCALO*/], PFChargedObj outmu[/*cfg.nMU*/]) {
+
+    if (g_pfalgo2hgc_debug_ref_) {
+#ifdef L1Trigger_Phase2L1ParticleFlow_DiscretePFInputs_MORE
+        for (unsigned int i = 0; i < cfg.nTRACK; ++i) { if (track[i].hwPt == 0) continue;
+            l1tpf_impl::PropagatedTrack tk; fw2dpf::convert(track[i], tk); 
+            printf("FW  \t track %3d: pt %8d [ %7.2f ]  calo eta %+7d [ %+5.2f ]  calo phi %+7d [ %+5.2f ]  calo ptErr %6d [ %7.2f ]   tight %d\n", 
+                                i, tk.hwPt, tk.floatPt(), tk.hwEta, tk.floatEta(), tk.hwPhi, tk.floatPhi(), tk.hwCaloPtErr, tk.floatCaloPtErr(), int(track[i].hwTightQuality));
+        }
+        for (unsigned int i = 0; i < cfg.nCALO; ++i) { if (calo[i].hwPt == 0) continue;
+            l1tpf_impl::CaloCluster c; fw2dpf::convert(calo[i], c); 
+            printf("FW  \t calo  %3d: pt %8d [ %7.2f ]  calo eta %+7d [ %+5.2f ]  calo phi %+7d [ %+5.2f ]  calo emPt %7d [ %7.2f ]   isEM %d \n", 
+                                i, c.hwPt, c.floatPt(), c.hwEta, c.floatEta(), c.hwPhi, c.floatPhi(), c.hwEmPt, c.floatEmPt(), c.isEM);
+        } 
+        for (unsigned int i = 0; i < cfg.nMU; ++i) { if (mu[i].hwPt == 0) continue;
+            l1tpf_impl::Muon muon; fw2dpf::convert(mu[i], muon); 
+            printf("FW  \t muon  %3d: pt %8d [ %7.2f ]  muon eta %+7d [ %+5.2f ]  muon phi %+7d [ %+5.2f ]   \n", 
+                                i, muon.hwPt, muon.floatPt(), muon.hwEta, muon.floatEta(), muon.hwPhi, muon.floatPhi());
+        } 
+#endif
+    }
+
+    // constants
+    const pt_t     TKPT_MAX_LOOSE = cfg.tk_MAXINVPT_LOOSE;
+    const pt_t     TKPT_MAX_TIGHT = cfg.tk_MAXINVPT_TIGHT;
+    const int      DR2MAX         = cfg.dR2MAX_TK_CALO;
+
+    ////////////////////////////////////////////////////
+    // TK-MU Linking
+    std::unique_ptr<bool[]> isMu(new bool[cfg.nTRACK]);
+    pfalgo_mu_ref(cfg, track, mu, &isMu[0], outmu, g_pfalgo2hgc_debug_ref_ );
+
+
+    ////////////////////////////////////////////////////
+    // TK-HAD Linking
+
+    // initialize sum track pt
+    std::vector<pt_t> calo_sumtk(cfg.nCALO), calo_subpt(cfg.nCALO);
+    std::vector<int>  calo_sumtkErr2(cfg.nCALO);
+    for (unsigned int ic = 0; ic < cfg.nCALO; ++ic) { calo_sumtk[ic] = 0;  calo_sumtkErr2[ic] = 0;}
+
+    // initialize good track bit
+    std::unique_ptr<bool[]> track_good(new bool[cfg.nTRACK]);
+    std::unique_ptr<bool[]> isEle(new bool[cfg.nTRACK]);
+    for (unsigned int it = 0; it < cfg.nTRACK; ++it) { 
+        track_good[it] = (track[it].hwPt < (track[it].hwTightQuality ? TKPT_MAX_TIGHT : TKPT_MAX_LOOSE) || isMu[it]); 
+        isEle[it] = false;
+    }
+
+    // initialize output
+    for (unsigned int ipf = 0; ipf < cfg.nTRACK; ++ipf) clear(outch[ipf]); 
+    for (unsigned int ipf = 0; ipf < cfg.nSELCALO; ++ipf) clear(outne[ipf]);
+
+    // for each track, find the closest calo
+    for (unsigned int it = 0; it < cfg.nTRACK; ++it) {
+        if (track[it].hwPt > 0 && !isMu[it]) {
+            int  ibest = best_match_with_pt_ref<HadCaloObj>(cfg.nCALO, DR2MAX, calo, track[it]);
+            if (ibest != -1) {
+                if (g_pfalgo2hgc_debug_ref_) printf("FW  \t track  %3d pt %7d matched to calo' %3d pt %7d\n", it, int(track[it].hwPt), ibest, int(calo[ibest].hwPt));
+                track_good[it] = 1;
+                isEle[it] = calo[ibest].hwIsEM;
+                calo_sumtk[ibest]    += track[it].hwPt;
+                calo_sumtkErr2[ibest] += sqr(track[it].hwPtErr);
+            }
+        }
+    }
+
+    for (unsigned int ic = 0; ic < cfg.nCALO; ++ic) {
+        if (calo_sumtk[ic] > 0) {
+            pt_t ptdiff = calo[ic].hwPt - calo_sumtk[ic];
+            int sigmamult = calo_sumtkErr2[ic]; //  + (calo_sumtkErr2[ic] >> 1)); // this multiplies by 1.5 = sqrt(1.5)^2 ~ (1.2)^2
+            if (g_pfalgo2hgc_debug_ref_ && (calo[ic].hwPt > 0)) {
+#ifdef L1Trigger_Phase2L1ParticleFlow_DiscretePFInputs_MORE
+                l1tpf_impl::CaloCluster floatcalo; fw2dpf::convert(calo[ic], floatcalo); 
+                printf("FW  \t calo'  %3d pt %7d [ %7.2f ] eta %+7d [ %+5.2f ] has a sum track pt %7d, difference %7d +- %.2f \n",
+                            ic, int(calo[ic].hwPt), floatcalo.floatPt(), int(calo[ic].hwEta), floatcalo.floatEta(), 
+                                int(calo_sumtk[ic]), int(ptdiff), std::sqrt(float(int(calo_sumtkErr2[ic]))));
+#endif
+                        
+            }
+            if (ptdiff > 0 && ptdiff*ptdiff > sigmamult) {
+                calo_subpt[ic] = ptdiff;
+            } else {
+                calo_subpt[ic] = 0;
+            }
+        } else {
+            calo_subpt[ic] = calo[ic].hwPt;
+        }
+        if (g_pfalgo2hgc_debug_ref_ && (calo[ic].hwPt > 0)) printf("FW  \t calo'  %3d pt %7d ---> %7d \n", ic, int(calo[ic].hwPt), int(calo_subpt[ic]));
+    }
+
+    // copy out charged hadrons
+    for (unsigned int it = 0; it < cfg.nTRACK; ++it) {
+        if (track_good[it]) {
+            assert(!(isEle[it] && isMu[it]));
+            outch[it].hwPt = track[it].hwPt;
+            outch[it].hwEta = track[it].hwEta;
+            outch[it].hwPhi = track[it].hwPhi;
+            outch[it].hwZ0 = track[it].hwZ0;
+            outch[it].hwId  = isEle[it] ? PID_Electron : (isMu[it] ? PID_Muon : PID_Charged);
+        }
+    }
+
+    // copy out neutral hadrons with sorting and cropping
+    std::vector<PFNeutralObj> outne_all(cfg.nCALO);
+    for (unsigned int ipf = 0; ipf < cfg.nCALO; ++ipf) clear(outne_all[ipf]);
+    for (unsigned int ic = 0; ic < cfg.nCALO; ++ic) {
+        if (calo_subpt[ic] > 0) {
+            outne_all[ic].hwPt  = calo_subpt[ic];
+            outne_all[ic].hwEta = calo[ic].hwEta;
+            outne_all[ic].hwPhi = calo[ic].hwPhi;
+            outne_all[ic].hwId  = calo[ic].hwIsEM ? PID_Photon : PID_Neutral;
+        }
+    }
+
+    ptsort_ref(cfg.nCALO, cfg.nSELCALO, outne_all, outne);
+
+}

--- a/L1Trigger/Phase2L1ParticleFlow/src/ref/pfalgo2hgc_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/ref/pfalgo2hgc_ref.h
@@ -1,0 +1,11 @@
+#ifndef PFALGO2HGC_REF_H
+#define PFALGO2HGC_REF_H
+
+#include "../firmware/pfalgo2hgc.h"
+#include "pfalgo_common_ref.h"
+
+void pfalgo2hgc_ref_set_debug(int debug) ;
+
+void pfalgo2hgc_ref(const pfalgo_config &cfg, const HadCaloObj calo[/*cfg.nCALO*/], const TkObj track[/*cfg.nTRACK*/], const MuObj mu[/*cfg.nMU*/], PFChargedObj outch[/*cfg.nTRACK*/], PFNeutralObj outne[/*cfg.nSELCALO*/], PFChargedObj outmu[/*cfg.nMU*/]) ;
+
+#endif

--- a/L1Trigger/Phase2L1ParticleFlow/src/ref/pfalgo3_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/ref/pfalgo3_ref.cpp
@@ -1,0 +1,310 @@
+#include "pfalgo3_ref.h"
+
+#ifndef CMSSW_GIT_HASH
+  #include "../DiscretePFInputs.h"
+#else
+  #include "../../interface/DiscretePFInputs.h"
+#endif
+
+#include "../utils/Firmware2DiscretePF.h"
+#include <cmath>
+#include <cstdio>
+#include <algorithm>
+#include <vector>
+#include <memory>
+
+
+int g_pfalgo3_debug_ref_ = 0;
+
+void pfalgo3_ref_set_debug(int debug) { g_pfalgo3_debug_ref_ = debug; }
+
+template<bool doPtMin, typename CO_t>
+int tk_best_match_ref(unsigned int nCAL, unsigned int dR2MAX, const CO_t calo[/*nCAL*/], const TkObj & track) {
+    pt_t caloPtMin = track.hwPt - 2*(track.hwPtErr);
+    if (caloPtMin < 0) caloPtMin = 0;
+    int  drmin = dR2MAX, ibest = -1;
+    for (unsigned int ic = 0; ic < nCAL; ++ic) {
+            if (calo[ic].hwPt <= 0) continue;
+            if (doPtMin && calo[ic].hwPt <= caloPtMin) continue;
+            int dr = dr2_int(track.hwEta, track.hwPhi, calo[ic].hwEta, calo[ic].hwPhi);
+            if (dr < drmin) { drmin = dr; ibest = ic; }
+    }
+    return ibest;
+}
+int em_best_match_ref(unsigned int nCAL, unsigned int dR2MAX, const HadCaloObj calo[/*nCAL*/], const EmCaloObj & em) {
+    pt_t emPtMin = em.hwPt >> 1;
+    int  drmin = dR2MAX, ibest = -1;
+    for (unsigned int ic = 0; ic < nCAL; ++ic) {
+            if (calo[ic].hwEmPt <= emPtMin) continue;
+            int dr = dr2_int(em.hwEta, em.hwPhi, calo[ic].hwEta, calo[ic].hwPhi);
+            if (dr < drmin) { drmin = dr; ibest = ic; }
+    }
+    return ibest;
+}
+
+
+void pfalgo3_em_ref(const pfalgo3_config &cfg, const EmCaloObj emcalo[/*cfg.nEMCALO*/], const HadCaloObj hadcalo[/*cfg.nCALO*/], const TkObj track[/*cfg.nTRACK*/], const bool isMu[/*cfg.nTRACK*/], bool isEle[/*cfg.nTRACK*/], PFNeutralObj outpho[/*cfg.nPHOTON*/], HadCaloObj hadcalo_out[/*cfg.nCALO*/]) {
+    // constants
+    const int DR2MAX_TE = cfg.dR2MAX_TK_EM;
+    const int DR2MAX_EH = cfg.dR2MAX_EM_CALO;
+
+    // initialize sum track pt
+    std::vector<pt_t> calo_sumtk(cfg.nEMCALO);
+    for (unsigned int ic = 0; ic < cfg.nEMCALO; ++ic) {  calo_sumtk[ic] = 0; }
+    std::vector<int> tk2em(cfg.nTRACK); 
+    std::vector<bool> isEM(cfg.nEMCALO);
+    // for each track, find the closest calo
+    for (unsigned int it = 0; it < cfg.nTRACK; ++it) {
+        if (track[it].hwPt > 0 && !isMu[it]) {
+            tk2em[it] = tk_best_match_ref<false,EmCaloObj>(cfg.nEMCALO, DR2MAX_TE, emcalo, track[it]);
+            if (tk2em[it] != -1) {
+                if (g_pfalgo3_debug_ref_) printf("FW  \t track  %3d pt %7d matched to em calo %3d pt %7d\n", it, int(track[it].hwPt), tk2em[it], int(emcalo[tk2em[it]].hwPt));
+                calo_sumtk[tk2em[it]] += track[it].hwPt;
+            }
+        } else {
+        	tk2em[it] = -1;
+        }
+    }
+
+    if (g_pfalgo3_debug_ref_) {
+        for (unsigned int ic = 0; ic < cfg.nEMCALO; ++ic) {  if (emcalo[ic].hwPt > 0) printf("FW  \t emcalo %3d pt %7d has sumtk %7d\n", ic, int(emcalo[ic].hwPt), int(calo_sumtk[ic])); }
+    }
+
+    for (unsigned int ic = 0; ic < cfg.nEMCALO; ++ic) {
+        pt_t photonPt;
+        if (calo_sumtk[ic] > 0) {
+            pt_t ptdiff = emcalo[ic].hwPt - calo_sumtk[ic];
+            int sigma2 = sqr(emcalo[ic].hwPtErr);
+            int sigma2Lo = 4*sigma2, sigma2Hi = sigma2; // + (sigma2>>1); // cut at 1 sigma instead of old cut at sqrt(1.5) sigma's
+            int ptdiff2 = ptdiff*ptdiff;
+            if ((ptdiff >= 0 && ptdiff2 <= sigma2Hi) || (ptdiff < 0 && ptdiff2 < sigma2Lo)) {
+                // electron
+                photonPt = 0; 
+                isEM[ic] = true;
+                if (g_pfalgo3_debug_ref_) printf("FW  \t emcalo %3d pt %7d ptdiff %7d [match window: -%.2f / +%.2f] flagged as electron\n", ic, int(emcalo[ic].hwPt), int(ptdiff), std::sqrt(float(sigma2Lo)), std::sqrt(float(sigma2Hi)));
+            } else if (ptdiff > 0) {
+                // electron + photon
+                photonPt = ptdiff; 
+                isEM[ic] = true;
+                if (g_pfalgo3_debug_ref_) printf("FW  \t emcalo %3d pt %7d ptdiff %7d [match window: -%.2f / +%.2f] flagged as electron + photon of pt %7d\n", ic, int(emcalo[ic].hwPt), int(ptdiff), std::sqrt(float(sigma2Lo)), std::sqrt(float(sigma2Hi)), int(photonPt));
+            } else {
+                // pion
+                photonPt = 0;
+                isEM[ic] = false;
+                if (g_pfalgo3_debug_ref_) printf("FW  \t emcalo %3d pt %7d ptdiff %7d [match window: -%.2f / +%.2f] flagged as pion\n", ic, int(emcalo[ic].hwPt), int(ptdiff), std::sqrt(float(sigma2Lo)), std::sqrt(float(sigma2Hi)));
+            }
+        } else {
+            // photon
+            isEM[ic] = true;
+            photonPt = emcalo[ic].hwPt;
+            if (g_pfalgo3_debug_ref_ && emcalo[ic].hwPt > 0) printf("FW  \t emcalo %3d pt %7d flagged as photon\n", ic, int(emcalo[ic].hwPt));
+        }
+        outpho[ic].hwPt  = photonPt;
+        outpho[ic].hwEta = photonPt ? emcalo[ic].hwEta : etaphi_t(0);
+        outpho[ic].hwPhi = photonPt ? emcalo[ic].hwPhi : etaphi_t(0);
+        outpho[ic].hwId  = photonPt ? PID_Photon : particleid_t(0);
+
+    }
+
+    for (unsigned int it = 0; it < cfg.nTRACK; ++it) {
+        isEle[it] = (tk2em[it] != -1) && isEM[tk2em[it]];
+        if (g_pfalgo3_debug_ref_ && isEle[it]) printf("FW  \t track  %3d pt %7d flagged as electron.\n", it, int(track[it].hwPt));
+    }
+
+    std::vector<int> em2calo(cfg.nEMCALO);
+    for (unsigned int ic = 0; ic < cfg.nEMCALO; ++ic) {
+        em2calo[ic] = em_best_match_ref(cfg.nCALO, DR2MAX_EH, hadcalo, emcalo[ic]);
+        if (g_pfalgo3_debug_ref_ && (emcalo[ic].hwPt > 0)) {
+             printf("FW  \t emcalo %3d pt %7d isEM %d matched to hadcalo %7d pt %7d emPt %7d isEM %d\n", 
+                                ic, int(emcalo[ic].hwPt), int(isEM[ic]), em2calo[ic], (em2calo[ic] >= 0 ? int(hadcalo[em2calo[ic]].hwPt) : -1), 
+                                (em2calo[ic] >= 0 ? int(hadcalo[em2calo[ic]].hwEmPt) : -1), (em2calo[ic] >= 0 ? int(hadcalo[em2calo[ic]].hwIsEM) : 0));
+        }
+    }
+    
+    for (unsigned int ih = 0; ih < cfg.nCALO; ++ih) {
+        hadcalo_out[ih] = hadcalo[ih];
+        pt_t sub = 0; bool keep = false;
+        for (unsigned int ic = 0; ic < cfg.nEMCALO; ++ic) {
+            if (em2calo[ic] == int(ih)) {
+                if (isEM[ic]) sub += emcalo[ic].hwPt;
+                else keep = true;
+            }
+        }
+        pt_t emdiff  = hadcalo[ih].hwEmPt - sub;
+        pt_t alldiff = hadcalo[ih].hwPt - sub;
+        if (g_pfalgo3_debug_ref_ && (hadcalo[ih].hwPt > 0)) {
+            printf("FW  \t calo   %3d pt %7d has a subtracted pt of %7d, empt %7d -> %7d   isem %d mustkeep %d \n",
+                        ih, int(hadcalo[ih].hwPt), int(alldiff), int(hadcalo[ih].hwEmPt), int(emdiff), int(hadcalo[ih].hwIsEM), keep);
+                    
+        }
+        if (alldiff <= ( hadcalo[ih].hwPt >>  4 ) ) {
+            hadcalo_out[ih].hwPt = 0;   // kill
+            hadcalo_out[ih].hwEmPt = 0; // kill
+            if (g_pfalgo3_debug_ref_ && (hadcalo[ih].hwPt > 0)) printf("FW  \t calo   %3d pt %7d --> discarded (zero pt)\n", ih, int(hadcalo[ih].hwPt));
+        } else if ((hadcalo[ih].hwIsEM && emdiff <= ( hadcalo[ih].hwEmPt >> 3 )) && !keep) {
+            hadcalo_out[ih].hwPt = 0;   // kill
+            hadcalo_out[ih].hwEmPt = 0; // kill
+            if (g_pfalgo3_debug_ref_ && (hadcalo[ih].hwPt > 0)) printf("FW  \t calo   %3d pt %7d --> discarded (zero em)\n", ih, int(hadcalo[ih].hwPt));
+        } else {
+            hadcalo_out[ih].hwPt   = alldiff;   
+            hadcalo_out[ih].hwEmPt = (emdiff > 0 ? emdiff : pt_t(0)); 
+        }
+    }
+}
+
+void pfalgo3_ref(const pfalgo3_config &cfg, const EmCaloObj emcalo[/*cfg.nEMCALO*/], const HadCaloObj hadcalo[/*cfg.nCALO*/], const TkObj track[/*cfg.nTRACK*/], const MuObj mu[/*cfg.nMU*/], PFChargedObj outch[/*cfg.nTRACK*/], PFNeutralObj outpho[/*cfg.nPHOTON*/], PFNeutralObj outne[/*cfg.nSELCALO*/], PFChargedObj outmu[/*cfg.nMU*/]) {
+
+    if (g_pfalgo3_debug_ref_) {
+#ifdef L1Trigger_Phase2L1ParticleFlow_DiscretePFInputs_MORE
+        for (unsigned int i = 0; i < cfg.nTRACK; ++i) { if (track[i].hwPt == 0) continue;
+            l1tpf_impl::PropagatedTrack tk; fw2dpf::convert(track[i], tk); 
+            printf("FW  \t track %3d: pt %8d [ %7.2f ]  calo eta %+7d [ %+5.2f ]  calo phi %+7d [ %+5.2f ]  calo ptErr %6d [ %7.2f ]   tight %d\n", 
+                                i, tk.hwPt, tk.floatPt(), tk.hwEta, tk.floatEta(), tk.hwPhi, tk.floatPhi(), tk.hwCaloPtErr, tk.floatCaloPtErr(), int(track[i].hwTightQuality));
+        }
+        for (unsigned int i = 0; i < cfg.nEMCALO; ++i) { if (emcalo[i].hwPt == 0) continue;
+            l1tpf_impl::CaloCluster em; fw2dpf::convert(emcalo[i], em); 
+            printf("FW  \t EM    %3d: pt %8d [ %7.2f ]  calo eta %+7d [ %+5.2f ]  calo phi %+7d [ %+5.2f ]  calo ptErr %6d [ %7.2f ] \n", 
+                                i, em.hwPt, em.floatPt(), em.hwEta, em.floatEta(), em.hwPhi, em.floatPhi(), em.hwPtErr, em.floatPtErr());
+        } 
+        for (unsigned int i = 0; i < cfg.nCALO; ++i) { if (hadcalo[i].hwPt == 0) continue;
+            l1tpf_impl::CaloCluster calo; fw2dpf::convert(hadcalo[i], calo); 
+            printf("FW  \t calo  %3d: pt %8d [ %7.2f ]  calo eta %+7d [ %+5.2f ]  calo phi %+7d [ %+5.2f ]  calo emPt %7d [ %7.2f ]   isEM %d \n", 
+                                i, calo.hwPt, calo.floatPt(), calo.hwEta, calo.floatEta(), calo.hwPhi, calo.floatPhi(), calo.hwEmPt, calo.floatEmPt(), calo.isEM);
+        } 
+        for (unsigned int i = 0; i < cfg.nMU; ++i) { if (mu[i].hwPt == 0) continue;
+            l1tpf_impl::Muon muon; fw2dpf::convert(mu[i], muon); 
+            printf("FW  \t muon  %3d: pt %8d [ %7.2f ]  muon eta %+7d [ %+5.2f ]  muon phi %+7d [ %+5.2f ]   \n", 
+                                i, muon.hwPt, muon.floatPt(), muon.hwEta, muon.floatEta(), muon.hwPhi, muon.floatPhi());
+        } 
+#endif
+    }
+
+    // constants
+    const pt_t TKPT_MAX_LOOSE = cfg.tk_MAXINVPT_LOOSE; 
+    const pt_t TKPT_MAX_TIGHT = cfg.tk_MAXINVPT_TIGHT; 
+    const int  DR2MAX = cfg.dR2MAX_TK_CALO;
+
+    ////////////////////////////////////////////////////
+    // TK-MU Linking
+    // // we can't use std::vector here because it's specialized
+    std::unique_ptr<bool[]> isMu(new bool[cfg.nTRACK]);
+    pfalgo_mu_ref(cfg, track, mu, &isMu[0], outmu, g_pfalgo3_debug_ref_);
+
+    ////////////////////////////////////////////////////
+    // TK-EM Linking
+    std::unique_ptr<bool[]> isEle(new bool[cfg.nTRACK]);
+    std::vector<HadCaloObj> hadcalo_subem(cfg.nCALO);
+    pfalgo3_em_ref(cfg, emcalo, hadcalo, track, &isMu[0], &isEle[0], outpho, &hadcalo_subem[0]);
+
+    ////////////////////////////////////////////////////
+    // TK-HAD Linking
+
+    // initialize sum track pt
+    std::vector<pt_t> calo_sumtk(cfg.nCALO), calo_subpt(cfg.nCALO);
+    std::vector<int>  calo_sumtkErr2(cfg.nCALO);
+    for (unsigned int ic = 0; ic < cfg.nCALO; ++ic) { calo_sumtk[ic] = 0;  calo_sumtkErr2[ic] = 0;}
+
+    // initialize good track bit
+    std::unique_ptr<bool[]>  track_good(new bool[cfg.nTRACK]);
+    for (unsigned int it = 0; it < cfg.nTRACK; ++it) { 
+        track_good[it] = (track[it].hwPt < (track[it].hwTightQuality ? TKPT_MAX_TIGHT : TKPT_MAX_LOOSE) || isEle[it] || isMu[it]); 
+    }
+
+    // initialize output
+    for (unsigned int ipf = 0; ipf < cfg.nTRACK; ++ipf) { clear(outch[ipf]); }
+    for (unsigned int ipf = 0; ipf < cfg.nSELCALO; ++ipf) { clear(outne[ipf]); }
+
+    // for each track, find the closest calo
+    for (unsigned int it = 0; it < cfg.nTRACK; ++it) {
+        if (track[it].hwPt > 0 && !isEle[it] && !isMu[it]) {
+            int  ibest = best_match_with_pt_ref<HadCaloObj>(cfg.nCALO, DR2MAX, &hadcalo_subem[0], track[it]);
+            //int  ibest = tk_best_match_ref<true,HadCaloObj>(cfg.nCALO, DR2MAX, &hadcalo_subem[0], track[it]);
+            if (ibest != -1) {
+                if (g_pfalgo3_debug_ref_) printf("FW  \t track  %3d pt %7d matched to calo %3d pt %7d\n", it, int(track[it].hwPt), ibest, int(hadcalo_subem[ibest].hwPt));
+                track_good[it] = 1;
+                calo_sumtk[ibest]    += track[it].hwPt;
+                calo_sumtkErr2[ibest] += sqr(track[it].hwPtErr);
+            }
+        }
+    }
+
+    for (unsigned int ic = 0; ic < cfg.nCALO; ++ic) {
+        if (calo_sumtk[ic] > 0) {
+            pt_t ptdiff = hadcalo_subem[ic].hwPt - calo_sumtk[ic];
+            int sigmamult = calo_sumtkErr2[ic]; // before we did (calo_sumtkErr2[ic] + (calo_sumtkErr2[ic] >> 1)); to multiply by 1.5 = sqrt(1.5)^2 ~ (1.2)^2
+            if (g_pfalgo3_debug_ref_ && (hadcalo_subem[ic].hwPt > 0)) {
+#ifdef L1Trigger_Phase2L1ParticleFlow_DiscretePFInputs_MORE
+                l1tpf_impl::CaloCluster floatcalo; fw2dpf::convert(hadcalo_subem[ic], floatcalo); 
+                printf("FW  \t calo  %3d pt %7d [ %7.2f ] eta %+7d [ %+5.2f ] has a sum track pt %7d, difference %7d +- %.2f \n",
+                            ic, int(hadcalo_subem[ic].hwPt), floatcalo.floatPt(), int(hadcalo_subem[ic].hwEta), floatcalo.floatEta(), 
+                                int(calo_sumtk[ic]), int(ptdiff), std::sqrt(float(int(calo_sumtkErr2[ic]))));
+#endif
+                        
+            }
+            if (ptdiff > 0 && ptdiff*ptdiff > sigmamult) {
+                calo_subpt[ic] = ptdiff;
+            } else {
+                calo_subpt[ic] = 0;
+            }
+        } else {
+            calo_subpt[ic] = hadcalo_subem[ic].hwPt;
+        }
+        if (g_pfalgo3_debug_ref_ && (hadcalo_subem[ic].hwPt > 0)) printf("FW  \t calo  %3d pt %7d ---> %7d \n", ic, int(hadcalo_subem[ic].hwPt), int(calo_subpt[ic]));
+    }
+
+    // copy out charged hadrons
+    for (unsigned int it = 0; it < cfg.nTRACK; ++it) {
+        if (track_good[it]) {
+            outch[it].hwPt = track[it].hwPt;
+            outch[it].hwEta = track[it].hwEta;
+            outch[it].hwPhi = track[it].hwPhi;
+            outch[it].hwZ0 = track[it].hwZ0;
+            outch[it].hwId  = isEle[it] ? PID_Electron : (isMu[it] ? PID_Muon : PID_Charged);
+        }
+    }
+
+    // copy out neutral hadrons
+    std::vector<PFNeutralObj> outne_all(cfg.nCALO);
+    for (unsigned int ipf = 0; ipf < cfg.nCALO; ++ipf) { clear(outne_all[ipf]); }
+    for (unsigned int ic = 0; ic < cfg.nCALO; ++ic) {
+        if (calo_subpt[ic] > 0) {
+            outne_all[ic].hwPt  = calo_subpt[ic];
+            outne_all[ic].hwEta = hadcalo_subem[ic].hwEta;
+            outne_all[ic].hwPhi = hadcalo_subem[ic].hwPhi;
+            outne_all[ic].hwId  = PID_Neutral;
+        }
+    }
+
+    ptsort_ref(cfg.nCALO, cfg.nSELCALO, outne_all, outne);
+
+    if (g_pfalgo3_debug_ref_) {
+#ifdef L1Trigger_Phase2L1ParticleFlow_DiscretePFInputs_MORE
+        std::vector<l1tpf_impl::PFParticle> tmp;
+        for (unsigned int i = 0; i < cfg.nTRACK; ++i) { if (outch[i].hwPt == 0) continue;
+            fw2dpf::convert(outch[i], track[i], tmp); auto & pf = tmp.back();
+            printf("FW  \t outch %3d: pt %8d [ %7.2f ]  calo eta %+7d [ %+5.2f ]  calo phi %+7d [ %+5.2f ]  pid %d\n", 
+                                i, pf.hwPt, pf.floatPt(), pf.hwEta, pf.floatEta(), pf.hwPhi, pf.floatPhi(), pf.hwId);
+        }
+        for (unsigned int i = 0; i < cfg.nPHOTON; ++i) { if (outpho[i].hwPt == 0) continue;
+            fw2dpf::convert(outpho[i], tmp); auto & pf = tmp.back();
+            printf("FW  \t outph %3d: pt %8d [ %7.2f ]  calo eta %+7d [ %+5.2f ]  calo phi %+7d [ %+5.2f ]  pid %d\n", 
+                                i, pf.hwPt, pf.floatPt(), pf.hwEta, pf.floatEta(), pf.hwPhi, pf.floatPhi(), pf.hwId);
+        }
+        for (unsigned int i = 0; i < cfg.nSELCALO; ++i) { if (outne[i].hwPt == 0) continue;
+            fw2dpf::convert(outne[i], tmp); auto & pf = tmp.back();
+            printf("FW  \t outne %3d: pt %8d [ %7.2f ]  calo eta %+7d [ %+5.2f ]  calo phi %+7d [ %+5.2f ]  pid %d\n", 
+                                i, pf.hwPt, pf.floatPt(), pf.hwEta, pf.floatEta(), pf.hwPhi, pf.floatPhi(), pf.hwId);
+        }
+#endif
+    }
+
+
+}
+
+void pfalgo3_merge_neutrals_ref(const pfalgo3_config &cfg, const PFNeutralObj pho[/*cfg.nPHOTON*/], const PFNeutralObj ne[/*cfg.nSELCALO*/], PFNeutralObj allne[/*cfg.nALLNEUTRALS*/]) 
+{
+    int j = 0;
+    for (unsigned int i = 0; i < cfg.nPHOTON;  ++i, ++j) allne[j] = pho[i];
+    for (unsigned int i = 0; i < cfg.nSELCALO; ++i, ++j) allne[j] = ne[i];
+}
+

--- a/L1Trigger/Phase2L1ParticleFlow/src/ref/pfalgo3_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/ref/pfalgo3_ref.h
@@ -1,0 +1,27 @@
+#ifndef PFALGO3_REF_H
+#define PFALGO3_REF_H
+
+#include "../firmware/pfalgo3.h"
+#include "pfalgo_common_ref.h"
+
+struct pfalgo3_config : public pfalgo_config {
+    unsigned int nEMCALO, nPHOTON, nALLNEUTRAL;
+    unsigned int dR2MAX_TK_EM;
+    unsigned int dR2MAX_EM_CALO;
+
+    pfalgo3_config(unsigned int nTrack, unsigned int nEmCalo, unsigned int nCalo, unsigned int nMu, 
+                   unsigned int nPhoton, unsigned int nSelCalo, unsigned int nAllNeutral, 
+                   unsigned int dR2Max_Tk_Mu, unsigned int dR2Max_Tk_Em, unsigned int dR2Max_Em_Calo, unsigned int dR2Max_Tk_Calo,
+                   unsigned int tk_MaxInvPt_Loose, unsigned int tk_MaxInvPt_Tight): 
+        pfalgo_config(nTrack, nCalo, nMu, nSelCalo, dR2Max_Tk_Mu, dR2Max_Tk_Calo, tk_MaxInvPt_Loose, tk_MaxInvPt_Tight),
+        nEMCALO(nEmCalo), nPHOTON(nPhoton), nALLNEUTRAL(nAllNeutral), dR2MAX_TK_EM(dR2Max_Tk_Em), dR2MAX_EM_CALO(dR2Max_Em_Calo) {}
+};
+
+
+void pfalgo3_ref_set_debug(int debug) ;
+
+void pfalgo3_em_ref(const pfalgo3_config &cfg, const EmCaloObj emcalo[/*cfg.nEMCALO*/], const HadCaloObj hadcalo[/*cfg.nCALO*/], const TkObj track[/*cfg.nTRACK*/], const bool isMu[/*cfg.nTRACK*/], bool isEle[/*cfg.nTRACK*/], PFNeutralObj outpho[/*cfg.nPHOTON*/], HadCaloObj hadcalo_out[/*cfg.nCALO*/]) ;
+void pfalgo3_ref(const pfalgo3_config &cfg, const EmCaloObj emcalo[/*cfg.nEMCALO*/], const HadCaloObj hadcalo[/*cfg.nCALO*/], const TkObj track[/*cfg.nTRACK*/], const MuObj mu[/*cfg.nMU*/], PFChargedObj outch[/*cfg.nTRACK*/], PFNeutralObj outpho[/*cfg.nPHOTON*/], PFNeutralObj outne[/*cfg.nSELCALO*/], PFChargedObj outmu[/*cfg.nMU*/]) ;
+
+void pfalgo3_merge_neutrals_ref(const pfalgo3_config &cfg, const PFNeutralObj pho[/*cfg.nPHOTON*/], const PFNeutralObj ne[/*cfg.nSELCALO*/], PFNeutralObj allne[/*cfg.nALLNEUTRALS*/]);
+#endif

--- a/L1Trigger/Phase2L1ParticleFlow/src/ref/pfalgo_common_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/ref/pfalgo_common_ref.cpp
@@ -1,0 +1,40 @@
+#include "pfalgo_common_ref.h"
+
+#include <cmath>
+#include <cstdio>
+
+void pfalgo_mu_ref(const pfalgo_config &cfg, const TkObj track[/*cfg.nTRACK*/], const MuObj mu[/*cfg.nMU*/], bool isMu[/*cfg.nTRACK*/], PFChargedObj outmu[/*cfg.nMU*/], bool debug) {
+
+    // init
+    for (unsigned int ipf = 0; ipf < cfg.nMU; ++ipf) clear(outmu[ipf]);
+    for (unsigned int it = 0; it < cfg.nTRACK; ++it) isMu[it] = 0;
+
+        // for each muon, find the closest track
+    for (unsigned int im = 0; im < cfg.nMU; ++im) {
+        if (mu[im].hwPt > 0) {
+            int ibest = -1;
+            int dptmin = mu[im].hwPt >> 1;
+            for (unsigned int it = 0; it < cfg.nTRACK; ++it) {
+                unsigned int dr = dr2_int(mu[im].hwEta, mu[im].hwPhi, track[it].hwEta, track[it].hwPhi);
+                //printf("deltaR2(mu %d float pt %5.1f, tk %2d float pt %5.1f) = int %d  (float deltaR = %.3f); int cut at %d\n", im, 0.25*int(mu[im].hwPt), it, 0.25*int(track[it].hwPt), dr, std::sqrt(float(dr))/229.2, cfg.dR2MAX_TK_MU);
+                if (dr < cfg.dR2MAX_TK_MU) { 
+                    int dpt = std::abs(int(track[it].hwPt - mu[im].hwPt));
+                    if (dpt < dptmin) {
+                        dptmin = dpt; ibest = it; 
+                    }
+                }
+            }
+            if (ibest != -1) {
+                outmu[im].hwPt = track[ibest].hwPt;
+                outmu[im].hwEta = track[ibest].hwEta;
+                outmu[im].hwPhi = track[ibest].hwPhi;
+                outmu[im].hwId  = PID_Muon;
+                outmu[im].hwZ0 = track[ibest].hwZ0;      
+                isMu[ibest] = 1;
+                if (debug) printf("FW  \t muon %3d linked to track %3d \n", im, ibest);
+            } else {
+                if (debug) printf("FW  \t muon %3d not linked to any track\n", im);
+            }
+        }
+    }
+}

--- a/L1Trigger/Phase2L1ParticleFlow/src/ref/pfalgo_common_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/ref/pfalgo_common_ref.h
@@ -1,0 +1,67 @@
+#ifndef PFALGO_COMMON_REF_H
+#define PFALGO_COMMON_REF_H
+
+#include "../firmware/data.h"
+#include "../firmware/pfalgo_common.h"
+#include <algorithm>
+
+template <typename T> inline int sqr(const T & t) { return t*t; }
+
+template<typename CO_t>
+int best_match_with_pt_ref(int nCAL, int dR2MAX, const CO_t calo[/*nCAL*/], const TkObj & track) ;
+ 
+template<typename T>
+void ptsort_ref(int nIn, int nOut, const T in[/*nIn*/], T out[/*nOut*/]) ;
+
+struct pfalgo_config {
+    unsigned int nTRACK, nCALO, nMU;
+    unsigned int nSELCALO;
+    unsigned int dR2MAX_TK_MU;
+    unsigned int dR2MAX_TK_CALO;
+    unsigned int tk_MAXINVPT_LOOSE, tk_MAXINVPT_TIGHT;
+
+    pfalgo_config(unsigned int nTrack, unsigned int nCalo, unsigned int nMu, unsigned int nSelCalo, 
+                  unsigned int dR2Max_Tk_Mu, unsigned int dR2Max_Tk_Calo, 
+                  unsigned int tk_MaxInvPt_Loose, unsigned int tk_MaxInvPt_Tight) :
+        nTRACK(nTrack), nCALO(nCalo), nMU(nMu), nSELCALO(nSelCalo), dR2MAX_TK_MU(dR2Max_Tk_Mu), dR2MAX_TK_CALO(dR2Max_Tk_Calo), tk_MAXINVPT_LOOSE(tk_MaxInvPt_Loose), tk_MAXINVPT_TIGHT(tk_MaxInvPt_Tight) {}
+};
+
+void pfalgo_mu_ref(const pfalgo_config &cfg, const TkObj track[/*cfg.nTRACK*/], const MuObj mu[/*cfg.nMU*/], bool isMu[/*cfg.nTRACK*/], PFChargedObj outmu[/*cfg.nMU*/], bool debug) ;
+
+//=== begin implementation part
+
+template<typename CO_t>
+int best_match_with_pt_ref(int nCAL, int dR2MAX, const CO_t calo[/*nCAL*/], const TkObj & track) {
+    pt_t caloPtMin = track.hwPt - 2*(track.hwPtErr);
+    if (caloPtMin < 0) caloPtMin = 0;
+    int dptscale = (dR2MAX<<8)/std::max<int>(1,sqr(track.hwPtErr));
+    int drmin = 0, ibest = -1;
+    for (int ic = 0; ic < nCAL; ++ic) {
+            if (calo[ic].hwPt <= caloPtMin) continue;
+            int dr = dr2_int(track.hwEta, track.hwPhi, calo[ic].hwEta, calo[ic].hwPhi);
+            if (dr >= dR2MAX) continue;
+            dr += (( sqr(std::max<int>(track.hwPt-calo[ic].hwPt,0))*dptscale ) >> 8);
+            if (ibest == -1 || dr < drmin) { drmin = dr; ibest = ic; }
+    }
+    return ibest;
+}
+
+template<typename T, typename TV>
+void ptsort_ref(int nIn, int nOut, const TV & in/*[nIn]*/, T out[/*nOut*/]) {
+    for (int iout = 0; iout < nOut; ++iout) {
+        out[iout].hwPt = 0;
+    }
+    for (int it = 0; it < nIn; ++it) {
+        for (int iout = 0; iout < nOut; ++iout) {
+            if (in[it].hwPt >= out[iout].hwPt) {
+                for (int i2 = nOut-1; i2 > iout; --i2) {
+                    out[i2] = out[i2-1];
+                }
+                out[iout] = in[it];
+                break;
+            }
+        }
+    }
+}
+
+#endif

--- a/L1Trigger/Phase2L1ParticleFlow/src/utils/DiscretePF2Firmware.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/utils/DiscretePF2Firmware.h
@@ -1,0 +1,69 @@
+#ifndef FASTPUPPI_NTUPLERPRODUCER_DISCRETEPF2FIRMWARE_H
+#define FASTPUPPI_NTUPLERPRODUCER_DISCRETEPF2FIRMWARE_H
+
+/// NOTE: this include is not standalone, since the path to DiscretePFInputs is different in CMSSW & Vivado_HLS
+
+#include "../firmware/data.h"
+#include <vector>
+
+namespace dpf2fw {
+
+    // convert inputs from discrete to firmware
+    void convert(const l1tpf_impl::PropagatedTrack & in, TkObj &out) {
+        out.hwPt = in.hwPt;
+        out.hwPtErr = in.hwCaloPtErr;
+        out.hwEta = in.hwEta; // @calo
+        out.hwPhi = in.hwPhi; // @calo
+        out.hwZ0 = in.hwZ0;
+        out.hwTightQuality = (in.hwStubs >= 6 && in.hwChi2 < 500);
+    }
+
+    TkObj transformConvert(const l1tpf_impl::PropagatedTrack & in) {
+        TkObj out;
+        convert(in, out);
+        return out;
+    }
+
+    void convert(const l1tpf_impl::CaloCluster & in, HadCaloObj & out) {
+        out.hwPt = in.hwPt;
+        out.hwEmPt = in.hwEmPt;
+        out.hwEta = in.hwEta;
+        out.hwPhi = in.hwPhi;
+        out.hwIsEM = in.isEM;
+    }
+    void convert(const l1tpf_impl::CaloCluster & in, EmCaloObj & out) {
+        out.hwPt = in.hwPt;
+        out.hwPtErr = in.hwPtErr;
+        out.hwEta = in.hwEta;
+        out.hwPhi = in.hwPhi;
+    }
+    void convert(const l1tpf_impl::Muon & in, MuObj & out) {
+        out.hwPt = in.hwPt;
+        out.hwPtErr = 0; // does not exist in input
+        out.hwEta = in.hwEta; // @calo
+        out.hwPhi = in.hwPhi; // @calo
+    }
+
+    template<unsigned int NMAX, typename In, typename Out>
+    void convert(const std::vector<In> & in, Out out[NMAX]) {
+        for (unsigned int i = 0, n = std::min<unsigned int>(NMAX, in.size()); i < n; ++i) {
+            convert(in[i], out[i]);
+        }
+        for (unsigned int i = in.size(); i < NMAX; ++i) {
+            clear(out[i]);
+        }
+    }
+
+    template<typename In, typename Out>
+    void convert(unsigned int NMAX, const std::vector<In> & in, Out out[]) {
+        for (unsigned int i = 0, n = std::min<unsigned int>(NMAX, in.size()); i < n; ++i) {
+            convert(in[i], out[i]);
+        }
+        for (unsigned int i = in.size(); i < NMAX; ++i) {
+            clear(out[i]);
+        }
+    }
+
+} // namespace
+
+#endif

--- a/L1Trigger/Phase2L1ParticleFlow/src/utils/Firmware2DiscretePF.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/utils/Firmware2DiscretePF.h
@@ -1,0 +1,137 @@
+#ifndef FASTPUPPI_NTUPLERPRODUCER_FIRMWARE2DISCRETEPF_H
+#define FASTPUPPI_NTUPLERPRODUCER_FIRMWARE2DISCRETEPF_H
+
+/// NOTE: this include is not standalone, since the path to DiscretePFInputs is different in CMSSW & Vivado_HLS
+
+#include "../firmware/data.h"
+#include <vector>
+#include <cassert>
+
+namespace fw2dpf {
+
+    // convert inputs from discrete to firmware
+    inline void convert(const PFChargedObj & src, const l1tpf_impl::PropagatedTrack & track, std::vector<l1tpf_impl::PFParticle> &out) {
+        l1tpf_impl::PFParticle pf;
+        pf.hwPt = src.hwPt;
+        pf.hwEta = src.hwEta;
+        pf.hwPhi = src.hwPhi;
+        pf.hwVtxEta = src.hwEta; // FIXME: get from the track
+        pf.hwVtxPhi = src.hwPhi; // before propagation
+        pf.track = track; // FIXME: ok only as long as there is a 1-1 mapping
+        pf.cluster.hwPt = 0;
+        pf.cluster.src = nullptr;
+        pf.muonsrc = nullptr;
+        switch(src.hwId) {
+            case PID_Electron: pf.hwId =  1; break;
+            case PID_Muon: pf.hwId =  4; break;
+            default: pf.hwId = 0; break;
+        };
+        pf.hwStatus = 0;
+        out.push_back(pf);
+    }
+    // convert inputs from discrete to firmware
+    inline void convert(const TkObj & in, l1tpf_impl::PropagatedTrack & out) ;
+    inline void convert(const PFChargedObj & src, const TkObj & track, std::vector<l1tpf_impl::PFParticle> &out) {
+        l1tpf_impl::PFParticle pf;
+        pf.hwPt = src.hwPt;
+        pf.hwEta = src.hwEta;
+        pf.hwPhi = src.hwPhi;
+        pf.hwVtxEta = src.hwEta; // FIXME: get from the track
+        pf.hwVtxPhi = src.hwPhi; // before propagation
+        convert(track, pf.track); // FIXME: ok only as long as there is a 1-1 mapping
+        pf.cluster.hwPt = 0;
+        pf.cluster.src = nullptr;
+        pf.muonsrc = nullptr;
+        switch(src.hwId) {
+            case PID_Electron: pf.hwId =  1; break;
+            case PID_Muon: pf.hwId =  4; break;
+            default: pf.hwId = 0; break;
+        };
+        pf.hwStatus = 0;
+        out.push_back(pf);
+    }
+    inline void convert(const PFNeutralObj & src, std::vector<l1tpf_impl::PFParticle> &out) {
+        l1tpf_impl::PFParticle pf;
+        pf.hwPt = src.hwPt;
+        pf.hwEta = src.hwEta;
+        pf.hwPhi = src.hwPhi;
+        pf.hwVtxEta = src.hwEta;
+        pf.hwVtxPhi = src.hwPhi;
+        pf.track.hwPt = 0;
+        pf.track.src = nullptr;
+        pf.cluster.hwPt = src.hwPt;
+        pf.cluster.src = nullptr;
+        pf.muonsrc = nullptr;
+        switch(src.hwId) {
+            case PID_Photon: pf.hwId = 3; break;
+            default: pf.hwId = 2; break;
+        }
+        pf.hwStatus = 0;
+        out.push_back(pf);
+    }
+
+    // convert inputs from discrete to firmware
+    inline void convert(const TkObj & in, l1tpf_impl::PropagatedTrack & out) {
+        out.hwPt = in.hwPt;
+        out.hwCaloPtErr = in.hwPtErr;
+        out.hwEta = in.hwEta; // @calo
+        out.hwPhi = in.hwPhi; // @calo
+        out.hwZ0 = in.hwZ0;
+        out.src = nullptr;
+    }
+    inline void convert(const HadCaloObj & in, l1tpf_impl::CaloCluster & out) {
+        out.hwPt = in.hwPt;
+        out.hwEmPt = in.hwEmPt;
+        out.hwEta = in.hwEta;
+        out.hwPhi = in.hwPhi;
+        out.isEM = in.hwIsEM;
+        out.src = nullptr;
+    }
+    inline void convert(const EmCaloObj & in, l1tpf_impl::CaloCluster & out) {
+        out.hwPt = in.hwPt;
+        out.hwPtErr = in.hwPtErr;
+        out.hwEta = in.hwEta;
+        out.hwPhi = in.hwPhi;
+        out.src = nullptr;
+    }
+    inline void convert(const MuObj & in, l1tpf_impl::Muon & out) {
+        out.hwPt = in.hwPt;
+        out.hwEta = in.hwEta; // @calo
+        out.hwPhi = in.hwPhi; // @calo
+        out.src = nullptr;
+    }
+
+
+    template<unsigned int NMAX, typename In>
+    void convert(const In in[NMAX], std::vector<l1tpf_impl::PFParticle> &out) {
+        for (unsigned int i = 0; i < NMAX; ++i) {
+            if (in[i].hwPt > 0) convert(in[i], out);
+        }
+    } 
+    template<typename In>
+    void convert(unsigned int NMAX, const In in[], std::vector<l1tpf_impl::PFParticle> &out) {
+        for (unsigned int i = 0; i < NMAX; ++i) {
+            if (in[i].hwPt > 0) convert(in[i], out);
+        }
+    } 
+    template<unsigned int NMAX>
+    void convert(const PFChargedObj in[NMAX], std::vector<l1tpf_impl::PropagatedTrack> srctracks, std::vector<l1tpf_impl::PFParticle> &out) {
+        for (unsigned int i = 0; i < NMAX; ++i) {
+            if (in[i].hwPt > 0) {
+                assert(i < srctracks.size());
+                convert(in[i], srctracks[i], out);
+            }
+        }
+    }
+    inline void convert(unsigned int NMAX, const PFChargedObj in[], std::vector<l1tpf_impl::PropagatedTrack> srctracks, std::vector<l1tpf_impl::PFParticle> &out) {
+        for (unsigned int i = 0; i < NMAX; ++i) {
+            if (in[i].hwPt > 0) {
+                assert(i < srctracks.size());
+                convert(in[i], srctracks[i], out);
+            }
+        }
+    }
+ 
+} // namespace
+
+#endif


### PR DESCRIPTION
Support for running the HLS PF algorithm in CMSSW.

See also https://github.com/p2l1pfp/GlobalCorrelator_HLS/pull/29 and https://indico.cern.ch/event/878544/

A PR for FastPUPPI will also be provided soon, in the meantime the configuration for the algorithms is
````
    process.l1pfProducerBitwiseBarrel = process.l1pfProducerRegionalBarrel.clone(
            pfAlgo = "BitwisePFAlgo",
            bitwiseAlgo = cms.string("pfalgo3"),
            bitwiseConfig = cms.PSet(
                NTRACK = cms.uint32(99),
                NEMCALO = cms.uint32(99),
                NCALO = cms.uint32(99),
                NMU = cms.uint32(9),
                NPHOTON = cms.uint32(99),
                NSELCALO = cms.uint32(99),
                NALLNEUTRAL = cms.uint32(199),
                DR2MAX_TK_MU = cms.uint32(2101),
                DR2MAX_TK_EM = cms.uint32(84),
                DR2MAX_EM_CALO = cms.uint32(525),
                DR2MAX_TK_CALO = cms.uint32(1182),
                TK_MAXINVPT_LOOSE = cms.uint32(40),
                TK_MAXINVPT_TIGHT = cms.uint32(80),
            ))
    process.l1pfProducerBitwiseHGCal = process.l1pfProducerRegionalHGCal.clone(
            pfAlgo = "BitwisePFAlgo",
            bitwiseAlgo = cms.string("pfalgo2hgc"),
            bitwiseConfig = cms.PSet(
                NTRACK = cms.uint32(99),
                NCALO = cms.uint32(99),
                NMU = cms.uint32(9),
                NSELCALO = cms.uint32(99),
                DR2MAX_TK_MU = cms.uint32(2101),
                DR2MAX_TK_CALO = cms.uint32(525),
                TK_MAXINVPT_LOOSE = cms.uint32(40),
                TK_MAXINVPT_TIGHT = cms.uint32(80),
            ))
````
and the parameter changes in order to get the CMSSW PF algo to best match the HLS one are
````
    process.l1pfProducerBarrel.linking.ecalPriority = False
    process.l1pfProducerBarrel.linking.trackEmMayUseCaloMomenta = False 
    process.l1pfProducerBarrel.linking.emCaloUseAlsoCaloSigma = False 
    process.l1pfProducerBarrel.linking.emCaloSubtractionPtSlope = 1.0 
    for det in "Barrel", "HGCal", "HGCalNoTK", "HF":
        l1pf = getattr(process, 'l1pfProducer'+det)
        l1pf.linking.trackMuMatch = "drBestByPtDiff" 
        l1pf.linking.trackCaloLinkMetric = "bestByDR2Pt2" 
 ````
