### PR TITLE
Bitwise puppi

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/interface/BitwisePuppiAlgo.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/BitwisePuppiAlgo.h
@@ -1,0 +1,28 @@
+#ifndef L1Trigger_Phase2L1ParticleFlow_BitwisePuppiAlgo_h
+#define L1Trigger_Phase2L1ParticleFlow_BitwisePuppiAlgo_h
+
+#include "L1Trigger/Phase2L1ParticleFlow/interface/PUAlgoBase.h"
+
+struct linpuppi_config;
+
+namespace l1tpf_impl { 
+
+  class BitwisePuppiAlgo : public PUAlgoBase {
+    public:
+        BitwisePuppiAlgo( const edm::ParameterSet& ) ;
+        virtual ~BitwisePuppiAlgo() ;
+
+        const std::vector<std::string> & puGlobalNames() const override ;
+        void doPUGlobals(const std::vector<Region> &rs, float z0, float npu, std::vector<float> & globals) const override ;
+        void runChargedPV(Region &r, float z0) const override ;
+        void runNeutralsPU(Region &r, float z0, float npu, const std::vector<float> & globals) const override ;
+
+    private:
+        enum AlgoChoice { linpuppi_algo, linpuppi_flt_algo, fwdlinpuppi_algo, fwdlinpuppi_flt_algo } algo_;
+        std::vector<linpuppi_config *> configs_; 
+        bool debug_;      
+  };
+
+} // end namespace
+
+#endif

--- a/L1Trigger/Phase2L1ParticleFlow/interface/LinearizedPuppiAlgo.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/LinearizedPuppiAlgo.h
@@ -11,8 +11,8 @@ namespace l1tpf_impl {
         virtual ~LinearizedPuppiAlgo() ;
 
         const std::vector<std::string> & puGlobalNames() const override ;
-        void doPUGlobals(const std::vector<Region> &rs, float npu, std::vector<float> & globals) const override ;
-        void runNeutralsPU(Region &r, float npu, const std::vector<float> & globals) const override ;
+        void doPUGlobals(const std::vector<Region> &rs, float z0, float npu, std::vector<float> & globals) const override ;
+        void runNeutralsPU(Region &r, float z0, float npu, const std::vector<float> & globals) const override ;
 
     protected:
         void computePuppiWeights(Region &r, float npu, const std::vector<float> & alphaC, const std::vector<float> & alphaF) const ;

--- a/L1Trigger/Phase2L1ParticleFlow/interface/PUAlgoBase.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/PUAlgoBase.h
@@ -18,8 +18,8 @@ namespace l1tpf_impl {
         virtual void runChargedPV(Region &r, float z0) const ;
         
         virtual const std::vector<std::string> & puGlobalNames() const ;
-        virtual void doPUGlobals(const std::vector<Region> &rs, float npu, std::vector<float> & globals) const = 0;
-        virtual void runNeutralsPU(Region &r, float npu, const std::vector<float> & globals) const = 0;
+        virtual void doPUGlobals(const std::vector<Region> &rs, float z0, float npu, std::vector<float> & globals) const = 0;
+        virtual void runNeutralsPU(Region &r, float z0, float npu, const std::vector<float> & globals) const = 0;
 
     protected:
         int debug_;

--- a/L1Trigger/Phase2L1ParticleFlow/interface/PuppiAlgo.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/PuppiAlgo.h
@@ -11,8 +11,8 @@ namespace l1tpf_impl {
         virtual ~PuppiAlgo() ;
 
         const std::vector<std::string> & puGlobalNames() const override ;
-        void doPUGlobals(const std::vector<Region> &rs, float npu, std::vector<float> & globals) const override ;
-        void runNeutralsPU(Region &r, float npu, const std::vector<float> & globals) const override ;
+        void doPUGlobals(const std::vector<Region> &rs, float z0, float npu, std::vector<float> & globals) const override ;
+        void runNeutralsPU(Region &r, float z0, float npu, const std::vector<float> & globals) const override ;
 
     protected:
         virtual void computePuppiMedRMS(const std::vector<Region> &rs, float &alphaCMed, float &alphaCRms, float &alphaFMed, float &alphaFRms) const ;

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TPFProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TPFProducer.cc
@@ -328,7 +328,7 @@ L1TPFProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
     // Then get our alphas (globally)
     std::vector<float> puGlobals;
-    l1pualgo_->doPUGlobals(l1regions_.regions(), -1., puGlobals); // FIXME we don't have yet an external PU estimate
+    l1pualgo_->doPUGlobals(l1regions_.regions(), z0, -1., puGlobals); // FIXME we don't have yet an external PU estimate
     const std::vector<std::string> & puGlobalNames = l1pualgo_->puGlobalNames();
     assert(puGlobals.size() == puGlobalNames.size());
     for (unsigned int i = 0, n = puGlobalNames.size(); i < n; ++i) {
@@ -340,7 +340,7 @@ L1TPFProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
     // Then run puppi (regionally)
     for (auto & l1region : l1regions_.regions()) {
-        l1pualgo_->runNeutralsPU(l1region, -1., puGlobals);
+        l1pualgo_->runNeutralsPU(l1region, z0, -1., puGlobals);
     }
     // and save puppi
     iEvent.put(l1regions_.fetch(true), "Puppi");

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TPFProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TPFProducer.cc
@@ -25,6 +25,7 @@
 #include "L1Trigger/Phase2L1ParticleFlow/interface/BitwisePFAlgo.h"
 #include "L1Trigger/Phase2L1ParticleFlow/interface/PuppiAlgo.h"
 #include "L1Trigger/Phase2L1ParticleFlow/interface/LinearizedPuppiAlgo.h"
+#include "L1Trigger/Phase2L1ParticleFlow/interface/BitwisePuppiAlgo.h"
 #include "L1Trigger/Phase2L1ParticleFlow/interface/DiscretePFInputsIO.h"
 #include "L1Trigger/Phase2L1ParticleFlow/interface/COEFile.h"
 
@@ -136,6 +137,8 @@ L1TPFProducer::L1TPFProducer(const edm::ParameterSet& iConfig):
         l1pualgo_.reset(new l1tpf_impl::PuppiAlgo(iConfig));
     } else if (pualgo == "LinearizedPuppi") {
         l1pualgo_.reset(new l1tpf_impl::LinearizedPuppiAlgo(iConfig));
+    } else if (pualgo == "BitwisePuppiAlgo") {
+        l1pualgo_.reset(new l1tpf_impl::BitwisePuppiAlgo(iConfig));
     } else throw cms::Exception("Configuration", "Unsupported PUAlgo");
 
     std::string vtxAlgo = iConfig.getParameter<std::string>("vtxAlgo");

--- a/L1Trigger/Phase2L1ParticleFlow/src/BitwisePuppiAlgo.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/BitwisePuppiAlgo.cc
@@ -1,0 +1,220 @@
+#include "L1Trigger/Phase2L1ParticleFlow/interface/BitwisePuppiAlgo.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include "ref/linpuppi_ref.h"
+int dr2_int(etaphi_t eta1, etaphi_t phi1, etaphi_t eta2, etaphi_t phi2) {
+    ap_int<etaphi_t::width+1> deta = (eta1-eta2);
+    ap_int<etaphi_t::width+1> dphi = (phi1-phi2);
+    return deta*deta + dphi*dphi;
+}
+
+
+#include "utils/DiscretePF2Firmware.h"
+#include "utils/Firmware2DiscretePF.h"
+
+
+namespace { 
+    std::vector<float> getvf(const edm::ParameterSet & iConfig , const std::string & name) {
+        const std::vector<double> & vd = iConfig.getParameter<std::vector<double>>(name);
+        std::vector<float> ret;
+        ret.insert(ret.end(), vd.begin(), vd.end());
+        return ret;
+    }
+    std::vector<int> getvi(const edm::ParameterSet & iConfig , const std::string & name) {
+        const std::vector<int32_t> & vd = iConfig.getParameter<std::vector<int32_t>>(name);
+        std::vector<int> ret;
+        ret.insert(ret.end(), vd.begin(), vd.end());
+        return ret;
+    }
+    std::vector<unsigned int> getvu(const edm::ParameterSet & iConfig , const std::string & name) {
+        const std::vector<uint32_t> & vd = iConfig.getParameter<std::vector<uint32_t>>(name);
+        std::vector<unsigned int> ret;
+        ret.insert(ret.end(), vd.begin(), vd.end());
+        return ret;
+    }
+
+}
+
+using namespace l1tpf_impl;
+
+BitwisePuppiAlgo::BitwisePuppiAlgo( const edm::ParameterSet & iConfig ) :
+    PUAlgoBase(iConfig), 
+    configs_(),
+    debug_(iConfig.getUntrackedParameter<int>("puppiDebug", debug_))
+{
+    const std::string & algo = iConfig.getParameter<std::string>("bitwisePUAlgo");
+    if (algo == "linpuppi") algo_ = linpuppi_algo;
+    else if (algo == "linpuppi_flt") algo_ = linpuppi_flt_algo;
+    else if (algo == "fwdlinpuppi") algo_ = fwdlinpuppi_algo;
+    else if (algo == "fwdlinpuppi_flt") algo_ = fwdlinpuppi_flt_algo;
+    else throw cms::Exception("Configuration", "Unsupported bitwisePUAlgo "+algo);
+    const edm::ParameterSet & pset = iConfig.getParameter<edm::ParameterSet>("bitwisePUConfig");
+    for (int inv = 0; inv <= 1; ++inv) {
+        configs_.push_back(new linpuppi_config( 
+                    pset.getParameter<uint32_t>("nTrack"), pset.getParameter<uint32_t>("nIn"), pset.getParameter<uint32_t>("nOut"),
+                    pset.getParameter<uint32_t>("dR2Min"), pset.getParameter<uint32_t>("dR2Max"), pset.getParameter<uint32_t>("ptMax"), pset.getParameter<uint32_t>("dzCut"),
+                    getvi(pset, "absEtaBins"), inv,
+                    getvf(pset, "ptSlopeNe"), getvf(pset, "ptSlopePh"), getvf(pset, "ptZeroNe"), getvf(pset, "ptZeroPh"), 
+                    getvf(pset, "alphaSlope"), getvf(pset, "alphaZero"), getvf(pset, "alphaCrop"), 
+                    getvf(pset, "priorNe"), getvf(pset, "priorPh"),
+                    getvu(pset, "ptCut")));
+        const auto cfg = configs_.back();
+        unsigned int neta = cfg->absEtaBins.size()+1;
+        if (cfg->ptSlopeNe.size() != neta || cfg->ptSlopePh.size() != neta || 
+                cfg->ptZeroNe.size() != neta || cfg->ptZeroPh.size() != neta ||
+                cfg->alphaSlope.size() != neta || cfg->alphaZero.size() != neta || cfg->alphaCrop.size() != neta ||
+                cfg->priorNe.size() != neta || cfg->priorPh.size() != neta || 
+                cfg->ptCut.size() != neta) {
+            throw cms::Exception("Configuration", "Mismatch in parameter vector sizes");
+        }
+        if (configs_.back()->absEtaBins.empty()) break; // no bins, no need to worry about inverting eta
+    }
+}
+
+BitwisePuppiAlgo::~BitwisePuppiAlgo() {
+    for (auto & p : configs_) { delete p; }
+    configs_.clear();
+}
+
+
+const std::vector<std::string> & BitwisePuppiAlgo::puGlobalNames() const {
+    static const std::vector<std::string> names_;
+    return names_;
+
+}
+void BitwisePuppiAlgo::doPUGlobals(const std::vector<Region> &rs, float z0, float npu, std::vector<float> & globals) const {
+}
+
+void BitwisePuppiAlgo::runChargedPV(Region &r, float z0) const {
+    if (algo_ == fwdlinpuppi_algo || algo_ == fwdlinpuppi_flt_algo) {
+        return;
+    }
+
+    const linpuppi_config *cfg = configs_[0];
+    if (!cfg->absEtaBins.empty() && r.etaCenter < 0) cfg = configs_[1];
+
+    std::unique_ptr<PFChargedObj[]> in(new PFChargedObj[cfg->nTrack]), out(new PFChargedObj[cfg->nTrack]);
+    std::vector<unsigned int> indices; 
+    for (unsigned int i = 0, n = r.pf.size(), nin = 0; i < n; ++i) {
+        if (r.pf[i].hwId <= 1 || r.pf[i].hwId == 4) {
+            r.pf[i].hwPuppiWeight = 0; // init
+            if (nin < cfg->nTrack) {
+                indices.push_back(i);
+                dpf2fw::convert(r.pf[i], in[nin]);
+                nin++;
+            }
+        }
+    }
+    for (unsigned int i = indices.size(); i < cfg->nTrack; ++i) {
+        clear(out[i]);
+    }
+
+    z0_t hwZ0 = int(std::round(z0 / l1tpf_impl::InputTrack::Z0_SCALE));
+
+    linpuppi_chs_ref(*cfg, hwZ0, in.get(), out.get());
+
+    for (unsigned int i = 0, n = indices.size(); i < n; ++i) {
+        unsigned int ipf = indices[i];
+        if (out[i].hwPt > 0) {
+            r.pf[ipf].setPuppiW(1.0f);
+            r.puppi.push_back(r.pf[ipf]);
+            r.puppi.back().hwPt = int(out[i].hwPt);
+        }
+    }
+}
+
+void BitwisePuppiAlgo::runNeutralsPU(Region &r, float z0, float npu, const std::vector<float> & globals) const {
+    const linpuppi_config *cfg = configs_[0];
+    //if (!cfg->absEtaBins.empty() && r.etaCenter < 0) std::cout << "Using config with inverted eta for region with eta center " << r.etaCenter << std::endl;
+    if (!cfg->absEtaBins.empty() && r.etaCenter < 0) cfg = configs_[1];
+   
+    std::unique_ptr<PFNeutralObj[]> outallne_nocut(new PFNeutralObj[cfg->nIn]);
+    std::unique_ptr<PFNeutralObj[]> outallne(new PFNeutralObj[cfg->nIn]);
+    std::unique_ptr<PFNeutralObj[]> outselne(new PFNeutralObj[cfg->nOut]);
+    if (algo_ == linpuppi_algo || algo_ == linpuppi_flt_algo) {
+        std::unique_ptr<TkObj[]> track(new TkObj[cfg->nTrack]);
+        dpf2fw::convert(cfg->nTrack, r.track, track.get());
+
+        z0_t hwZ0 = int(std::round(z0 / l1tpf_impl::InputTrack::Z0_SCALE));
+        std::unique_ptr<PFNeutralObj[]> in(new PFNeutralObj[cfg->nIn]);
+        
+        std::vector<unsigned int> indices; 
+        for (unsigned int i = 0, n = r.pf.size(), nin = 0; i < n; ++i) {
+            if (r.pf[i].hwId == 2 || r.pf[i].hwId == 3) {
+                r.pf[i].hwPuppiWeight = 0; // init
+                if (nin < cfg->nIn) {
+                    indices.push_back(i);
+                    dpf2fw::convert(r.pf[i], in[nin]);
+                    nin++;
+                }
+            }
+        }
+        for (unsigned int i = indices.size(); i < cfg->nIn; ++i) {
+            clear(in[i]);
+        }
+
+        if (debug_) {
+            printf("BitwisePuppi\nBitwisePuppi region eta [ %+5.2f , %+5.2f ], phi [ %+5.2f , %+5.2f ], algo = %d\n", r.etaMin - r.etaExtra, r.etaMax + r.etaExtra, r.phiCenter-r.phiHalfWidth-r.phiExtra, r.phiCenter+r.phiHalfWidth+r.phiExtra, int(algo_) );
+            printf("BitwisePuppi \t N(track) %3lu [max %2u]   N(pfne) %2lu [max %2u]    Nout %3u\n", r.track.size(), cfg->nTrack, indices.size(), cfg->nIn, cfg->nOut);
+            for (int itk = 0, ntk = r.track.size(); itk < ntk; ++itk) {
+                const auto & tk = r.track[itk]; 
+                printf("BitwisePuppi \t track %3d: pt %7.2f vtx eta %+5.2f  vtx phi %+5.2f  calo eta %+5.2f  calo phi %+5.2f  vz %+6.3f  dz %+6.3f\n", 
+                        itk, tk.floatPt(), tk.floatVtxEta(), tk.floatVtxPhi(), tk.floatEta(), tk.floatPhi(), tk.floatDZ(), tk.floatDZ() - z0);
+            }
+            for (int ipf = 0, npf = indices.size(); ipf < npf; ++ipf) {
+                const auto & pf = r.pf[indices[ipf]]; 
+                printf("BitwisePuppi \t pfne  %3d: pt %7.2f                                 calo eta %+5.2f  calo phi %+5.2f  pid %d\n", 
+                        ipf, pf.floatPt(), pf.floatEta(), pf.floatPhi(), int(pf.hwId));
+            }
+        }
+
+
+        if (algo_ == linpuppi_algo) linpuppi_ref(*cfg, track.get(), hwZ0, in.get(), outallne_nocut.get(), outallne.get(), outselne.get(), debug_);
+        else                        linpuppi_flt(*cfg, track.get(), hwZ0, in.get(), outallne_nocut.get(), outallne.get(), outselne.get(), debug_);
+
+        for (unsigned int i = 0, n = indices.size(); i < n; ++i) {
+            unsigned int ipf = indices[i];
+            if (outallne[i].hwPtPuppi > 0) {
+                r.pf[ipf].setPuppiW( int(outallne[i].hwPtPuppi) / float(r.pf[ipf].hwPt) );
+                r.puppi.push_back(r.pf[ipf]);
+                r.puppi.back().hwPt = int(outallne[i].hwPt);
+            }
+        }
+
+     } else {
+        std::unique_ptr<HadCaloObj[]> calo(new HadCaloObj[cfg->nIn]);
+        dpf2fw::convert(cfg->nIn, r.calo, calo.get());
+
+        if (debug_) {
+            printf("BitwisePuppi\nBitwisePuppi region eta [ %+5.2f , %+5.2f ], phi [ %+5.2f , %+5.2f ], algo = %d\n", r.etaMin - r.etaExtra, r.etaMax + r.etaExtra, r.phiCenter-r.phiHalfWidth-r.phiExtra, r.phiCenter+r.phiHalfWidth+r.phiExtra, int(algo_) );
+            printf("BitwisePuppi \t N(calo) %3lu [max %2u]    Nout %3u\n", r.calo.size(), cfg->nIn, cfg->nOut);
+            for (int ic = 0, nc = r.calo.size(); ic < nc; ++ic) {
+                const auto & c = r.calo[ic]; 
+                printf("BitwisePuppi \t calo  %3d: pt %7.2f eta %+5.2f  phi %+5.2f  isEM %1d\n", 
+                        ic, c.floatPt(), c.floatEta(), c.floatPhi(), int(c.isEM));
+            }
+        }
+
+        if (algo_ == fwdlinpuppi_algo) fwdlinpuppi_ref(*cfg, calo.get(), outallne_nocut.get(), outallne.get(), outselne.get(), debug_);
+        else                           fwdlinpuppi_flt(*cfg, calo.get(), outallne_nocut.get(), outallne.get(), outselne.get(), debug_);
+        
+        fw2dpf::convert_puppi(cfg->nOut, outselne.get(), r.puppi);
+        
+    } 
+
+    if (debug_) {
+        printf("BitwisePuppi \t Output N(ch) %3u/%3u   N(nh) %3u/%3u   N(ph) %3u/%u   [all/fiducial]\n", 
+                r.nOutput(l1tpf_impl::Region::charged_type,true,false), r.nOutput(l1tpf_impl::Region::charged_type,true,true), 
+                r.nOutput(l1tpf_impl::Region::neutral_hadron_type,true,false), r.nOutput(l1tpf_impl::Region::neutral_hadron_type,true,true), 
+                r.nOutput(l1tpf_impl::Region::photon_type,true,false), r.nOutput(l1tpf_impl::Region::photon_type,true,true));
+        for (int ipf = 0, npf = r.puppi.size(); ipf < npf; ++ipf) {
+            const auto & pf = r.puppi[ipf]; 
+            printf("BitwisePuppi \t pf    %3d: pt %7.2f pid %d   vtx eta %+5.2f  vtx phi %+5.2f  calo eta %+5.2f  calo phi %+5.2f\n", 
+                    ipf, pf.floatPt(), int(pf.hwId), pf.floatVtxEta(), pf.floatVtxPhi(), pf.floatEta(), pf.floatPhi());
+        }
+    }
+
+
+}
+
+

--- a/L1Trigger/Phase2L1ParticleFlow/src/LinearizedPuppiAlgo.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/LinearizedPuppiAlgo.cc
@@ -53,10 +53,10 @@ const std::vector<std::string> & LinearizedPuppiAlgo::puGlobalNames() const {
     return names_;
 
 }
-void LinearizedPuppiAlgo::doPUGlobals(const std::vector<Region> &rs, float npu, std::vector<float> & globals) const {
+void LinearizedPuppiAlgo::doPUGlobals(const std::vector<Region> &rs, float z0, float npu, std::vector<float> & globals) const {
     globals.clear();
 }
-void LinearizedPuppiAlgo::runNeutralsPU(Region &r, float npu, const std::vector<float> & globals) const {
+void LinearizedPuppiAlgo::runNeutralsPU(Region &r, float z0, float npu, const std::vector<float> & globals) const {
     std::vector<float> alphaC, alphaF;
     PuppiAlgo::computePuppiAlphas(r, alphaC, alphaF);
     computePuppiWeights(r, npu, alphaC, alphaF);

--- a/L1Trigger/Phase2L1ParticleFlow/src/PuppiAlgo.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/PuppiAlgo.cc
@@ -46,12 +46,12 @@ const std::vector<std::string> & PuppiAlgo::puGlobalNames() const {
     return names_;
 
 }
-void PuppiAlgo::doPUGlobals(const std::vector<Region> &rs, float npu, std::vector<float> & globals) const {
+void PuppiAlgo::doPUGlobals(const std::vector<Region> &rs, float z0, float npu, std::vector<float> & globals) const {
     globals.resize(4);
     computePuppiMedRMS(rs, globals[0], globals[1], globals[2], globals[3]);
 }
 
-void PuppiAlgo::runNeutralsPU(Region &r, float npu, const std::vector<float> & globals) const {
+void PuppiAlgo::runNeutralsPU(Region &r, float z0, float npu, const std::vector<float> & globals) const {
     std::vector<float> alphaC, alphaF;
     computePuppiAlphas(r, alphaC, alphaF);
     computePuppiWeights(r, alphaC, alphaF, globals[0], globals[1], globals[2], globals[3]);

--- a/L1Trigger/Phase2L1ParticleFlow/src/firmware/linpuppi.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/firmware/linpuppi.h
@@ -1,0 +1,160 @@
+#ifndef FIRMWARE_LINPUPPI_H
+#define FIRMWARE_LINPUPPI_H
+
+#include <cmath>
+#ifdef CMSSW_GIT_HASH
+#include "data.h"
+#else
+#include "../../firmware/data.h"
+#endif
+
+#if defined(PACKING_DATA_SIZE) && defined(PACKING_NCHANN)
+#include "../../firmware/l1pf_encoding.h"
+#endif
+
+int dr2_int(etaphi_t eta1, etaphi_t phi1, etaphi_t eta2, etaphi_t phi2);
+
+// charged
+void linpuppi_chs(z0_t pvZ0, const PFChargedObj pfch[NTRACK], PFChargedObj outallch[NTRACK]) ;
+
+// neutrals, in the tracker
+void linpuppiNoCrop(const TkObj track[NTRACK], z0_t pvZ0, const PFNeutralObj pfallne[NALLNEUTRALS], PFNeutralObj outallne[NALLNEUTRALS]) ;
+void linpuppi(const TkObj track[NTRACK], z0_t pvZ0, const PFNeutralObj pfallne[NALLNEUTRALS], PFNeutralObj outselne[NNEUTRALS]) ;
+
+// neutrals, forward
+void fwdlinpuppi(const HadCaloObj caloin[NCALO], PFNeutralObj pfselne[NNEUTRALS]);
+void fwdlinpuppiNoCrop(const HadCaloObj caloin[NCALO], PFNeutralObj pfallne[NCALO]);
+
+#if defined(PACKING_DATA_SIZE) && defined(PACKING_NCHANN)
+void packed_fwdlinpuppi(const ap_uint<PACKING_DATA_SIZE> input[PACKING_NCHANN], ap_uint<PACKING_DATA_SIZE> output[PACKING_NCHANN]) ;
+void packed_fwdlinpuppiNoCrop(const ap_uint<PACKING_DATA_SIZE> input[PACKING_NCHANN], ap_uint<PACKING_DATA_SIZE> output[PACKING_NCHANN]) ;
+
+void packed_linpuppi_chs(const ap_uint<PACKING_DATA_SIZE> input[PACKING_NCHANN], ap_uint<PACKING_DATA_SIZE> output[PACKING_NCHANN]);
+void packed_linpuppi(const ap_uint<PACKING_DATA_SIZE> input[PACKING_NCHANN], ap_uint<PACKING_DATA_SIZE> output[PACKING_NCHANN]);
+void packed_linpuppiNoCrop(const ap_uint<PACKING_DATA_SIZE> input[PACKING_NCHANN], ap_uint<PACKING_DATA_SIZE> output[PACKING_NCHANN]);
+
+void linpuppi_pack_in(const TkObj track[NTRACK], z0_t pvZ0, const PFNeutralObj pfallne[NALLNEUTRALS], ap_uint<PACKING_DATA_SIZE> input[PACKING_NCHANN]);
+void linpuppi_unpack_in(const ap_uint<PACKING_DATA_SIZE> input[PACKING_NCHANN], TkObj track[NTRACK], z0_t & pvZ0, PFNeutralObj pfallne[NALLNEUTRALS]);
+void linpuppi_chs_pack_in(z0_t pvZ0, const PFChargedObj pfch[NTRACK], ap_uint<PACKING_DATA_SIZE> input[PACKING_NCHANN]);
+void linpuppi_chs_unpack_in(const ap_uint<PACKING_DATA_SIZE> input[PACKING_NCHANN], z0_t & pvZ0, PFChargedObj pfch[NTRACK]);
+void linpuppi_pack_pv(z0_t pvZ0, ap_uint<PACKING_DATA_SIZE> & word);
+void linpuppi_unpack_pv(ap_uint<PACKING_DATA_SIZE> word, z0_t & pvZ0);
+#endif
+
+void linpuppi_set_debug(bool debug);
+
+#define LINPUPPI_ptLSB 0.25
+#define LINPUPPI_DR2LSB 1.9e-5
+#define LINPUPPI_dzLSB  0.05
+#define LINPUPPI_pt2LSB LINPUPPI_ptLSB*LINPUPPI_ptLSB
+#define LINPUPPI_pt2DR2_scale LINPUPPI_ptLSB*LINPUPPI_ptLSB/LINPUPPI_DR2LSB
+
+#define LINPUPPI_sum_bitShift  15
+#define LINPUPPI_x2_bits  6    // decimal bits the discriminator values
+#define LINPUPPI_alpha_bits  5 // decimal bits of the alpha values
+#define LINPUPPI_alphaSlope_bits  5 // decimal bits of the alphaSlope values
+#define LINPUPPI_ptSlope_bits  6    // decimal bits of the ptSlope values 
+#define LINPUPPI_weight_bits  8
+
+
+//=================================================
+#if defined(REG_Barrel)
+
+#define LINPUPPI_DR2MAX  4727 // 0.3 cone
+#define LINPUPPI_DR2MIN   257 // 0.07 cone
+#define LINPUPPI_dzCut     10
+#define LINPUPPI_ptMax    200 // 50.0/LINPUPPI_ptLSB 
+
+#define LINPUPPI_ptSlopeNe  0.3
+#define LINPUPPI_ptSlopePh  0.3
+#define LINPUPPI_ptZeroNe   4.0
+#define LINPUPPI_ptZeroPh   2.5
+#define LINPUPPI_alphaSlope 0.7
+#define LINPUPPI_alphaZero  6.0
+#define LINPUPPI_alphaCrop  4.0
+#define LINPUPPI_priorNe    5.0
+#define LINPUPPI_priorPh    1.0
+
+#define LINPUPPI_ptCut        4 // 1.0/LINPUPPI_ptLSB
+
+//=================================================
+#elif defined(REG_HGCal) 
+
+#define LINPUPPI_etaBins 2
+#define LINPUPPI_etaCut  0 // assuming the region spans [1.5,2.5] (or 1.25,2.75 with the overlaps), 
+                           // the cut is exactly at the region center (2.0), so it's at 0 in integer coordinates
+#define LINPUPPI_invertEta 0 // 0 if we're building the FW for the positive eta endcap.
+
+#define LINPUPPI_DR2MAX  4727 // 0.3 cone
+#define LINPUPPI_DR2MIN    84 // 0.04 cone
+#define LINPUPPI_dzCut     40
+#define LINPUPPI_ptMax    200 // 50.0/LINPUPPI_ptLSB 
+
+#define LINPUPPI_ptSlopeNe  0.3 
+#define LINPUPPI_ptSlopePh  0.4 
+#define LINPUPPI_ptZeroNe   5.0 
+#define LINPUPPI_ptZeroPh   3.0 
+#define LINPUPPI_alphaSlope 1.5 
+#define LINPUPPI_alphaZero  6.0 
+#define LINPUPPI_alphaCrop  3.0 
+#define LINPUPPI_priorNe    5.0 
+#define LINPUPPI_priorPh    1.5 
+
+#define LINPUPPI_ptSlopeNe_1  0.3 
+#define LINPUPPI_ptSlopePh_1  0.4 
+#define LINPUPPI_ptZeroNe_1   7.0 
+#define LINPUPPI_ptZeroPh_1   4.0 
+#define LINPUPPI_alphaSlope_1 1.5 
+#define LINPUPPI_alphaZero_1  6.0 
+#define LINPUPPI_alphaCrop_1  3.0 
+#define LINPUPPI_priorNe_1    5.0 
+#define LINPUPPI_priorPh_1    1.5 
+
+
+#define LINPUPPI_ptCut        4 // 1.0/LINPUPPI_ptLSB
+#define LINPUPPI_ptCut_1      8 // 2.0/LINPUPPI_ptLSB
+
+//=================================================
+#elif defined(REG_HGCalNoTK)
+
+#define LINPUPPI_DR2MAX  4727 // 0.3 cone
+#define LINPUPPI_DR2MIN    84 // 0.04 cone
+#define LINPUPPI_dzCut     40 // unused
+#define LINPUPPI_ptMax    200 // 50.0/LINPUPPI_ptLSB 
+
+#define LINPUPPI_ptSlopeNe  0.3
+#define LINPUPPI_ptSlopePh  0.4
+#define LINPUPPI_ptZeroNe   9.0
+#define LINPUPPI_ptZeroPh   5.0
+#define LINPUPPI_alphaSlope 2.2
+#define LINPUPPI_alphaZero  9.0
+#define LINPUPPI_alphaCrop  4.0
+#define LINPUPPI_priorNe    7.0
+#define LINPUPPI_priorPh    5.0
+
+#define LINPUPPI_ptCut       16 // 4.0/LINPUPPI_ptLSB
+
+//=================================================
+#elif defined(REG_HF)
+
+#define LINPUPPI_DR2MAX  4727 // 0.3 cone
+#define LINPUPPI_DR2MIN   525 // 0.1 cone
+#define LINPUPPI_dzCut     40 // unused
+
+#define LINPUPPI_ptMax    400 // 100.0/LINPUPPI_ptLSB 
+
+#define LINPUPPI_ptSlopeNe  0.25
+#define LINPUPPI_ptSlopePh  0.25
+#define LINPUPPI_ptZeroNe   14.
+#define LINPUPPI_ptZeroPh   14.
+#define LINPUPPI_alphaSlope 0.6
+#define LINPUPPI_alphaZero  9.0
+#define LINPUPPI_alphaCrop  4.0
+#define LINPUPPI_priorNe    6.0
+#define LINPUPPI_priorPh    6.0
+
+#define LINPUPPI_ptCut      40  // 10.0/LINPUPPI_ptLSB
+
+#endif
+
+#endif

--- a/L1Trigger/Phase2L1ParticleFlow/src/ref/linpuppi_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/ref/linpuppi_ref.cpp
@@ -65,13 +65,17 @@ void puppisort_and_crop_ref(unsigned int nIn, unsigned int nOut, const T in[/*nI
 }
 
 
-void linpuppi_chs_ref(const linpuppi_config &cfg, z0_t pvZ0, const PFChargedObj pfch[/*cfg.nTrack*/], PFChargedObj outallch[/*cfg.nTrack*/]) {
+void linpuppi_chs_ref(const linpuppi_config &cfg, z0_t pvZ0, const PFChargedObj pfch[/*cfg.nTrack*/], PFChargedObj outallch[/*cfg.nTrack*/], bool debug) {
     for (unsigned int i = 0; i < cfg.nTrack; ++i) {
         int z0diff = pfch[i].hwZ0 - pvZ0;
         if (std::abs(z0diff) <= cfg.dzCut || pfch[i].hwId == PID_Muon) {
             outallch[i] = pfch[i];
+            if (debug && pfch[i].hwPt > 0) printf("ref candidate %02u pt %7.2f pid %1d   vz %+6d  dz %+6d (cut %5d) -> pass\n", i, 
+                                    int(pfch[i].hwPt)*LINPUPPI_ptLSB, int(pfch[i].hwId), int(pfch[i].hwZ0), z0diff, cfg.dzCut);
         } else {
             clear(outallch[i]);
+            if (debug && pfch[i].hwPt > 0) printf("ref candidate %02u pt %7.2f pid %1d   vz %+6d  dz %+6d (cut %5d) -> fail\n", i, 
+                                    int(pfch[i].hwPt)*LINPUPPI_ptLSB, int(pfch[i].hwId), int(pfch[i].hwZ0), z0diff, cfg.dzCut);
         }
     }
 }

--- a/L1Trigger/Phase2L1ParticleFlow/src/ref/linpuppi_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/ref/linpuppi_ref.cpp
@@ -1,0 +1,346 @@
+#include "linpuppi_ref.h"
+#include <cmath>
+#include <algorithm>
+
+linpuppi_config::linpuppi_config(unsigned int nTrack_, unsigned int nIn_, unsigned int nOut_,
+                    unsigned int dR2Min_, unsigned int dR2Max_, unsigned int ptMax_, unsigned int dzCut_,
+                    int etaCut, bool invertEta,
+                    float ptSlopeNe_0, float ptSlopeNe_1, float ptSlopePh_0, float ptSlopePh_1, float ptZeroNe_0, float ptZeroNe_1, float ptZeroPh_0, float ptZeroPh_1, 
+                    float alphaSlope_0, float alphaSlope_1, float alphaZero_0, float alphaZero_1, float alphaCrop_0, float alphaCrop_1, 
+                    float priorNe_0, float priorNe_1, float priorPh_0, float priorPh_1, 
+                    unsigned int ptCut_0, unsigned int ptCut_1) :
+                nTrack(nTrack_), nIn(nIn_), nOut(nOut_),
+                dR2Min(dR2Min_), dR2Max(dR2Max_), ptMax(ptMax_), dzCut(dzCut_),
+                absEtaBins(1, etaCut), invertEtaBins(invertEta),
+                ptSlopeNe(2), ptSlopePh(2), ptZeroNe(2), ptZeroPh(2), alphaSlope(2), alphaZero(2), alphaCrop(2), priorNe(2), priorPh(2), 
+                ptCut(2) 
+{
+    ptSlopeNe[0] = ptSlopeNe_0; 
+    ptSlopeNe[1] = ptSlopeNe_1;
+    ptSlopePh[0] = ptSlopePh_0; 
+    ptSlopePh[1] = ptSlopePh_1;
+    ptZeroNe[0] = ptZeroNe_0; 
+    ptZeroNe[1] = ptZeroNe_1;
+    ptZeroPh[0] = ptZeroPh_0; 
+    ptZeroPh[1] = ptZeroPh_1;
+    alphaSlope[0] = alphaSlope_0; 
+    alphaSlope[1] = alphaSlope_1;
+    alphaZero[0] = alphaZero_0;
+    alphaZero[1] = alphaZero_1;
+    alphaCrop[0] = alphaCrop_0; 
+    alphaCrop[1] = alphaCrop_1;
+    priorNe[0] = priorNe_0; 
+    priorNe[1] = priorNe_1;
+    priorPh[0] = priorPh_0; 
+    priorPh[1] = priorPh_1;
+    ptCut[0] = ptCut_0; 
+    ptCut[1] = ptCut_1;
+}
+
+
+template<typename T>
+void puppisort_and_crop_ref(unsigned int nIn, unsigned int nOut, const T in[/*nIn*/], T out[/*nOut*/]) {
+    std::vector<T> tmp(nOut);
+
+    for (unsigned int iout = 0; iout < nOut; ++iout) {
+        clear(tmp[iout]);
+    }
+
+    for (unsigned int it = 0; it < nIn; ++it) {
+        for (int iout = int(nOut)-1; iout >= 0; --iout) {
+            if (tmp[iout].hwPtPuppi <= in[it].hwPtPuppi) {
+                if (iout == 0 || tmp[iout-1].hwPtPuppi > in[it].hwPtPuppi) {
+                    tmp[iout] = in[it];
+                } else {
+                    tmp[iout] = tmp[iout-1];
+                }
+            }
+        }
+    }
+
+    for (unsigned int iout = 0; iout < nOut; ++iout) {
+        out[iout] = tmp[iout];
+    }
+
+}
+
+
+void linpuppi_chs_ref(const linpuppi_config &cfg, z0_t pvZ0, const PFChargedObj pfch[/*cfg.nTrack*/], PFChargedObj outallch[/*cfg.nTrack*/]) {
+    for (unsigned int i = 0; i < cfg.nTrack; ++i) {
+        int z0diff = pfch[i].hwZ0 - pvZ0;
+        if (std::abs(z0diff) <= cfg.dzCut || pfch[i].hwId == PID_Muon) {
+            outallch[i] = pfch[i];
+        } else {
+            clear(outallch[i]);
+        }
+    }
+}
+
+unsigned int linpuppi_ieta_ref(const linpuppi_config &cfg, etaphi_t eta) {
+    int n = cfg.absEtaBins.size();
+    for (int i = 0; i < n; ++i) {
+        if (int(eta) <= cfg.absEtaBins[i]) return (cfg.invertEtaBins ? n-i : i);
+    }
+    return cfg.invertEtaBins ? 0 : n;
+}
+
+pt_t linpuppi_ref_sum2puppiPt(const linpuppi_config &cfg, uint64_t sum, pt_t pt, unsigned int ieta, bool isEM, int icand, bool debug) {
+    const int sum_bitShift = LINPUPPI_sum_bitShift;
+    const int x2_bits = LINPUPPI_x2_bits;    // decimal bits the discriminator values
+    const int alpha_bits = LINPUPPI_alpha_bits; // decimal bits of the alpha values
+    const int alphaSlope_bits = LINPUPPI_alphaSlope_bits; // decimal bits of the alphaSlope values
+    const int ptSlope_bits = LINPUPPI_ptSlope_bits;    // decimal bits of the ptSlope values 
+    const int weight_bits = LINPUPPI_weight_bits;
+
+    const int ptSlopeNe = cfg.ptSlopeNe[ieta] * (1 << ptSlope_bits);
+    const int ptSlopePh = cfg.ptSlopePh[ieta] * (1 << ptSlope_bits);
+    const int ptZeroNe = cfg.ptZeroNe[ieta] / LINPUPPI_ptLSB; // in pt scale
+    const int ptZeroPh = cfg.ptZeroPh[ieta] / LINPUPPI_ptLSB; // in pt scale
+    const int alphaCrop = cfg.alphaCrop[ieta] * (1 << x2_bits);
+    const int alphaSlopeNe = cfg.alphaSlope[ieta] * std::log(2.) * (1 << alphaSlope_bits); // we put a log(2) here since we compute alpha as log2(sum) instead of ln(sum)
+    const int alphaSlopePh = cfg.alphaSlope[ieta] * std::log(2.) * (1 << alphaSlope_bits);
+    const int alphaZeroNe = cfg.alphaZero[ieta] / std::log(2.) * (1 << alpha_bits);
+    const int alphaZeroPh = cfg.alphaZero[ieta] / std::log(2.) * (1 << alpha_bits);
+    const int priorNe = cfg.priorNe[ieta] * (1 << x2_bits);
+    const int priorPh = cfg.priorPh[ieta] * (1 << x2_bits);
+
+    // -- simplest version
+    //int alpha = sum > 0 ? int(std::log2(float(sum) * LINPUPPI_pt2DR2_scale / (1<<sum_bitShift)) * (1 << alpha_bits) + 0.5) :  0;
+    // -- re-written bringing terms out of the log
+    //int alpha = sum > 0 ? int(std::log2(float(sum))*(1 << alpha_bits) + (std::log2(LINPUPPI_pt2DR2_scale) - sum_bitShift)*(1 << alpha_bits) + 0.5 ) :  0;
+    // -- re-written for a LUT implementation of the log2
+    const int log2lut_bits = 10;
+    int alpha = 0; uint64_t logarg = sum;
+    if (logarg > 0) {
+        alpha = int((std::log2(LINPUPPI_pt2DR2_scale) - sum_bitShift)*(1 << alpha_bits) + 0.5);
+        while (logarg >= (1 << log2lut_bits)) { logarg = logarg >> 1; alpha += (1 << alpha_bits); }
+        alpha += int(std::log2(float(logarg))*(1 << alpha_bits)); // the maximum value of this term is log2lut_bits * (1 << alpha_bits) ~ 10*16 = 160 => fits in ap_uint<4+alpha_bits>
+    }
+    int alphaZero  = (isEM ? alphaZeroPh : alphaZeroNe);
+    int alphaSlope = (isEM ? alphaSlopePh : alphaSlopeNe);
+    int x2a = std::min(std::max( alphaSlope * (alpha - alphaZero)  >> (alphaSlope_bits + alpha_bits - x2_bits), -alphaCrop), alphaCrop);
+
+    // -- re-written to fit in a single LUT
+    int x2a_lut = - alphaSlope * alphaZero; logarg = sum;
+    if (logarg > 0) {
+        x2a_lut += alphaSlope * int((std::log2(LINPUPPI_pt2DR2_scale) - sum_bitShift)*(1 << alpha_bits) + 0.5);
+        while (logarg >= (1 << log2lut_bits)) { 
+            logarg = logarg >> 1; x2a_lut += alphaSlope * (1 << alpha_bits); 
+        }
+        x2a_lut += alphaSlope * int(std::log2(float(logarg))*(1 << alpha_bits)); 
+        /*if (in <= 3) printf("ref [%d]:  x2a(sum = %9lu): logarg = %9lu, sumterm = %9d, table[logarg] = %9d, ret pre-crop = %9d\n", 
+          in, sum, logarg, 
+          alphaSlope * int((std::log2(LINPUPPI_pt2DR2_scale) - sum_bitShift)*(1 << alpha_bits) + 0.5) - alphaSlope * alphaZero,
+          alphaSlope * int(std::log2(float(logarg))*(1 << alpha_bits)), 
+          x2a_lut); */
+    } else {
+        //if (in <= 3) printf("ref [%d]:  x2a(sum = %9lu): logarg = %9lu, ret pre-crop = %9d\n", 
+        //        in, sum, logarg, x2a_lut); 
+    }
+    x2a_lut = std::min(std::max( x2a_lut >> (alphaSlope_bits + alpha_bits - x2_bits), -alphaCrop), alphaCrop);
+    assert( x2a_lut == x2a );
+
+    int ptZero  = (isEM ? ptZeroPh : ptZeroNe);
+    int ptSlope = (isEM ? ptSlopePh : ptSlopeNe);
+    int x2pt    = ptSlope * (pt - ptZero) >> (ptSlope_bits + 2 - x2_bits);
+
+    int prior  = (isEM ? priorPh : priorNe);
+
+    int x2 = x2a + x2pt - prior;
+
+    int weight = std::min<int>( 1.0/(1.0 + std::exp(- float(x2)/(1<<x2_bits))) * ( 1 << weight_bits ) + 0.5, (1 << weight_bits) );
+
+    pt_t ptPuppi = ( pt * weight ) >> weight_bits;
+
+    if (debug) printf("ref candidate %02d pt %7.2f  em %1d: alpha %+7.2f   x2a %+5d = %+7.3f  x2pt %+5d = %+7.3f   x2 %+5d = %+7.3f  --> weight %4d = %.4f  puppi pt %7.2f\n",
+               icand, pt*LINPUPPI_ptLSB, int(isEM), 
+               std::max<float>(alpha/float(1<<alpha_bits)*std::log(2.),-99.99f), 
+               x2a, x2a/float(1<<x2_bits), x2pt, x2pt/float(1<<x2_bits), x2, x2/float(1<<x2_bits), 
+               weight, weight/float( 1 << weight_bits ), 
+               ptPuppi*LINPUPPI_ptLSB);
+
+    return ptPuppi;
+}
+
+
+void fwdlinpuppi_ref(const linpuppi_config &cfg, const HadCaloObj caloin[/*cfg.nIn*/], PFNeutralObj outallne_nocut[/*cfg.nIn*/], PFNeutralObj outallne[/*cfg.nIn*/], PFNeutralObj outselne[/*cfg.nOut*/], bool debug) {
+    const int DR2MAX = cfg.dR2Max; 
+    const int DR2MIN = cfg.dR2Min; 
+    const int PTMAX2 = (cfg.ptMax*cfg.ptMax);
+
+    for (unsigned int i = 0; i < cfg.nIn; ++i) {
+        outallne_nocut[i].hwPt      = caloin[i].hwPt;
+        outallne_nocut[i].hwEta     = caloin[i].hwEta;
+        outallne_nocut[i].hwPhi     = caloin[i].hwPhi;
+        outallne_nocut[i].hwId      = caloin[i].hwIsEM ? PID_Photon : PID_Neutral;
+        outallne_nocut[i].hwPtPuppi = 0;
+        clear(outallne[i]);
+    }
+
+    const int sum_bitShift = LINPUPPI_sum_bitShift;
+
+    for (unsigned int in = 0; in < cfg.nIn; ++in) {
+        if (caloin[in].hwPt == 0) continue;
+        uint64_t sum = 0; // 2 ^ sum_bitShift times (int pt^2)/(int dr2)
+        for (unsigned int it = 0; it < cfg.nIn; ++it) {
+            if (it == in || caloin[it].hwPt == 0) continue;
+            int dr2 = dr2_int(caloin[it].hwEta, caloin[it].hwPhi, caloin[in].hwEta, caloin[in].hwPhi); // if dr is inside puppi cone
+            if (dr2 <= DR2MAX) {
+                ap_uint<9> dr2short = (dr2 >= DR2MIN ? dr2 : DR2MIN) >> 5; // reduce precision to make divide LUT cheaper
+                uint64_t pt2 = caloin[it].hwPt*caloin[it].hwPt;
+                uint64_t term = std::min<uint64_t>(pt2 >> 5, PTMAX2 >> 5)*((1 << sum_bitShift)/int(dr2short));
+                //      dr2short >= (DR2MIN >> 5) = 2
+                //      num <= (PTMAX2 >> 5) << sum_bitShift = (2^11) << 15 = 2^26
+                //      ==> term <= 2^25
+                //printf("ref term [%2d,%2d]: dr = %8d  pt2_shift = %8lu  term = %12lu\n", in, it, dr2, std::min<uint64_t>(pt2 >> 5, PTMAX2 >> 5), term);
+                assert(uint64_t(PTMAX2 << (sum_bitShift-5))/(DR2MIN >> 5) <= (1 << 25));
+                assert(term < (1 << 25));
+                sum += term;
+                //printf("    pT cand %5.1f    pT item %5.1f    dR = %.3f   term = %.1f [dbl] = %lu [int]\n",
+                //            LINPUPPI_ptLSB*caloin[in].hwPt, LINPUPPI_ptLSB*caloin[it].hwPt, std::sqrt(dr2*LINPUPPI_DR2LSB),
+                //            double(std::min<uint64_t>(pt2 >> 5, 131071)<<15)/double(std::max<int>(dr2,DR2MIN) >> 5),
+                //            term);
+            }
+        }
+        unsigned int ieta = linpuppi_ieta_ref(cfg, caloin[in].hwEta);
+        outallne_nocut[in].hwPtPuppi = linpuppi_ref_sum2puppiPt(cfg, sum, caloin[in].hwPt, ieta, caloin[in].hwIsEM, in, debug);
+        if (outallne_nocut[in].hwPtPuppi >= cfg.ptCut[ieta]) {
+            outallne[in] = outallne_nocut[in];
+        }
+    }
+    puppisort_and_crop_ref(cfg.nIn, cfg.nOut, outallne, outselne);
+}
+
+void linpuppi_ref(const linpuppi_config &cfg, const TkObj track[/*cfg.nTrack*/], z0_t pvZ0, const PFNeutralObj pfallne[/*cfg.nIn*/], PFNeutralObj outallne_nocut[/*cfg.nIn*/], PFNeutralObj outallne[/*cfg.nIn*/], PFNeutralObj outselne[/*cfg.nOut*/], bool debug) {
+    const int DR2MAX = cfg.dR2Max; 
+    const int DR2MIN = cfg.dR2Min; 
+    const int PTMAX2 = (cfg.ptMax*cfg.ptMax);
+
+    const int sum_bitShift = LINPUPPI_sum_bitShift;
+
+    for (unsigned int in = 0; in < cfg.nIn; ++in) {
+        outallne_nocut[in] = pfallne[in]; clear(outallne[in]);
+        if (pfallne[in].hwPt == 0) continue;
+        uint64_t sum = 0; // 2 ^ sum_bitShift times (int pt^2)/(int dr2)
+        for (unsigned int it = 0; it < cfg.nTrack; ++it) {
+            if (it == in || track[it].hwPt == 0) continue;
+            if (std::abs(int(track[it].hwZ0 - pvZ0)) > cfg.dzCut) continue;
+            int dr2 = dr2_int(pfallne[in].hwEta, pfallne[in].hwPhi, track[it].hwEta, track[it].hwPhi); // if dr is inside puppi cone
+            if (dr2 <= DR2MAX) {
+                ap_uint<9> dr2short = (dr2 >= DR2MIN ? dr2 : DR2MIN) >> 5; // reduce precision to make divide LUT cheaper
+                uint64_t pt2 = track[it].hwPt*track[it].hwPt;
+                uint64_t term = std::min<uint64_t>(pt2 >> 5, PTMAX2 >> 5)*((1 << sum_bitShift)/int(dr2short));
+                //      dr2short >= (DR2MIN >> 5) = 2
+                //      num <= (PTMAX2 >> 5) << sum_bitShift = (2^11) << 15 = 2^26
+                //      ==> term <= 2^25
+                //printf("ref term [%2d,%2d]: dr = %8d  pt2_shift = %8lu  term = %12lu\n", in, it, dr2, std::min<uint64_t>(pt2 >> 5, PTMAX2 >> 5), term);
+                assert(uint64_t(PTMAX2 << (sum_bitShift-5))/(DR2MIN >> 5) <= (1 << 25));
+                assert(term < (1 << 25));
+                sum += term;
+                //printf("    pT cand %5.1f    pT item %5.1f    dR = %.3f   term = %.1f [dbl] = %lu [int]\n",
+                //            LINPUPPI_ptLSB*pfallne[in].hwPt, LINPUPPI_ptLSB*track[it].hwPt, std::sqrt(dr2*LINPUPPI_DR2LSB),
+                //            double(std::min<uint64_t>(pt2 >> 5, 131071)<<15)/double(std::max<int>(dr2,DR2MIN) >> 5),
+                //            term);
+            }
+        }
+
+        unsigned int ieta = linpuppi_ieta_ref(cfg, pfallne[in].hwEta);
+        bool isEM = (pfallne[in].hwId == PID_Photon);
+        outallne_nocut[in].hwPtPuppi = linpuppi_ref_sum2puppiPt(cfg, sum, pfallne[in].hwPt, ieta, isEM, in, debug);
+        if (outallne_nocut[in].hwPtPuppi >= cfg.ptCut[ieta]) {
+            outallne[in] = outallne_nocut[in];
+        }
+     }
+    puppisort_and_crop_ref(cfg.nIn, cfg.nOut, outallne, outselne);
+
+}
+
+float linpuppi_flt_sum2puppiPt(const linpuppi_config &cfg, float sum, float pt, unsigned int ieta, bool isEM, int icand, bool debug) {
+    float alphaZero  = cfg.alphaZero[ieta], alphaSlope = cfg.alphaSlope[ieta], alphaCrop = cfg.alphaCrop[ieta];
+    float alpha = sum > 0 ? std::log(sum) : -9e9;
+    float x2a = std::min(std::max( alphaSlope * (alpha - alphaZero), -alphaCrop), alphaCrop);
+
+    float ptZero  = (isEM ? cfg.ptZeroPh[ieta]  : cfg.ptZeroNe[ieta]);
+    float ptSlope = (isEM ? cfg.ptSlopePh[ieta] : cfg.ptSlopeNe[ieta]);
+    float x2pt    = ptSlope * (pt - ptZero);
+
+    float prior  = (isEM ? cfg.priorPh[ieta] : cfg.priorNe[ieta]);
+
+    float x2 = x2a + x2pt - prior;
+
+    float weight = 1.0/(1.0 + std::exp(-x2));
+
+    float puppiPt = pt *weight;
+    if (debug) printf("flt candidate %02d pt %7.2f  em %1d: alpha %+7.2f   x2a         %+7.3f  x2pt         %+7.3f   x2         %+7.3f  --> weight        %.4f  puppi pt %7.2f\n",
+                   icand, pt, int(isEM), std::max(alpha,-99.99f), x2a, x2pt, x2, weight, puppiPt);
+
+    return puppiPt;
+}
+
+
+void fwdlinpuppi_flt(const linpuppi_config &cfg, const HadCaloObj caloin[/*cfg.nIn*/], PFNeutralObj outallne_nocut[/*cfg.nIn*/], PFNeutralObj outallne[/*cfg.nIn*/], PFNeutralObj outselne[/*cfg.nOut*/], bool debug) {
+    const int DR2MAX = cfg.dR2Max; 
+    const int DR2MIN = cfg.dR2Min; 
+    const float f_ptMax = cfg.ptMax * LINPUPPI_ptLSB;
+
+    for (unsigned int i = 0; i < cfg.nIn; ++i) {
+        outallne_nocut[i].hwPt      = caloin[i].hwPt;
+        outallne_nocut[i].hwEta     = caloin[i].hwEta;
+        outallne_nocut[i].hwPhi     = caloin[i].hwPhi;
+        outallne_nocut[i].hwId      = caloin[i].hwIsEM ? PID_Photon : PID_Neutral;
+        outallne_nocut[i].hwPtPuppi = 0;
+        clear(outallne[i]);
+    }
+
+    for (unsigned int in = 0; in < cfg.nIn; ++in) {
+        if (caloin[in].hwPt == 0) continue;
+        float sum = 0;
+        for (unsigned int it = 0; it < cfg.nIn; ++it) {
+            if (it == in || caloin[it].hwPt == 0) continue;
+            int dr2 = dr2_int(caloin[it].hwEta, caloin[it].hwPhi, caloin[in].hwEta, caloin[in].hwPhi); // if dr is inside puppi cone
+            if (dr2 <= DR2MAX) {
+                sum += std::pow(std::min<float>(caloin[it].hwPt*LINPUPPI_ptLSB,f_ptMax),2) / (std::max<int>(dr2,DR2MIN) * LINPUPPI_DR2LSB);
+            }
+        }
+
+        unsigned int ieta = linpuppi_ieta_ref(cfg, caloin[in].hwEta);
+        float ptPuppi = linpuppi_flt_sum2puppiPt(cfg, sum, caloin[in].hwPt*LINPUPPI_ptLSB, ieta, caloin[in].hwIsEM, in, debug);
+        outallne_nocut[in].hwPtPuppi = int(ptPuppi / LINPUPPI_ptLSB);
+        if (outallne_nocut[in].hwPtPuppi >= cfg.ptCut[ieta]) {
+            outallne[in] = outallne_nocut[in];
+        }
+    }
+
+    puppisort_and_crop_ref(cfg.nIn, cfg.nOut, outallne, outselne);
+}
+
+void linpuppi_flt(const linpuppi_config &cfg, const TkObj track[/*cfg.nTrack*/], z0_t pvZ0, const PFNeutralObj pfallne[/*cfg.nIn*/], PFNeutralObj outallne_nocut[/*cfg.nIn*/], PFNeutralObj outallne[/*cfg.nIn*/], PFNeutralObj outselne[/*cfg.nOut*/], bool debug) {
+    const int DR2MAX = cfg.dR2Max; 
+    const int DR2MIN = cfg.dR2Min; 
+    const float f_ptMax = cfg.ptMax * LINPUPPI_ptLSB;
+
+    for (unsigned int in = 0; in < cfg.nIn; ++in) {
+        outallne_nocut[in] = pfallne[in]; clear(outallne[in]);
+        if (pfallne[in].hwPt == 0) continue;
+        float sum = 0;
+        for (unsigned int it = 0; it < cfg.nTrack; ++it) {
+            if (it == in || track[it].hwPt == 0) continue;
+            if (std::abs(int(track[it].hwZ0 - pvZ0)) > cfg.dzCut) continue;
+            int dr2 = dr2_int(pfallne[in].hwEta, pfallne[in].hwPhi, track[it].hwEta, track[it].hwPhi); // if dr is inside puppi cone
+            if (dr2 <= DR2MAX) {
+                sum += std::pow(std::min<float>(track[it].hwPt*LINPUPPI_ptLSB,f_ptMax),2) / (std::max<int>(dr2,DR2MIN) * LINPUPPI_DR2LSB);
+            }
+        }
+        unsigned int ieta = linpuppi_ieta_ref(cfg, pfallne[in].hwEta);
+        bool isEM = (pfallne[in].hwId == PID_Photon);
+        float ptPuppi = linpuppi_flt_sum2puppiPt(cfg, sum, pfallne[in].hwPt*LINPUPPI_ptLSB, ieta, isEM, in, debug);
+        outallne_nocut[in].hwPtPuppi = int(ptPuppi / LINPUPPI_ptLSB);
+        if (outallne_nocut[in].hwPtPuppi >= cfg.ptCut[ieta]) {
+            outallne[in] = outallne_nocut[in];
+        }
+    }
+    puppisort_and_crop_ref(cfg.nIn, cfg.nOut, outallne, outselne);
+}
+
+
+

--- a/L1Trigger/Phase2L1ParticleFlow/src/ref/linpuppi_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/ref/linpuppi_ref.h
@@ -1,0 +1,67 @@
+#ifndef LINPUPPI_REF_H
+#define LINPUPPI_REF_H
+
+#ifdef CMSSW_GIT_HASH
+  #include "../firmware/linpuppi.h"
+#else
+  #include "firmware/linpuppi.h"
+#endif
+#include <vector>
+
+struct linpuppi_config {
+    unsigned int nTrack, nIn, nOut; // nIn, nOut refer to the calorimeter clusters or neutral PF candidates as input and as output (after sorting)
+    unsigned int dR2Min, dR2Max, ptMax, dzCut;
+    std::vector<int> absEtaBins; bool invertEtaBins;
+    std::vector<float> ptSlopeNe, ptSlopePh, ptZeroNe, ptZeroPh;
+    std::vector<float> alphaSlope, alphaZero, alphaCrop;
+    std::vector<float> priorNe, priorPh;
+    std::vector<unsigned int> ptCut;
+
+    linpuppi_config(unsigned int nTrack_, unsigned int nIn_, unsigned int nOut_,
+                    unsigned int dR2Min_, unsigned int dR2Max_, unsigned int ptMax_, unsigned int dzCut_,
+                    float ptSlopeNe_, float ptSlopePh_, float ptZeroNe_, float ptZeroPh_, 
+                    float alphaSlope_, float alphaZero_, float alphaCrop_, 
+                    float priorNe_, float priorPh_, 
+                    unsigned int ptCut_) :
+                nTrack(nTrack_), nIn(nIn_), nOut(nOut_),
+                dR2Min(dR2Min_), dR2Max(dR2Max_), ptMax(ptMax_), dzCut(dzCut_),
+                absEtaBins(), invertEtaBins(false), 
+                ptSlopeNe(1, ptSlopeNe_), ptSlopePh(1, ptSlopePh_), ptZeroNe(1, ptZeroNe_), ptZeroPh(1, ptZeroPh_), alphaSlope(1, alphaSlope_), alphaZero(1, alphaZero_), alphaCrop(1, alphaCrop_), priorNe(1, priorNe_), priorPh(1, priorPh_), 
+                ptCut(1, ptCut_) {}
+
+     linpuppi_config(unsigned int nTrack_, unsigned int nIn_, unsigned int nOut_,
+                    unsigned int dR2Min_, unsigned int dR2Max_, unsigned int ptMax_, unsigned int dzCut_,
+                    int etaCut_, bool invertEtaBins_,
+                    float ptSlopeNe_0, float ptSlopeNe_1, float ptSlopePh_0, float ptSlopePh_1, float ptZeroNe_0, float ptZeroNe_1, float ptZeroPh_0, float ptZeroPh_1, 
+                    float alphaSlope_0, float alphaSlope_1, float alphaZero_0, float alphaZero_1, float alphaCrop_0, float alphaCrop_1, 
+                    float priorNe_0, float priorNe_1, float priorPh_0, float priorPh_1, 
+                    unsigned int ptCut_0, unsigned int ptCut_1) ;
+
+
+    linpuppi_config(unsigned int nTrack_, unsigned int nIn_, unsigned int nOut_,
+                    unsigned int dR2Min_, unsigned int dR2Max_, unsigned int ptMax_, unsigned int dzCut_,
+                    const std::vector<int> & absEtaBins_, bool invertEtaBins_,
+                    const std::vector<float> & ptSlopeNe_, const std::vector<float> & ptSlopePh_, const std::vector<float> & ptZeroNe_, const std::vector<float> & ptZeroPh_, 
+                    const std::vector<float> & alphaSlope_, const std::vector<float> & alphaZero_, const std::vector<float> & alphaCrop_, 
+                    const std::vector<float> & priorNe_, const std::vector<float> & priorPh_,
+                    const std::vector<unsigned int> & ptCut_) :
+                nTrack(nTrack_), nIn(nIn_), nOut(nOut_),
+                dR2Min(dR2Min_), dR2Max(dR2Max_), ptMax(ptMax_), dzCut(dzCut_),
+                absEtaBins(absEtaBins_), invertEtaBins(invertEtaBins_),
+                ptSlopeNe(ptSlopeNe_), ptSlopePh(ptSlopePh_), ptZeroNe(ptZeroNe_), ptZeroPh(ptZeroPh_), alphaSlope(alphaSlope_), alphaZero(alphaZero_), alphaCrop(alphaCrop_), priorNe(priorNe_), priorPh(priorPh_), 
+                ptCut(ptCut_) {}
+
+};
+
+// charged
+void linpuppi_chs_ref(const linpuppi_config &cfg, z0_t pvZ0, const PFChargedObj pfch[/*cfg.nTrack*/], PFChargedObj outallch[/*cfg.nTrack*/]) ;
+
+// neutrals, in the tracker
+void linpuppi_flt(const linpuppi_config &cfg, const TkObj track[/*cfg.nTrack*/], z0_t pvZ0, const PFNeutralObj pfallne[/*cfg.nIn*/], PFNeutralObj outallne_nocut[/*cfg.nIn*/], PFNeutralObj outallne[/*cfg.nIn*/], PFNeutralObj outselne[/*cfg.nOut*/], bool debug) ;
+void linpuppi_ref(const linpuppi_config &cfg, const TkObj track[/*cfg.nTrack*/], z0_t pvZ0, const PFNeutralObj pfallne[/*cfg.nIn*/], PFNeutralObj outallne_nocut[/*cfg.nIn*/], PFNeutralObj outallne[/*cfg.nIn*/], PFNeutralObj outselne[/*cfg.nOut*/], bool debug) ;
+
+// neutrals, forward
+void fwdlinpuppi_ref(const linpuppi_config &cfg, const HadCaloObj caloin[/*cfg.nIn*/], PFNeutralObj outallne_nocut[/*cfg.nIn*/], PFNeutralObj outallne[/*cfg.nIn*/], PFNeutralObj outselne[/*cfg.nOut*/], bool debug);
+void fwdlinpuppi_flt(const linpuppi_config &cfg, const HadCaloObj caloin[/*cfg.nIn*/], PFNeutralObj outallne_nocut[/*cfg.nIn*/], PFNeutralObj outallne[/*cfg.nIn*/], PFNeutralObj outselne[/*cfg.nOut*/], bool debug);
+
+#endif

--- a/L1Trigger/Phase2L1ParticleFlow/src/ref/linpuppi_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/ref/linpuppi_ref.h
@@ -54,7 +54,7 @@ struct linpuppi_config {
 };
 
 // charged
-void linpuppi_chs_ref(const linpuppi_config &cfg, z0_t pvZ0, const PFChargedObj pfch[/*cfg.nTrack*/], PFChargedObj outallch[/*cfg.nTrack*/]) ;
+void linpuppi_chs_ref(const linpuppi_config &cfg, z0_t pvZ0, const PFChargedObj pfch[/*cfg.nTrack*/], PFChargedObj outallch[/*cfg.nTrack*/], bool debug) ;
 
 // neutrals, in the tracker
 void linpuppi_flt(const linpuppi_config &cfg, const TkObj track[/*cfg.nTrack*/], z0_t pvZ0, const PFNeutralObj pfallne[/*cfg.nIn*/], PFNeutralObj outallne_nocut[/*cfg.nIn*/], PFNeutralObj outallne[/*cfg.nIn*/], PFNeutralObj outselne[/*cfg.nOut*/], bool debug) ;

--- a/L1Trigger/Phase2L1ParticleFlow/src/utils/DiscretePF2Firmware.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/utils/DiscretePF2Firmware.h
@@ -9,7 +9,7 @@
 namespace dpf2fw {
 
     // convert inputs from discrete to firmware
-    void convert(const l1tpf_impl::PropagatedTrack & in, TkObj &out) {
+    inline void convert(const l1tpf_impl::PropagatedTrack & in, TkObj &out) {
         out.hwPt = in.hwPt;
         out.hwPtErr = in.hwCaloPtErr;
         out.hwEta = in.hwEta; // @calo
@@ -18,31 +18,48 @@ namespace dpf2fw {
         out.hwTightQuality = (in.hwStubs >= 6 && in.hwChi2 < 500);
     }
 
-    TkObj transformConvert(const l1tpf_impl::PropagatedTrack & in) {
+    inline TkObj transformConvert(const l1tpf_impl::PropagatedTrack & in) {
         TkObj out;
         convert(in, out);
         return out;
     }
 
-    void convert(const l1tpf_impl::CaloCluster & in, HadCaloObj & out) {
+    inline void convert(const l1tpf_impl::CaloCluster & in, HadCaloObj & out) {
         out.hwPt = in.hwPt;
         out.hwEmPt = in.hwEmPt;
         out.hwEta = in.hwEta;
         out.hwPhi = in.hwPhi;
         out.hwIsEM = in.isEM;
     }
-    void convert(const l1tpf_impl::CaloCluster & in, EmCaloObj & out) {
+    inline void convert(const l1tpf_impl::CaloCluster & in, EmCaloObj & out) {
         out.hwPt = in.hwPt;
         out.hwPtErr = in.hwPtErr;
         out.hwEta = in.hwEta;
         out.hwPhi = in.hwPhi;
     }
-    void convert(const l1tpf_impl::Muon & in, MuObj & out) {
+    inline void convert(const l1tpf_impl::Muon & in, MuObj & out) {
         out.hwPt = in.hwPt;
         out.hwPtErr = 0; // does not exist in input
         out.hwEta = in.hwEta; // @calo
         out.hwPhi = in.hwPhi; // @calo
     }
+
+    inline void convert(const l1tpf_impl::PFParticle &src, PFChargedObj & pf) {
+        pf.hwPt = src.hwPt;
+        pf.hwEta = src.hwEta;
+        pf.hwPhi = src.hwPhi;
+        pf.hwId = src.hwId;
+        pf.hwZ0 = src.track.hwZ0;
+    }
+    inline void convert(const l1tpf_impl::PFParticle &src, PFNeutralObj & pf, bool isPuppi=false) {
+        pf.hwPt = src.hwPt;
+        pf.hwEta = src.hwEta;
+        pf.hwPhi = src.hwPhi;
+        pf.hwId = src.hwId;
+        pf.hwPtPuppi = isPuppi ? pt_t(src.hwPt) : pt_t(0);
+    }
+
+
 
     template<unsigned int NMAX, typename In, typename Out>
     void convert(const std::vector<In> & in, Out out[NMAX]) {

--- a/L1Trigger/Phase2L1ParticleFlow/src/utils/DiscretePF2Firmware.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/utils/DiscretePF2Firmware.h
@@ -48,14 +48,26 @@ namespace dpf2fw {
         pf.hwPt = src.hwPt;
         pf.hwEta = src.hwEta;
         pf.hwPhi = src.hwPhi;
-        pf.hwId = src.hwId;
+        switch(src.hwId) {
+            case 0: pf.hwId = PID_Charged; break;
+            case 1: pf.hwId = PID_Electron; break;
+            case 2: pf.hwId = PID_Neutral; break;
+            case 3: pf.hwId = PID_Photon; break;
+            case 4: pf.hwId = PID_Muon; break;
+        }
         pf.hwZ0 = src.track.hwZ0;
     }
     inline void convert(const l1tpf_impl::PFParticle &src, PFNeutralObj & pf, bool isPuppi=false) {
         pf.hwPt = src.hwPt;
         pf.hwEta = src.hwEta;
         pf.hwPhi = src.hwPhi;
-        pf.hwId = src.hwId;
+        switch(src.hwId) {
+            case 0: pf.hwId = PID_Charged; break;
+            case 1: pf.hwId = PID_Electron; break;
+            case 2: pf.hwId = PID_Neutral; break;
+            case 3: pf.hwId = PID_Photon; break;
+            case 4: pf.hwId = PID_Muon; break;
+        }
         pf.hwPtPuppi = isPuppi ? pt_t(src.hwPt) : pt_t(0);
     }
 

--- a/L1Trigger/Phase2L1ParticleFlow/src/utils/Firmware2DiscretePF.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/utils/Firmware2DiscretePF.h
@@ -69,6 +69,13 @@ namespace fw2dpf {
         pf.hwStatus = 0;
         out.push_back(pf);
     }
+    inline void convert_puppi(const PFNeutralObj & src, std::vector<l1tpf_impl::PFParticle> &out) {
+        convert(src, out);
+        out.back().hwPt = src.hwPtPuppi;
+        out.back().setPuppiW(out.back().hwPt/float(src.hwPt));
+    }
+
+
 
     // convert inputs from discrete to firmware
     inline void convert(const TkObj & in, l1tpf_impl::PropagatedTrack & out) {
@@ -114,6 +121,12 @@ namespace fw2dpf {
             if (in[i].hwPt > 0) convert(in[i], out);
         }
     } 
+    inline void convert_puppi(unsigned int NMAX, const PFNeutralObj in[], std::vector<l1tpf_impl::PFParticle> &out) {
+        for (unsigned int i = 0; i < NMAX; ++i) {
+            if (in[i].hwPtPuppi > 0) convert_puppi(in[i], out);
+        }
+    } 
+
     template<unsigned int NMAX>
     void convert(const PFChargedObj in[NMAX], std::vector<l1tpf_impl::PropagatedTrack> srctracks, std::vector<l1tpf_impl::PFParticle> &out) {
         for (unsigned int i = 0; i < NMAX; ++i) {


### PR DESCRIPTION
Module to allow running the HLS reference version of LinearizedPuppi into CMSSW
Presentation: https://indico.cern.ch/event/932700/contributions/3919387

Validation plot of overall trigger performance on larger stats: https://gpetrucc.web.cern.ch/gpetrucc/drop/plots/l1stage2/11_1_X/from110X/110X_v0.3/val 
  * "CMSS": standard CMSSW PF + Puppi, 
  * "Tuned:" CMSSW PF tuned match the firmware + Puppi
  * "Regional" Same as above but with regionizing
  * "BitwisePF": CMSSW PF replaced with BitwisePF (i.e. HLS), but default CMSSW Puppi
  * "Bitwise": Bitwise PF & Bitwise Puppi
Up to some statistical noise, no significant differences in performance seen.