### PR TITLE
Initial implementation of EG objects in correlator

### DIFF
--- a/DataFormats/L1TCorrelator/interface/TkEm.h
+++ b/DataFormats/L1TCorrelator/interface/TkEm.h
@@ -37,19 +37,30 @@ namespace l1t {
 
     const double l1RefEt() const { return egRef_->et(); }
 
-    float trkIsol() const { return trkIsol_; }  // not constrained to the PV, just track ptSum
-
-    float trkIsolPV() const { return trkIsolPV_; }  // constrained to the PV by DZ
+    float trkIsol() const { return trkIsol_; }          // not constrained to the PV, just track ptSum
+    float trkIsolPV() const { return trkIsolPV_; }      // constrained to the PV by DZ
+    float pfIsol() const { return pfIsol_; }            // not constrained to the PV, just track ptSum
+    float pfIsolPV() const { return pfIsolPV_; }        // constrained to the PV by DZ
+    float puppiIsol() const { return puppiIsol_; }      // not constrained to the PV, just track ptSum
+    float puppiIsolPV() const { return puppiIsolPV_; }  // constrained to the PV by DZ
 
     // ---------- member functions ---------------------------
 
     void setTrkIsol(float TrkIsol) { trkIsol_ = TrkIsol; }
     void setTrkIsolPV(float TrkIsolPV) { trkIsolPV_ = TrkIsolPV; }
+    void setPFIsol(float pfIsol) { pfIsol_ = pfIsol; }
+    void setPFIsolPV(float pfIsolPV) { pfIsolPV_ = pfIsolPV; }
+    void setPuppiIsol(float puppiIsol) { puppiIsol_ = puppiIsol; }
+    void setPuppiIsolPV(float puppiIsolPV) { puppiIsolPV_ = puppiIsolPV; }
 
   private:
     edm::Ref<EGammaBxCollection> egRef_;
     float trkIsol_;
     float trkIsolPV_;
+    float pfIsol_;
+    float pfIsolPV_;
+    float puppiIsol_;
+    float puppiIsolPV_;
   };
 }  // namespace l1t
 

--- a/DataFormats/L1TCorrelator/src/TkEm.cc
+++ b/DataFormats/L1TCorrelator/src/TkEm.cc
@@ -11,7 +11,14 @@ using namespace l1t;
 TkEm::TkEm() {}
 
 TkEm::TkEm(const LorentzVector& p4, const edm::Ref<EGammaBxCollection>& egRef, float tkisol)
-    : L1Candidate(p4), egRef_(egRef), trkIsol_(tkisol), trkIsolPV_(-999) {}
+    : TkEm(p4, egRef, tkisol, -999) {}
 
 TkEm::TkEm(const LorentzVector& p4, const edm::Ref<EGammaBxCollection>& egRef, float tkisol, float tkisolPV)
-    : L1Candidate(p4), egRef_(egRef), trkIsol_(tkisol), trkIsolPV_(tkisolPV) {}
+    : L1Candidate(p4),
+      egRef_(egRef),
+      trkIsol_(tkisol),
+      trkIsolPV_(tkisolPV),
+      pfIsol_(-999),
+      pfIsolPV_(-999),
+      puppiIsol_(-999),
+      puppiIsolPV_(-999) {}

--- a/DataFormats/L1TCorrelator/src/classes_def.xml
+++ b/DataFormats/L1TCorrelator/src/classes_def.xml
@@ -15,7 +15,8 @@
  <class name="edm::Wrapper<l1t::TkEtMiss>"/>
   <class name="edm::Wrapper<std::vector<l1t::TkEtMiss> >"/>
 
-  <class name="l1t::TkEm" ClassVersion="3">
+  <class name="l1t::TkEm" ClassVersion="4">
+   <version ClassVersion="4" checksum="1043577432"/>
    <version ClassVersion="3" checksum="2161257944"/>
   </class>
   <class name="std::vector<l1t::TkEm>"/>
@@ -43,7 +44,8 @@
   <class name="edm::Wrapper<std::vector<l1t::L1CaloTkTau> >"/>
   <class name="edm::Ref<std::vector<l1t::L1CaloTkTau>,l1t::L1CaloTkTau,edm::refhelper::FindUsingAdvance<std::vector<l1t::L1CaloTkTau>,l1t::L1CaloTkTau> >"/>
 
-  <class name="l1t::TkElectron" ClassVersion="3">
+  <class name="l1t::TkElectron" ClassVersion="4">
+   <version ClassVersion="4" checksum="3922083203"/>
    <version ClassVersion="3" checksum="3970647299"/>
   </class>
   <class name="std::vector<l1t::TkElectron>"/>

--- a/L1Trigger/Phase2L1ParticleFlow/BuildFile.xml
+++ b/L1Trigger/Phase2L1ParticleFlow/BuildFile.xml
@@ -2,6 +2,8 @@
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>
 <use name="DataFormats/L1TParticleFlow"/>
+<use name="DataFormats/L1TCorrelator"/>
+
 <use name="CommonTools/BaseParticlePropagator"/>
 <use name="FastSimulation/Particle"/>
 <use name="DataFormats/ParticleFlowReco"/>

--- a/L1Trigger/Phase2L1ParticleFlow/interface/DiscretePFInputs.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/DiscretePFInputs.h
@@ -220,8 +220,6 @@ namespace l1tpf_impl {
 #endif
   };
 
-
-
   struct EGParticle {
     int16_t hwPt;
     int16_t hwEta;  // at calo face
@@ -234,14 +232,13 @@ namespace l1tpf_impl {
     // sorting
     bool operator<(const EGParticle &other) const { return hwPt > other.hwPt; }
 
-    #ifdef L1Trigger_Phase2L1ParticleFlow_DiscretePFInputs_MORE
-      static constexpr float ISO_SCALE = 100;
-      void setFloatPt(float pt) { hwPt = round(pt * CaloCluster::PT_SCALE); }
-      float floatPt() const { return float(hwPt) / CaloCluster::PT_SCALE; }
-      float floatEta() const { return float(hwEta) / CaloCluster::ETAPHI_SCALE; }
-      float floatPhi() const { return float(hwPhi) / CaloCluster::ETAPHI_SCALE; }
-    #endif
-
+#ifdef L1Trigger_Phase2L1ParticleFlow_DiscretePFInputs_MORE
+    static constexpr float ISO_SCALE = 100;
+    void setFloatPt(float pt) { hwPt = round(pt * CaloCluster::PT_SCALE); }
+    float floatPt() const { return float(hwPt) / CaloCluster::PT_SCALE; }
+    float floatEta() const { return float(hwEta) / CaloCluster::ETAPHI_SCALE; }
+    float floatPhi() const { return float(hwPhi) / CaloCluster::ETAPHI_SCALE; }
+#endif
   };
 
   struct EGIso {
@@ -249,35 +246,29 @@ namespace l1tpf_impl {
     uint16_t hwIso;
     uint16_t hwPFIso;
 
-    #ifdef L1Trigger_Phase2L1ParticleFlow_DiscretePFInputs_MORE
-      void setIso(float iso, uint16_t &hwIso) {
-        hwIso = round(iso * EGParticle::ISO_SCALE);
-      }
-      void setIso(float iso) { setIso(iso, hwIso);}
-      void setPFIso(float iso) { setIso(iso, hwPFIso);}
+#ifdef L1Trigger_Phase2L1ParticleFlow_DiscretePFInputs_MORE
+    void setIso(float iso, uint16_t &hwIso) { hwIso = round(iso * EGParticle::ISO_SCALE); }
+    void setIso(float iso) { setIso(iso, hwIso); }
+    void setPFIso(float iso) { setIso(iso, hwPFIso); }
 
-      float getFloatIso(uint16_t hwIso) const {
-        return float(hwIso) / EGParticle::ISO_SCALE;
-      }
-      float floatIso() const { return getFloatIso(hwIso); }
-      float floatPFIso() const { return getFloatIso(hwPFIso); }
-    #endif
-
+    float getFloatIso(uint16_t hwIso) const { return float(hwIso) / EGParticle::ISO_SCALE; }
+    float floatIso() const { return getFloatIso(hwIso); }
+    float floatPFIso() const { return getFloatIso(hwPFIso); }
+#endif
   };
 
   struct EGIsoPV : public EGIso {
     uint16_t hwIsoPV;
     uint16_t hwPFIsoPV;
 
-    #ifdef L1Trigger_Phase2L1ParticleFlow_DiscretePFInputs_MORE
-      void setIsoPV(float iso) { setIso(iso, hwIsoPV);}
-      void setPFIsoPV(float iso) { setIso(iso, hwPFIsoPV);}
+#ifdef L1Trigger_Phase2L1ParticleFlow_DiscretePFInputs_MORE
+    void setIsoPV(float iso) { setIso(iso, hwIsoPV); }
+    void setPFIsoPV(float iso) { setIso(iso, hwPFIsoPV); }
 
-      float floatIsoPV() const { return getFloatIso(hwIsoPV); }
-      float floatPFIsoPV() const { return getFloatIso(hwPFIsoPV); }
-    #endif
+    float floatIsoPV() const { return getFloatIso(hwIsoPV); }
+    float floatPFIsoPV() const { return getFloatIso(hwPFIsoPV); }
+#endif
   };
-
 
   struct EGIsoEleParticle : public EGParticle, public EGIso {
     // track parameters for electrons
@@ -287,25 +278,22 @@ namespace l1tpf_impl {
     bool hwCharge;
     PropagatedTrack track;
 
-    #ifdef L1Trigger_Phase2L1ParticleFlow_DiscretePFInputs_MORE
+#ifdef L1Trigger_Phase2L1ParticleFlow_DiscretePFInputs_MORE
 
-      float floatVtxEta() const { return float(hwVtxEta) / CaloCluster::ETAPHI_SCALE; }
-      float floatVtxPhi() const { return float(hwVtxPhi) / CaloCluster::ETAPHI_SCALE; }
-      float floatDZ() const { return float(track.hwZ0) / InputTrack::Z0_SCALE; }
-      int intCharge() const { return hwCharge ? +1 : -1; }
+    float floatVtxEta() const { return float(hwVtxEta) / CaloCluster::ETAPHI_SCALE; }
+    float floatVtxPhi() const { return float(hwVtxPhi) / CaloCluster::ETAPHI_SCALE; }
+    float floatDZ() const { return float(track.hwZ0) / InputTrack::Z0_SCALE; }
+    int intCharge() const { return hwCharge ? +1 : -1; }
 
-    #endif
-
-    };
+#endif
+  };
 
   struct EGIsoParticle : public EGParticle, public EGIsoPV {
-
-    #ifdef L1Trigger_Phase2L1ParticleFlow_DiscretePFInputs_MORE
-      // NOTE: this is needed because of CMSSW requirements
-      // i.e. we need to put the EG object and the TkEm and TkEle ones at the same time to have a valid ref
-      int ele_idx;
-    #endif
-
+#ifdef L1Trigger_Phase2L1ParticleFlow_DiscretePFInputs_MORE
+    // NOTE: this is needed because of CMSSW requirements
+    // i.e. we need to put the EG object and the TkEm and TkEle ones at the same time to have a valid ref
+    int ele_idx;
+#endif
   };
 
   struct InputRegion {

--- a/L1Trigger/Phase2L1ParticleFlow/interface/DiscretePFInputs.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/DiscretePFInputs.h
@@ -233,7 +233,6 @@ namespace l1tpf_impl {
     bool operator<(const EGParticle &other) const { return hwPt > other.hwPt; }
 
 #ifdef L1Trigger_Phase2L1ParticleFlow_DiscretePFInputs_MORE
-    static constexpr float ISO_SCALE = 100;
     void setFloatPt(float pt) { hwPt = round(pt * CaloCluster::PT_SCALE); }
     float floatPt() const { return float(hwPt) / CaloCluster::PT_SCALE; }
     float floatEta() const { return float(hwEta) / CaloCluster::ETAPHI_SCALE; }
@@ -247,11 +246,12 @@ namespace l1tpf_impl {
     uint16_t hwPFIso;
 
 #ifdef L1Trigger_Phase2L1ParticleFlow_DiscretePFInputs_MORE
-    void setIso(float iso, uint16_t &hwIso) { hwIso = round(iso * EGParticle::ISO_SCALE); }
+    static constexpr float ISO_SCALE = 100;
+    void setIso(float iso, uint16_t &hwIso) { hwIso = round(iso * EGIso::ISO_SCALE); }
     void setIso(float iso) { setIso(iso, hwIso); }
     void setPFIso(float iso) { setIso(iso, hwPFIso); }
 
-    float getFloatIso(uint16_t hwIso) const { return float(hwIso) / EGParticle::ISO_SCALE; }
+    float getFloatIso(uint16_t hwIso) const { return float(hwIso) / EGIso::ISO_SCALE; }
     float floatIso() const { return getFloatIso(hwIso); }
     float floatPFIso() const { return getFloatIso(hwPFIso); }
 #endif

--- a/L1Trigger/Phase2L1ParticleFlow/interface/DiscretePFInputs.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/DiscretePFInputs.h
@@ -280,8 +280,8 @@ namespace l1tpf_impl {
 
 #ifdef L1Trigger_Phase2L1ParticleFlow_DiscretePFInputs_MORE
 
-    float floatVtxEta() const { return float(hwVtxEta) / CaloCluster::ETAPHI_SCALE; }
-    float floatVtxPhi() const { return float(hwVtxPhi) / CaloCluster::ETAPHI_SCALE; }
+    float floatVtxEta() const { return float(hwVtxEta) / InputTrack::VTX_ETA_SCALE; }
+    float floatVtxPhi() const { return float(hwVtxPhi) / InputTrack::VTX_PHI_SCALE; }
     float floatDZ() const { return float(track.hwZ0) / InputTrack::Z0_SCALE; }
     int intCharge() const { return hwCharge ? +1 : -1; }
 

--- a/L1Trigger/Phase2L1ParticleFlow/interface/DiscretePFInputs.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/DiscretePFInputs.h
@@ -220,6 +220,94 @@ namespace l1tpf_impl {
 #endif
   };
 
+
+
+  struct EGParticle {
+    int16_t hwPt;
+    int16_t hwEta;  // at calo face
+    int16_t hwPhi;
+    uint16_t hwQual;
+
+    // FIXME: an index would also do...
+    CaloCluster cluster;
+
+    // sorting
+    bool operator<(const EGParticle &other) const { return hwPt > other.hwPt; }
+
+    #ifdef L1Trigger_Phase2L1ParticleFlow_DiscretePFInputs_MORE
+      static constexpr float ISO_SCALE = 100;
+      void setFloatPt(float pt) { hwPt = round(pt * CaloCluster::PT_SCALE); }
+      float floatPt() const { return float(hwPt) / CaloCluster::PT_SCALE; }
+      float floatEta() const { return float(hwEta) / CaloCluster::ETAPHI_SCALE; }
+      float floatPhi() const { return float(hwPhi) / CaloCluster::ETAPHI_SCALE; }
+    #endif
+
+  };
+
+  struct EGIso {
+    // FIXME: eventually only one iso will be saved
+    uint16_t hwIso;
+    uint16_t hwPFIso;
+
+    #ifdef L1Trigger_Phase2L1ParticleFlow_DiscretePFInputs_MORE
+      void setIso(float iso, uint16_t &hwIso) {
+        hwIso = round(iso * EGParticle::ISO_SCALE);
+      }
+      void setIso(float iso) { setIso(iso, hwIso);}
+      void setPFIso(float iso) { setIso(iso, hwPFIso);}
+
+      float getFloatIso(uint16_t hwIso) const {
+        return float(hwIso) / EGParticle::ISO_SCALE;
+      }
+      float floatIso() const { return getFloatIso(hwIso); }
+      float floatPFIso() const { return getFloatIso(hwPFIso); }
+    #endif
+
+  };
+
+  struct EGIsoPV : public EGIso {
+    uint16_t hwIsoPV;
+    uint16_t hwPFIsoPV;
+
+    #ifdef L1Trigger_Phase2L1ParticleFlow_DiscretePFInputs_MORE
+      void setIsoPV(float iso) { setIso(iso, hwIsoPV);}
+      void setPFIsoPV(float iso) { setIso(iso, hwPFIsoPV);}
+
+      float floatIsoPV() const { return getFloatIso(hwIsoPV); }
+      float floatPFIsoPV() const { return getFloatIso(hwPFIsoPV); }
+    #endif
+  };
+
+
+  struct EGIsoEleParticle : public EGParticle, public EGIso {
+    // track parameters for electrons
+    int16_t hwVtxEta;
+    int16_t hwVtxPhi;
+    int16_t hwZ0;
+    bool hwCharge;
+    PropagatedTrack track;
+
+    #ifdef L1Trigger_Phase2L1ParticleFlow_DiscretePFInputs_MORE
+
+      float floatVtxEta() const { return float(hwVtxEta) / CaloCluster::ETAPHI_SCALE; }
+      float floatVtxPhi() const { return float(hwVtxPhi) / CaloCluster::ETAPHI_SCALE; }
+      float floatDZ() const { return float(track.hwZ0) / InputTrack::Z0_SCALE; }
+      int intCharge() const { return hwCharge ? +1 : -1; }
+
+    #endif
+
+    };
+
+  struct EGIsoParticle : public EGParticle, public EGIsoPV {
+
+    #ifdef L1Trigger_Phase2L1ParticleFlow_DiscretePFInputs_MORE
+      // NOTE: this is needed because of CMSSW requirements
+      // i.e. we need to put the EG object and the TkEm and TkEle ones at the same time to have a valid ref
+      int ele_idx;
+    #endif
+
+  };
+
   struct InputRegion {
     float etaCenter, etaMin, etaMax, phiCenter, phiHalfWidth;
     float etaExtra, phiExtra;

--- a/L1Trigger/Phase2L1ParticleFlow/interface/PFTkEGAlgo.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/PFTkEGAlgo.h
@@ -110,12 +110,11 @@ namespace l1tpf_impl {
           if (tk.intCharge() != 0 && std::abs(tk.floatDZ() - egele.floatDZ()) > params.dZ)
             continue;
 
-
           float d_phi = deltaPhi(tk.floatVtxPhi(), egele.floatVtxPhi());
           float d_eta = tk.floatVtxEta() - egele.floatVtxEta();
           float dR2 = d_phi * d_phi + d_eta * d_eta;
 
-          if (dR2 > params.dRMin2 && dR2 < params.dRMax2){
+          if (dR2 > params.dRMin2 && dR2 < params.dRMax2) {
             sumPt += tk.floatPt();
           }
         }
@@ -129,11 +128,7 @@ namespace l1tpf_impl {
 
     void eg_algo(Region &r, const std::vector<int> &emCalo2emCalo, const std::vector<int> &emCalo2tk) const;
 
-    void addEgObjsToPF(Region &r,
-                       const int calo_idx,
-                       const int hwQual,
-                       const float ptCorr,
-                       const int tk_idx = -1) const;
+    void addEgObjsToPF(Region &r, const int calo_idx, const int hwQual, const float ptCorr, const int tk_idx = -1) const;
 
     EGIsoParticle &addEGIsoToPF(std::vector<EGIsoParticle> &egobjs,
                                 const CaloCluster &calo,
@@ -145,7 +140,6 @@ namespace l1tpf_impl {
                                       const PropagatedTrack &track,
                                       const int hwQual,
                                       const float ptCorr) const;
-
   };
 
 }  // namespace l1tpf_impl

--- a/L1Trigger/Phase2L1ParticleFlow/interface/PFTkEGAlgo.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/PFTkEGAlgo.h
@@ -1,0 +1,32 @@
+#ifndef L1Trigger_Phase2L1ParticleFlow_PFTkEGAlgo_h
+#define L1Trigger_Phase2L1ParticleFlow_PFTkEGAlgo_h
+
+#include <algorithm>
+
+#include "L1Trigger/Phase2L1ParticleFlow/interface/Region.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+namespace l1tpf_impl {
+
+  class PFTkEGAlgo {
+  public:
+    PFTkEGAlgo(const edm::ParameterSet &);
+    virtual ~PFTkEGAlgo();
+    void runTkEG(Region &r) const;
+
+  protected:
+    int debug_;
+
+    void initRegion(Region &r) const;
+    void link_emCalo2emCalo(Region &r, std::vector<int> &emCalo2emCalo) const;
+    void link_emCalo2tk(Region &r, std::vector<int> &emCalo2tk) const;
+
+    void eg_algo(Region &r, const std::vector<int> &emCalo2emCalo, const std::vector<int> &emCalo2tk) const;
+
+    l1tpf_impl::EgObjectIndexer& addEgObjsToPF(std::vector<l1tpf_impl::EgObjectIndexer> egobjs,
+                                               const int calo_idx, const int hwQual, const float ptCorr = -1, const int tk_idx = -1, const float iso = -1) const;
+  };
+
+}  // namespace l1tpf_impl
+
+#endif

--- a/L1Trigger/Phase2L1ParticleFlow/interface/PFTkEGAlgo.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/PFTkEGAlgo.h
@@ -15,9 +15,7 @@ namespace l1tpf_impl {
     virtual ~PFTkEGAlgo();
     void runTkEG(Region &r) const;
 
-    bool writeEgSta() const {
-      return writeEgSta_;
-    }
+    bool writeEgSta() const { return writeEgSta_; }
 
   protected:
     int debug_;

--- a/L1Trigger/Phase2L1ParticleFlow/interface/PFTkEGAlgo.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/PFTkEGAlgo.h
@@ -14,12 +14,27 @@ namespace l1tpf_impl {
     PFTkEGAlgo(const edm::ParameterSet &);
     virtual ~PFTkEGAlgo();
     void runTkEG(Region &r) const;
+    void runTkIso(Region &r, const float z0) const;
+    void runPFIso(Region &r, const float z0) const;
 
     bool writeEgSta() const { return writeEgSta_; }
 
   protected:
+    struct IsoParameters {
+      IsoParameters(const edm::ParameterSet &);
+      float tkQualityPtMin;
+      float dZ;
+      float dRMin;
+      float dRMax;
+      float tkQualityChi2Max;
+      float dRMin2;
+      float dRMax2;
+      ;
+    };
+
     int debug_;
     bool doBremRecovery_;
+    bool doTkIsolation_;
     bool filterHwQuality_;
     int caloHwQual_;
     float dEtaMaxBrem_;
@@ -31,10 +46,88 @@ namespace l1tpf_impl {
     float trkQualityPtMin_;
     float trkQualityChi2_;
     bool writeEgSta_;
+    IsoParameters tkIsoParametersTkEm_;
+    IsoParameters tkIsoParametersTkEle_;
+    IsoParameters pfIsoParametersTkEm_;
+    IsoParameters pfIsoParametersTkEle_;
 
     void initRegion(Region &r) const;
     void link_emCalo2emCalo(Region &r, std::vector<int> &emCalo2emCalo) const;
     void link_emCalo2tk(Region &r, std::vector<int> &emCalo2tk) const;
+
+    template <typename T>
+    void compute_isolation_tkEm(
+        Region &r, const std::vector<T> &objects, const IsoParameters &params, const float z0, bool isPF) const {
+      for (int ic = 0, nc = r.egobjs.size(); ic < nc; ++ic) {
+        auto &egidxer = r.egobjs[ic];
+        const auto &calo = r.emcalo[egidxer.emCaloIdx];
+
+        float sumPt = 0.;
+        float sumPtPV = 0.;
+
+        for (int itk = 0, ntk = objects.size(); itk < ntk; ++itk) {
+          const auto &tk = objects[itk];
+
+          if (tk.floatPt() < params.tkQualityPtMin)
+            continue;
+
+          float d_phi = deltaPhi(tk.floatPhi(), calo.floatPhi());
+          float d_eta = tk.floatEta() - calo.floatEta();
+          float dR2 = d_phi * d_phi + d_eta * d_eta;
+
+          if (dR2 > params.dRMin2 && dR2 < params.dRMax2) {
+            sumPt += tk.floatPt();
+            if (std::abs(tk.floatDZ() - z0) > params.dZ)
+              sumPtPV += tk.floatPt();
+          }
+        }
+        if (isPF) {
+          egidxer.iso = sumPt / egidxer.ptcorr;
+          egidxer.isoPV = sumPt / egidxer.ptcorr;
+        } else {
+          egidxer.pfIso = sumPt / egidxer.ptcorr;
+          egidxer.pfIsoPV = sumPt / egidxer.ptcorr;
+        }
+      }
+    }
+
+    template <typename T>
+    void compute_isolation_tkEle(
+        Region &r, const std::vector<T> &objects, const IsoParameters &params, const float z0, bool isPF) const {
+      for (int ic = 0, nc = r.egobjs.size(); ic < nc; ++ic) {
+        auto &egidxer = r.egobjs[ic];
+
+        if (egidxer.tkIdx == -1)
+          continue;
+
+        const auto &calo = r.emcalo[egidxer.emCaloIdx];
+
+        float dz_ref = r.track[egidxer.tkIdx].floatDZ();
+        float sumPt = 0.;
+
+        for (int itk = 0, ntk = objects.size(); itk < ntk; ++itk) {
+          const auto &tk = objects[itk];
+
+          if (tk.floatPt() < params.tkQualityPtMin)
+            continue;
+
+          if (std::abs(tk.floatDZ() - dz_ref) > params.dZ)
+            continue;
+
+          float d_phi = deltaPhi(tk.floatPhi(), calo.floatPhi());
+          float d_eta = tk.floatEta() - calo.floatEta();
+          float dR2 = d_phi * d_phi + d_eta * d_eta;
+
+          if (dR2 > params.dRMin2 && dR2 < params.dRMax2)
+            sumPt += tk.floatPt();
+        }
+        if (isPF) {
+          egidxer.pfIsoDZ = sumPt / egidxer.ptcorr;
+        } else {
+          egidxer.isoDZ = sumPt / egidxer.ptcorr;
+        }
+      }
+    }
 
     void eg_algo(Region &r, const std::vector<int> &emCalo2emCalo, const std::vector<int> &emCalo2tk) const;
 
@@ -42,8 +135,7 @@ namespace l1tpf_impl {
                                                const int calo_idx,
                                                const int hwQual,
                                                const float ptCorr = -1,
-                                               const int tk_idx = -1,
-                                               const float iso = -1) const;
+                                               const int tk_idx = -1) const;
   };
 
 }  // namespace l1tpf_impl

--- a/L1Trigger/Phase2L1ParticleFlow/interface/PFTkEGAlgo.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/PFTkEGAlgo.h
@@ -2,6 +2,7 @@
 #define L1Trigger_Phase2L1ParticleFlow_PFTkEGAlgo_h
 
 #include <algorithm>
+#include <vector>
 
 #include "L1Trigger/Phase2L1ParticleFlow/interface/Region.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -14,8 +15,24 @@ namespace l1tpf_impl {
     virtual ~PFTkEGAlgo();
     void runTkEG(Region &r) const;
 
+    bool writeEgSta() const {
+      return writeEgSta_;
+    }
+
   protected:
     int debug_;
+    bool doBremRecovery_;
+    bool filterHwQuality_;
+    int caloHwQual_;
+    float dEtaMaxBrem_;
+    float dPhiMaxBrem_;
+    std::vector<double> absEtaBoundaries_;
+    std::vector<double> dEtaValues_;
+    std::vector<double> dPhiValues_;
+    float caloEtMin_;
+    float trkQualityPtMin_;
+    float trkQualityChi2_;
+    bool writeEgSta_;
 
     void initRegion(Region &r) const;
     void link_emCalo2emCalo(Region &r, std::vector<int> &emCalo2emCalo) const;
@@ -23,7 +40,7 @@ namespace l1tpf_impl {
 
     void eg_algo(Region &r, const std::vector<int> &emCalo2emCalo, const std::vector<int> &emCalo2tk) const;
 
-    l1tpf_impl::EgObjectIndexer &addEgObjsToPF(std::vector<l1tpf_impl::EgObjectIndexer> egobjs,
+    l1tpf_impl::EgObjectIndexer &addEgObjsToPF(std::vector<l1tpf_impl::EgObjectIndexer> &egobjs,
                                                const int calo_idx,
                                                const int hwQual,
                                                const float ptCorr = -1,

--- a/L1Trigger/Phase2L1ParticleFlow/interface/PFTkEGAlgo.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/PFTkEGAlgo.h
@@ -23,8 +23,12 @@ namespace l1tpf_impl {
 
     void eg_algo(Region &r, const std::vector<int> &emCalo2emCalo, const std::vector<int> &emCalo2tk) const;
 
-    l1tpf_impl::EgObjectIndexer& addEgObjsToPF(std::vector<l1tpf_impl::EgObjectIndexer> egobjs,
-                                               const int calo_idx, const int hwQual, const float ptCorr = -1, const int tk_idx = -1, const float iso = -1) const;
+    l1tpf_impl::EgObjectIndexer &addEgObjsToPF(std::vector<l1tpf_impl::EgObjectIndexer> egobjs,
+                                               const int calo_idx,
+                                               const int hwQual,
+                                               const float ptCorr = -1,
+                                               const int tk_idx = -1,
+                                               const float iso = -1) const;
   };
 
 }  // namespace l1tpf_impl

--- a/L1Trigger/Phase2L1ParticleFlow/interface/Region.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/Region.h
@@ -6,40 +6,11 @@
 
 namespace l1tpf_impl {
 
-  // FIXME: this is temporary, to be substituted with proper EG objects
-  struct EgObjectIndexer {
-    EgObjectIndexer(int emCaloIdx,
-                    int hwQual,
-                    float ptcorr,
-                    int tkIdx = -1)
-        : emCaloIdx(emCaloIdx),
-          hwQual(hwQual),
-          tkIdx(tkIdx),
-          ptcorr(ptcorr),
-          iso(-1),
-          isoPV(-1),
-          isoDZ(-1),
-          pfIso(-1),
-          pfIsoPV(-1),
-          pfIsoDZ(-1) {}
-
-    int emCaloIdx;
-    int hwQual;
-    int tkIdx;
-    float ptcorr;
-    float iso; // iso using all tks
-    float isoPV; // iso using tks compatible with PV
-    float isoDZ; // iso using tks compatible with mathed Tk (for TkElectrons only)
-    float pfIso; // iso using all PF cands
-    float pfIsoPV; // iso using PF cands compatible with PV
-    float pfIsoDZ; // iso using PF cands compatible with mathed Tk (for TkElectrons only)
-
-  };
-
   struct Region : public InputRegion {
     std::vector<PFParticle> pf;
     std::vector<PFParticle> puppi;
-    std::vector<l1tpf_impl::EgObjectIndexer> egobjs;
+    std::vector<EGIsoEleParticle> egeles;
+    std::vector<EGIsoParticle> egphotons;
 
     unsigned int caloOverflow, emcaloOverflow, trackOverflow, muonOverflow, pfOverflow, puppiOverflow;
 
@@ -61,7 +32,8 @@ namespace l1tpf_impl {
         : InputRegion(0.5 * (etamin + etamax), etamin, etamax, phicenter, 0.5 * phiwidth, etaextra, phiextra),
           pf(),
           puppi(),
-          egobjs(),
+          egeles(),
+          egphotons(),
           caloOverflow(),
           emcaloOverflow(),
           trackOverflow(),
@@ -130,7 +102,8 @@ namespace l1tpf_impl {
       muon.clear();
       pf.clear();
       puppi.clear();
-      egobjs.clear();
+      egeles.clear();
+      egphotons.clear();
       caloOverflow = 0;
       emcaloOverflow = 0;
       trackOverflow = 0;

--- a/L1Trigger/Phase2L1ParticleFlow/interface/Region.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/Region.h
@@ -4,10 +4,30 @@
 #include "L1Trigger/Phase2L1ParticleFlow/interface/DiscretePFInputs.h"
 #include "DataFormats/Math/interface/deltaPhi.h"
 
+
 namespace l1tpf_impl {
+
+  struct EgObjectIndexer {
+    EgObjectIndexer(int emCaloIdx, int hwQual, float ptcorr, int tkIdx = -1, float iso = -1)
+    : emCaloIdx(emCaloIdx),
+      hwQual(hwQual),
+      tkIdx(tkIdx),
+      ptcorr(ptcorr),
+      iso(iso) {}
+
+    int emCaloIdx;
+    int hwQual;
+    int tkIdx;
+    float ptcorr;
+    float iso;
+  };
+
+
   struct Region : public InputRegion {
     std::vector<PFParticle> pf;
     std::vector<PFParticle> puppi;
+    std::vector<l1tpf_impl::EgObjectIndexer> egobjs;
+
     unsigned int caloOverflow, emcaloOverflow, trackOverflow, muonOverflow, pfOverflow, puppiOverflow;
 
     const bool relativeCoordinates;  // whether the eta,phi in each region are global or relative to the region center
@@ -28,6 +48,7 @@ namespace l1tpf_impl {
         : InputRegion(0.5 * (etamin + etamax), etamin, etamax, phicenter, 0.5 * phiwidth, etaextra, phiextra),
           pf(),
           puppi(),
+          egobjs(),
           caloOverflow(),
           emcaloOverflow(),
           trackOverflow(),
@@ -96,6 +117,7 @@ namespace l1tpf_impl {
       muon.clear();
       pf.clear();
       puppi.clear();
+      egobjs.clear();
       caloOverflow = 0;
       emcaloOverflow = 0;
       trackOverflow = 0;

--- a/L1Trigger/Phase2L1ParticleFlow/interface/Region.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/Region.h
@@ -6,15 +6,34 @@
 
 namespace l1tpf_impl {
 
+  // FIXME: this is temporary, to be substituted with proper EG objects
   struct EgObjectIndexer {
-    EgObjectIndexer(int emCaloIdx, int hwQual, float ptcorr, int tkIdx = -1, float iso = -1)
-        : emCaloIdx(emCaloIdx), hwQual(hwQual), tkIdx(tkIdx), ptcorr(ptcorr), iso(iso) {}
+    EgObjectIndexer(int emCaloIdx,
+                    int hwQual,
+                    float ptcorr,
+                    int tkIdx = -1)
+        : emCaloIdx(emCaloIdx),
+          hwQual(hwQual),
+          tkIdx(tkIdx),
+          ptcorr(ptcorr),
+          iso(-1),
+          isoPV(-1),
+          isoDZ(-1),
+          pfIso(-1),
+          pfIsoPV(-1),
+          pfIsoDZ(-1) {}
 
     int emCaloIdx;
     int hwQual;
     int tkIdx;
     float ptcorr;
-    float iso;
+    float iso; // iso using all tks
+    float isoPV; // iso using tks compatible with PV
+    float isoDZ; // iso using tks compatible with mathed Tk (for TkElectrons only)
+    float pfIso; // iso using all PF cands
+    float pfIsoPV; // iso using PF cands compatible with PV
+    float pfIsoDZ; // iso using PF cands compatible with mathed Tk (for TkElectrons only)
+
   };
 
   struct Region : public InputRegion {

--- a/L1Trigger/Phase2L1ParticleFlow/interface/Region.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/Region.h
@@ -4,16 +4,11 @@
 #include "L1Trigger/Phase2L1ParticleFlow/interface/DiscretePFInputs.h"
 #include "DataFormats/Math/interface/deltaPhi.h"
 
-
 namespace l1tpf_impl {
 
   struct EgObjectIndexer {
     EgObjectIndexer(int emCaloIdx, int hwQual, float ptcorr, int tkIdx = -1, float iso = -1)
-    : emCaloIdx(emCaloIdx),
-      hwQual(hwQual),
-      tkIdx(tkIdx),
-      ptcorr(ptcorr),
-      iso(iso) {}
+        : emCaloIdx(emCaloIdx), hwQual(hwQual), tkIdx(tkIdx), ptcorr(ptcorr), iso(iso) {}
 
     int emCaloIdx;
     int hwQual;
@@ -21,7 +16,6 @@ namespace l1tpf_impl {
     float ptcorr;
     float iso;
   };
-
 
   struct Region : public InputRegion {
     std::vector<PFParticle> pf;

--- a/L1Trigger/Phase2L1ParticleFlow/interface/RegionMapper.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/RegionMapper.h
@@ -40,8 +40,13 @@ namespace l1tpf_impl {
     std::unique_ptr<l1t::PFCandidateCollection> fetch(bool puppi = true, float ptMin = 0.01) const;
     std::unique_ptr<l1t::PFCandidateCollection> fetchCalo(float ptMin = 0.01, bool emcalo = false) const;
     std::unique_ptr<l1t::PFCandidateCollection> fetchTracks(float ptMin = 0.01, bool fromPV = false) const;
-    // FIXME: refine interface as needed
-    void putEgObjects(edm::Event &iEvent, std::string egLablel, std::string tkEmLabel, std::string tkEleLabel) const;
+
+    void putEgObjects(edm::Event &iEvent,
+                      const bool writeEgSta,
+                      const std::string &egLablel,
+                      const std::string &tkEmLabel,
+                      const std::string &tkEleLabel,
+                      const float ptMin = 0.01) const;
 
     std::pair<unsigned, unsigned> totAndMaxInput(/*Region::InputType*/ int type) const;
     std::pair<unsigned, unsigned> totAndMaxOutput(/*Region::OutputType*/ int type, bool puppi) const;

--- a/L1Trigger/Phase2L1ParticleFlow/interface/RegionMapper.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/RegionMapper.h
@@ -41,7 +41,7 @@ namespace l1tpf_impl {
     std::unique_ptr<l1t::PFCandidateCollection> fetchCalo(float ptMin = 0.01, bool emcalo = false) const;
     std::unique_ptr<l1t::PFCandidateCollection> fetchTracks(float ptMin = 0.01, bool fromPV = false) const;
     // FIXME: refine interface as needed
-    void putEgObjects(edm::Event& iEvent, std::string egLablel, std::string tkEmLabel, std::string tkEleLabel) const;
+    void putEgObjects(edm::Event &iEvent, std::string egLablel, std::string tkEmLabel, std::string tkEleLabel) const;
 
     std::pair<unsigned, unsigned> totAndMaxInput(/*Region::InputType*/ int type) const;
     std::pair<unsigned, unsigned> totAndMaxOutput(/*Region::OutputType*/ int type, bool puppi) const;

--- a/L1Trigger/Phase2L1ParticleFlow/interface/RegionMapper.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/RegionMapper.h
@@ -11,6 +11,10 @@
 
 #include <unordered_map>
 
+namespace edm {
+  class Event;
+}
+
 namespace l1tpf_impl {
   class RegionMapper {
     // This does the input and filling of regions.
@@ -36,6 +40,8 @@ namespace l1tpf_impl {
     std::unique_ptr<l1t::PFCandidateCollection> fetch(bool puppi = true, float ptMin = 0.01) const;
     std::unique_ptr<l1t::PFCandidateCollection> fetchCalo(float ptMin = 0.01, bool emcalo = false) const;
     std::unique_ptr<l1t::PFCandidateCollection> fetchTracks(float ptMin = 0.01, bool fromPV = false) const;
+    // FIXME: refine interface as needed
+    void putEgObjects(edm::Event& iEvent, std::string egLablel, std::string tkEmLabel, std::string tkEleLabel) const;
 
     std::pair<unsigned, unsigned> totAndMaxInput(/*Region::InputType*/ int type) const;
     std::pair<unsigned, unsigned> totAndMaxOutput(/*Region::OutputType*/ int type, bool puppi) const;

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TPFProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TPFProducer.cc
@@ -126,11 +126,6 @@ L1TPFProducer::L1TPFProducer(const edm::ParameterSet& iConfig)
   produces<l1t::PFCandidateCollection>("TK");
   produces<l1t::PFCandidateCollection>("TKVtx");
 
-  // FIXME: should this be conditional to running the right algorithm?
-  produces<BXVector<l1t::EGamma>>("L1Eg");
-  produces<l1t::TkElectronCollection>("L1TkEle");
-  produces<l1t::TkEmCollection>("L1TkEm");
-
   produces<float>("z0");
 
   for (const auto& tag : iConfig.getParameter<std::vector<edm::InputTag>>("emClusters")) {
@@ -158,14 +153,11 @@ L1TPFProducer::L1TPFProducer(const edm::ParameterSet& iConfig)
   } else
     throw cms::Exception("Configuration", "Unsupported PUAlgo");
 
-  // const std::string& pualgo = iConfig.getParameter<std::string>("puAlgo");
-  l1tkegalgo_.reset(new l1tpf_impl::PFTkEGAlgo(iConfig));
-  // if (pualgo == "Puppi") {
-  //   l1pualgo_.reset(new l1tpf_impl::PuppiAlgo(iConfig));
-  // } else if (pualgo == "LinearizedPuppi") {
-  //   l1pualgo_.reset(new l1tpf_impl::LinearizedPuppiAlgo(iConfig));
-  // } else
-  // throw cms::Exception("Configuration", "Unsupported PUAlgo");
+  l1tkegalgo_.reset(new l1tpf_impl::PFTkEGAlgo(iConfig.getParameter<edm::ParameterSet>("tkEgAlgoConfig")));
+  if (l1tkegalgo_->writeEgSta())
+    produces<BXVector<l1t::EGamma>>("L1Eg");
+  produces<l1t::TkElectronCollection>("L1TkEle");
+  produces<l1t::TkEmCollection>("L1TkEm");
 
   std::string vtxAlgo = iConfig.getParameter<std::string>("vtxAlgo");
   if (vtxAlgo == "TP")
@@ -366,8 +358,8 @@ void L1TPFProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // Then run PF in each region
   for (auto& l1region : l1regions_.regions()) {
     l1pfalgo_->runPF(l1region);
-    l1tkegalgo_->runTkEG(l1region);
     l1pualgo_->runChargedPV(l1region, z0);
+    l1tkegalgo_->runTkEG(l1region);
   }
   // save PF into the event
   iEvent.put(l1regions_.fetch(false), "PF");
@@ -392,10 +384,8 @@ void L1TPFProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // and save puppi
   iEvent.put(l1regions_.fetch(true), "Puppi");
 
-  l1regions_.putEgObjects(iEvent, "L1Eg", "L1TkEm", "L1TkEle");
-  // iEvent.put(l1regions_.fetchEgs(), "L1Eg");
-  // iEvent.put(l1regions_.fetchTkEms(), "TkEm");
-  // iEvent.put(l1regions_.fetchTkEles(), "TkEle");
+  // save the EG objects
+  l1regions_.putEgObjects(iEvent, l1tkegalgo_->writeEgSta(), "L1Eg", "L1TkEm", "L1TkEle");
 
   // Then go do the multiplicities
 

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TPFProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TPFProducer.cc
@@ -158,7 +158,6 @@ L1TPFProducer::L1TPFProducer(const edm::ParameterSet& iConfig)
   } else
     throw cms::Exception("Configuration", "Unsupported PUAlgo");
 
-
   // const std::string& pualgo = iConfig.getParameter<std::string>("puAlgo");
   l1tkegalgo_.reset(new l1tpf_impl::PFTkEGAlgo(iConfig));
   // if (pualgo == "Puppi") {
@@ -166,7 +165,7 @@ L1TPFProducer::L1TPFProducer(const edm::ParameterSet& iConfig)
   // } else if (pualgo == "LinearizedPuppi") {
   //   l1pualgo_.reset(new l1tpf_impl::LinearizedPuppiAlgo(iConfig));
   // } else
-    // throw cms::Exception("Configuration", "Unsupported PUAlgo");
+  // throw cms::Exception("Configuration", "Unsupported PUAlgo");
 
   std::string vtxAlgo = iConfig.getParameter<std::string>("vtxAlgo");
   if (vtxAlgo == "TP")
@@ -393,7 +392,7 @@ void L1TPFProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // and save puppi
   iEvent.put(l1regions_.fetch(true), "Puppi");
 
-  l1regions_.putEgObjects(iEvent,  "L1Eg", "L1TkEm", "L1TkEle");
+  l1regions_.putEgObjects(iEvent, "L1Eg", "L1TkEm", "L1TkEle");
   // iEvent.put(l1regions_.fetchEgs(), "L1Eg");
   // iEvent.put(l1regions_.fetchTkEms(), "TkEm");
   // iEvent.put(l1regions_.fetchTkEles(), "TkEle");

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TPFProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TPFProducer.cc
@@ -22,6 +22,7 @@
 #include "L1Trigger/Phase2L1ParticleFlow/interface/PFAlgoBase.h"
 #include "L1Trigger/Phase2L1ParticleFlow/interface/PFAlgo3.h"
 #include "L1Trigger/Phase2L1ParticleFlow/interface/PFAlgo2HGC.h"
+#include "L1Trigger/Phase2L1ParticleFlow/interface/PFTkEGAlgo.h"
 #include "L1Trigger/Phase2L1ParticleFlow/interface/BitwisePFAlgo.h"
 #include "L1Trigger/Phase2L1ParticleFlow/interface/PuppiAlgo.h"
 #include "L1Trigger/Phase2L1ParticleFlow/interface/LinearizedPuppiAlgo.h"
@@ -30,6 +31,12 @@
 
 #include "DataFormats/L1TCorrelator/interface/TkMuon.h"
 #include "DataFormats/L1TCorrelator/interface/TkMuonFwd.h"
+
+#include "DataFormats/L1TCorrelator/interface/TkElectron.h"
+#include "DataFormats/L1TCorrelator/interface/TkElectronFwd.h"
+#include "DataFormats/L1Trigger/interface/EGamma.h"
+#include "DataFormats/L1TCorrelator/interface/TkEm.h"
+#include "DataFormats/L1TCorrelator/interface/TkEmFwd.h"
 
 //--------------------------------------------------------------------------------------------------
 class L1TPFProducer : public edm::stream::EDProducer<> {
@@ -62,6 +69,7 @@ private:
   l1tpf_impl::RegionMapper l1regions_;
   std::unique_ptr<l1tpf_impl::PFAlgoBase> l1pfalgo_;
   std::unique_ptr<l1tpf_impl::PUAlgoBase> l1pualgo_;
+  std::unique_ptr<l1tpf_impl::PFTkEGAlgo> l1tkegalgo_;
 
   edm::EDGetTokenT<math::XYZPointF> TokGenOrigin_;
 
@@ -100,6 +108,7 @@ L1TPFProducer::L1TPFProducer(const edm::ParameterSet& iConfig)
       l1regions_(iConfig),
       l1pfalgo_(nullptr),
       l1pualgo_(nullptr),
+      l1tkegalgo_(nullptr),
       regionDumpName_(iConfig.getUntrackedParameter<std::string>("dumpFileName", "")),
       regionCOEName_(iConfig.getUntrackedParameter<std::string>("coeFileName", "")),
       fRegionDump_(nullptr),
@@ -116,6 +125,11 @@ L1TPFProducer::L1TPFProducer(const edm::ParameterSet& iConfig)
   produces<l1t::PFCandidateCollection>("Calo");
   produces<l1t::PFCandidateCollection>("TK");
   produces<l1t::PFCandidateCollection>("TKVtx");
+
+  // FIXME: should this be conditional to running the right algorithm?
+  produces<BXVector<l1t::EGamma>>("L1Eg");
+  produces<l1t::TkElectronCollection>("L1TkEle");
+  produces<l1t::TkEmCollection>("L1TkEm");
 
   produces<float>("z0");
 
@@ -143,6 +157,16 @@ L1TPFProducer::L1TPFProducer(const edm::ParameterSet& iConfig)
     l1pualgo_.reset(new l1tpf_impl::LinearizedPuppiAlgo(iConfig));
   } else
     throw cms::Exception("Configuration", "Unsupported PUAlgo");
+
+
+  // const std::string& pualgo = iConfig.getParameter<std::string>("puAlgo");
+  l1tkegalgo_.reset(new l1tpf_impl::PFTkEGAlgo(iConfig));
+  // if (pualgo == "Puppi") {
+  //   l1pualgo_.reset(new l1tpf_impl::PuppiAlgo(iConfig));
+  // } else if (pualgo == "LinearizedPuppi") {
+  //   l1pualgo_.reset(new l1tpf_impl::LinearizedPuppiAlgo(iConfig));
+  // } else
+    // throw cms::Exception("Configuration", "Unsupported PUAlgo");
 
   std::string vtxAlgo = iConfig.getParameter<std::string>("vtxAlgo");
   if (vtxAlgo == "TP")
@@ -343,6 +367,7 @@ void L1TPFProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // Then run PF in each region
   for (auto& l1region : l1regions_.regions()) {
     l1pfalgo_->runPF(l1region);
+    l1tkegalgo_->runTkEG(l1region);
     l1pualgo_->runChargedPV(l1region, z0);
   }
   // save PF into the event
@@ -367,6 +392,11 @@ void L1TPFProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   }
   // and save puppi
   iEvent.put(l1regions_.fetch(true), "Puppi");
+
+  l1regions_.putEgObjects(iEvent,  "L1Eg", "L1TkEm", "L1TkEle");
+  // iEvent.put(l1regions_.fetchEgs(), "L1Eg");
+  // iEvent.put(l1regions_.fetchTkEms(), "TkEm");
+  // iEvent.put(l1regions_.fetchTkEles(), "TkEle");
 
   // Then go do the multiplicities
 

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TPFProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TPFProducer.cc
@@ -53,7 +53,7 @@ private:
 
   bool hasTracks_;
   edm::EDGetTokenT<l1t::PFTrackCollection> tkCands_;
-  float trkPt_, trkMaxChi2_;
+  float trkPt_, trkMaxChi2_, trkPtNoChi2_;
   unsigned trkMinStubs_;
   l1tpf_impl::PUAlgoBase::VertexAlgo vtxAlgo_;
   edm::EDGetTokenT<std::vector<l1t::TkPrimaryVertex>> extTkVtx_;
@@ -100,6 +100,7 @@ L1TPFProducer::L1TPFProducer(const edm::ParameterSet& iConfig)
                           : edm::EDGetTokenT<l1t::PFTrackCollection>()),
       trkPt_(iConfig.getParameter<double>("trkPtCut")),
       trkMaxChi2_(iConfig.getParameter<double>("trkMaxChi2")),
+      trkPtNoChi2_(iConfig.getParameter<double>("trkPtNoChi2")),
       trkMinStubs_(iConfig.getParameter<unsigned>("trkMinStubs")),
       muCands_(consumes<l1t::MuonBxCollection>(iConfig.getParameter<edm::InputTag>("muons"))),
       tkMuCands_(consumes<l1t::TkMuonCollection>(iConfig.getParameter<edm::InputTag>("tkMuons"))),
@@ -242,7 +243,8 @@ void L1TPFProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
       // adding objects to PF
       if (debugR_ > 0 && deltaR(tk.eta(), tk.phi(), debugEta_, debugPhi_) > debugR_)
         continue;
-      if (tk.pt() > trkPt_ && tk.nStubs() >= trkMinStubs_ && tk.normalizedChi2() < trkMaxChi2_) {
+      if ((tk.pt() > trkPt_ && tk.nStubs() >= trkMinStubs_ && tk.normalizedChi2() < trkMaxChi2_) ||
+          (tk.pt() > trkPtNoChi2_)) {
         l1regions_.addTrack(tk, l1t::PFTrackRef(htracks, itk));
       }
     }
@@ -358,8 +360,11 @@ void L1TPFProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // Then run PF in each region
   for (auto& l1region : l1regions_.regions()) {
     l1pfalgo_->runPF(l1region);
-    l1pualgo_->runChargedPV(l1region, z0);
     l1tkegalgo_->runTkEG(l1region);
+    l1pualgo_->runChargedPV(l1region, z0);
+    // this is a separate step since the z0 from vertex might come at different latency
+    l1tkegalgo_->runTkIso(l1region, z0);
+    l1tkegalgo_->runPFIso(l1region, z0);
   }
   // save PF into the event
   iEvent.put(l1regions_.fetch(false), "PF");

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/PFClusterProducerFromHGC3DClusters.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/PFClusterProducerFromHGC3DClusters.cc
@@ -82,9 +82,10 @@ void l1tpf::PFClusterProducerFromHGC3DClusters::produce(edm::Event &iEvent, cons
     if (pt <= etCut_)
       continue;
 
-    if(it->hwQual()) { // this is the EG ID shipped with the HGC TPs
+    if (it->hwQual()) {  // this is the EG ID shipped with the HGC TPs
       // we use the EM interpretation of the cluster energy
-      l1t::PFCluster egcluster(it->iPt(l1t::HGCalMulticluster::EnergyInterpretation::EM), it->eta(), it->phi(), hoe, false);
+      l1t::PFCluster egcluster(
+          it->iPt(l1t::HGCalMulticluster::EnergyInterpretation::EM), it->eta(), it->phi(), hoe, false);
       // FIXME: we use HW qual = 4 to identify the EG candidates and set isEM to false not to interfere with the rest of the PF...
       // we start from 4 not to intefere with flags used elesewhere
       egcluster.setHwQual(4);

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/PFClusterProducerFromHGC3DClusters.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/PFClusterProducerFromHGC3DClusters.cc
@@ -82,6 +82,16 @@ void l1tpf::PFClusterProducerFromHGC3DClusters::produce(edm::Event &iEvent, cons
     if (pt <= etCut_)
       continue;
 
+    if(it->hwQual()) { // this is the EG ID shipped with the HGC TPs
+      // we use the EM interpretation of the cluster energy
+      l1t::PFCluster egcluster(it->iPt(l1t::HGCalMulticluster::EnergyInterpretation::EM), it->eta(), it->phi(), hoe, false);
+      // FIXME: we use HW qual = 4 to identify the EG candidates and set isEM to false not to interfere with the rest of the PF...
+      // we start from 4 not to intefere with flags used elesewhere
+      egcluster.setHwQual(4);
+      egcluster.addConstituent(edm::Ptr<l1t::L1Candidate>(multiclusters, multiclusters->key(it)));
+      outEm->push_back(egcluster);
+    }
+
     l1t::PFCluster cluster(pt, it->eta(), it->phi(), hoe, /*isEM=*/isEM);
     if (!emVsPUID_.method().empty()) {
       if (!emVsPUID_.passID(*it, cluster)) {
@@ -89,7 +99,9 @@ void l1tpf::PFClusterProducerFromHGC3DClusters::produce(edm::Event &iEvent, cons
       }
     }
     if (!emVsPionID_.method().empty()) {
-      cluster.setIsEM(emVsPionID_.passID(*it, cluster));
+      isEM = emVsPionID_.passID(*it, cluster);
+      cluster.setIsEM(isEM);
+      //FIXME: in the previous version isEM would remain ttrue resulting in pions in the em collection
     }
     if (corrector_.valid())
       corrector_.correctPt(cluster);

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/PFClusterProducerFromHGC3DClusters.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/PFClusterProducerFromHGC3DClusters.cc
@@ -86,7 +86,7 @@ void l1tpf::PFClusterProducerFromHGC3DClusters::produce(edm::Event &iEvent, cons
       // we use the EM interpretation of the cluster energy
       l1t::PFCluster egcluster(
           it->iPt(l1t::HGCalMulticluster::EnergyInterpretation::EM), it->eta(), it->phi(), hoe, false);
-      // FIXME: we use HW qual = 4 to identify the EG candidates and set isEM to false not to interfere with the rest of the PF...
+      // NOTE: we use HW qual = 4 to identify the EG candidates and set isEM to false not to interfere with the rest of the PF...
       // we start from 4 not to intefere with flags used elesewhere
       egcluster.setHwQual(4);
       egcluster.addConstituent(edm::Ptr<l1t::L1Candidate>(multiclusters, multiclusters->key(it)));
@@ -102,7 +102,6 @@ void l1tpf::PFClusterProducerFromHGC3DClusters::produce(edm::Event &iEvent, cons
     if (!emVsPionID_.method().empty()) {
       isEM = emVsPionID_.passID(*it, cluster);
       cluster.setIsEM(isEM);
-      //FIXME: in the previous version isEM would remain ttrue resulting in pions in the em collection
     }
     if (corrector_.valid())
       corrector_.correctPt(cluster);

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/PFClusterProducerFromL1EGClusters.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/PFClusterProducerFromL1EGClusters.cc
@@ -7,7 +7,7 @@
 #include "DataFormats/L1TParticleFlow/interface/PFCluster.h"
 #include "L1Trigger/Phase2L1ParticleFlow/src/corrector.h"
 #include "L1Trigger/Phase2L1ParticleFlow/interface/ParametricResolution.h"
-#include "DataFormats/L1TCalorimeterPhase2/interface/CaloCrystalCluster.h"
+#include "DataFormats/L1Trigger/interface/EGamma.h"
 
 namespace l1tpf {
   class PFClusterProducerFromL1EGClusters : public edm::stream::EDProducer<> {
@@ -16,7 +16,7 @@ namespace l1tpf {
     ~PFClusterProducerFromL1EGClusters() override {}
 
   private:
-    edm::EDGetTokenT<l1tp2::CaloCrystalClusterCollection> src_;
+    edm::EDGetTokenT<BXVector<l1t::EGamma>> src_;
     double etCut_;
     l1tpf::corrector corrector_;
     l1tpf::ParametricResolution resol_;
@@ -27,7 +27,7 @@ namespace l1tpf {
 }  // namespace l1tpf
 
 l1tpf::PFClusterProducerFromL1EGClusters::PFClusterProducerFromL1EGClusters(const edm::ParameterSet &iConfig)
-    : src_(consumes<l1tp2::CaloCrystalClusterCollection>(iConfig.getParameter<edm::InputTag>("src"))),
+    : src_(consumes<BXVector<l1t::EGamma>>(iConfig.getParameter<edm::InputTag>("src"))),
       etCut_(iConfig.getParameter<double>("etMin")),
       corrector_(iConfig.getParameter<std::string>("corrector"), -1),
       resol_(iConfig.getParameter<edm::ParameterSet>("resol")) {
@@ -36,7 +36,7 @@ l1tpf::PFClusterProducerFromL1EGClusters::PFClusterProducerFromL1EGClusters(cons
 
 void l1tpf::PFClusterProducerFromL1EGClusters::produce(edm::Event &iEvent, const edm::EventSetup &) {
   std::unique_ptr<l1t::PFClusterCollection> out(new l1t::PFClusterCollection());
-  edm::Handle<l1tp2::CaloCrystalClusterCollection> clusters;
+  edm::Handle<BXVector<l1t::EGamma>> clusters;
   iEvent.getByToken(src_, clusters);
 
   unsigned int index = 0;

--- a/L1Trigger/Phase2L1ParticleFlow/python/l1ParticleFlow_cff.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1ParticleFlow_cff.py
@@ -4,6 +4,7 @@ from L1Trigger.Phase2L1ParticleFlow.pfTracksFromL1Tracks_cfi import pfTracksFrom
 from L1Trigger.Phase2L1ParticleFlow.pfClustersFromL1EGClusters_cfi import pfClustersFromL1EGClusters
 from L1Trigger.Phase2L1ParticleFlow.pfClustersFromCombinedCalo_cfi import pfClustersFromCombinedCalo
 from L1Trigger.Phase2L1ParticleFlow.l1pfProducer_cfi import l1pfProducer
+from L1Trigger.Phase2L1ParticleFlow.l1TkEgAlgo_cfi import tkEgConfig
 
 # Using phase2_hgcalV10 to customize the config for all 106X samples, since there's no other modifier for it
 from Configuration.Eras.Modifier_phase2_hgcalV10_cff import phase2_hgcalV10
@@ -85,6 +86,11 @@ l1ParticleFlow_calo_Task = cms.Task(
 )
 l1ParticleFlow_calo = cms.Sequence(l1ParticleFlow_calo_Task)
 
+l1TkEgConfigBarrel = tkEgConfig.clone(
+    doBremRecovery=False,
+    filterHwQuality=False,
+    writeEgSta=False
+)
 
 # PF in the barrel
 l1pfProducerBarrel = l1pfProducer.clone(
@@ -99,6 +105,8 @@ l1pfProducerBarrel = l1pfProducer.clone(
     vtxAlgo = "external",
     vtxFormat = cms.string("TkPrimaryVertex"),
     vtxCollection = cms.InputTag("L1TkPrimaryVertex",""),
+    # eg algo configuration
+    tkEgAlgoConfig = l1TkEgConfigBarrel,
     # puppi tuning
     puAlgo = "LinearizedPuppi",
     puppiEtaCuts            = cms.vdouble( 1.6 ), # just one bin
@@ -135,6 +143,9 @@ l1ParticleFlow_pf_barrel_Task = cms.Task(
 l1ParticleFlow_pf_barrel = cms.Sequence(l1ParticleFlow_pf_barrel_Task)
 
 
+l1TkEgConfigHGCal = tkEgConfig.clone(
+    debug=0
+)
 
 # PF in HGCal
 pfTracksFromL1TracksHGCal = pfTracksFromL1Tracks.clone(
@@ -154,6 +165,8 @@ l1pfProducerHGCal = l1pfProducer.clone(
     vtxAlgo = "external",
     vtxFormat = cms.string("TkPrimaryVertex"),
     vtxCollection = cms.InputTag("L1TkPrimaryVertex",""),
+    # eg algo configuration
+    tkEgAlgoConfig = l1TkEgConfigHGCal,
     # puppi tuning
     puAlgo = "LinearizedPuppi",
     puppiEtaCuts            = cms.vdouble( 2.0, 2.4, 3.1 ), # two bins in the tracker (different pT), one outside
@@ -213,8 +226,9 @@ l1ParticleFlow_pf_hgcal_Task = cms.Task(
 )
 l1ParticleFlow_pf_hgcal = cms.Sequence(l1ParticleFlow_pf_hgcal_Task)
 
-
-
+l1TkEgConfigHF = tkEgConfig.clone(
+    debug=0
+)
 # PF in HF
 l1pfProducerHF = l1pfProducer.clone(
     # inputs
@@ -228,6 +242,8 @@ l1pfProducerHF = l1pfProducer.clone(
     vtxAlgo = "external",
     vtxFormat = cms.string("TkPrimaryVertex"),
     vtxCollection = cms.InputTag("L1TkPrimaryVertex",""),
+    # eg algo configuration
+    tkEgAlgoConfig = l1TkEgConfigHF,
     # puppi tuning
     puAlgo = "LinearizedPuppi",
     puppiEtaCuts            = cms.vdouble( 5.5 ), # one bin

--- a/L1Trigger/Phase2L1ParticleFlow/python/l1ParticleFlow_cff.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1ParticleFlow_cff.py
@@ -107,11 +107,11 @@ l1pfProducerBarrel = l1pfProducer.clone(
     puppiPtSlopes           = cms.vdouble( 0.3 ), # coefficient for pT
     puppiPtSlopesPhotons    = cms.vdouble( 0.3 ),
     puppiPtZeros            = cms.vdouble( 4.0 ), # ballpark pT from PU
-    puppiPtZerosPhotons     = cms.vdouble( 2.5 ), 
+    puppiPtZerosPhotons     = cms.vdouble( 2.5 ),
     puppiAlphaSlopes        = cms.vdouble( 0.7 ), # coefficient for alpha
     puppiAlphaSlopesPhotons = cms.vdouble( 0.7 ),
     puppiAlphaZeros         = cms.vdouble( 6.0 ), # ballpark alpha from PU
-    puppiAlphaZerosPhotons  = cms.vdouble( 6.0 ), 
+    puppiAlphaZerosPhotons  = cms.vdouble( 6.0 ),
     puppiAlphaCrops         = cms.vdouble(  4  ), # max. absolute value for alpha term
     puppiAlphaCropsPhotons  = cms.vdouble(  4  ),
     puppiPriors             = cms.vdouble( 5.0 ),
@@ -129,7 +129,7 @@ l1pfProducerBarrel = l1pfProducer.clone(
     ),
 )
 l1ParticleFlow_pf_barrel_Task = cms.Task(
-    pfTracksFromL1TracksBarrel ,   
+    pfTracksFromL1TracksBarrel ,
     l1pfProducerBarrel
 )
 l1ParticleFlow_pf_barrel = cms.Sequence(l1ParticleFlow_pf_barrel_Task)
@@ -145,7 +145,7 @@ l1pfProducerHGCal = l1pfProducer.clone(
     pfAlgo = "PFAlgo2HGC",
     # inputs
     tracks = cms.InputTag('pfTracksFromL1TracksHGCal'),
-    emClusters  = [ ],  # EM clusters are not used (only added to NTuple for calibration/monitoring)
+    emClusters  = [ cms.InputTag("pfClustersFromHGC3DClusters:em")],  # EM clusters are not used (only added to NTuple for calibration/monitoring)
     hadClusters = [ cms.InputTag("pfClustersFromHGC3DClusters") ],
     # track-based PUPPI
     puppiDrMin = 0.04,
@@ -162,7 +162,7 @@ l1pfProducerHGCal = l1pfProducer.clone(
     puppiPtSlopes           = cms.vdouble( 0.3, 0.3, 0.3 ), # coefficient for pT
     puppiPtSlopesPhotons    = cms.vdouble( 0.4, 0.4, 0.4 ), #When e/g ID not applied, use: cms.vdouble( 0.3, 0.3, 0.3 ),
     puppiPtZeros            = cms.vdouble( 5.0, 7.0, 9.0 ), # ballpark pT from PU
-    puppiPtZerosPhotons     = cms.vdouble( 3.0, 4.0, 5.0 ), 
+    puppiPtZerosPhotons     = cms.vdouble( 3.0, 4.0, 5.0 ),
     puppiAlphaSlopes        = cms.vdouble( 1.5, 1.5, 2.2 ),
     puppiAlphaSlopesPhotons = cms.vdouble( 1.5, 1.5, 2.2 ),
     puppiAlphaZeros         = cms.vdouble( 6.0, 6.0, 9.0 ),
@@ -207,7 +207,7 @@ l1pfProducerHGCalNoTK = l1pfProducerHGCal.clone(regions = cms.VPSet(
 ))
 
 l1ParticleFlow_pf_hgcal_Task = cms.Task(
-    pfTracksFromL1TracksHGCal ,   
+    pfTracksFromL1TracksHGCal ,
     l1pfProducerHGCal ,
     l1pfProducerHGCalNoTK
 )
@@ -289,7 +289,7 @@ l1ParticleFlow_pf_tsa = cms.Sequence(
 # Merging all outputs
 l1pfCandidates = cms.EDProducer("L1TPFCandMultiMerger",
     pfProducers = cms.VInputTag(
-        cms.InputTag("l1pfProducerBarrel"), 
+        cms.InputTag("l1pfProducerBarrel"),
         cms.InputTag("l1pfProducerHGCal"),
         cms.InputTag("l1pfProducerHGCalNoTK"),
         cms.InputTag("l1pfProducerHF")

--- a/L1Trigger/Phase2L1ParticleFlow/python/l1TkEgAlgo_cfi.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1TkEgAlgo_cfi.py
@@ -26,14 +26,14 @@ tkEgConfig = cms.PSet(
         tkQualityPtMin=cms.double(2.),
         dZ=cms.double(0.6),
         dRMin=cms.double(0.03),
-        dRMax=cms.double(0.30),
+        dRMax=cms.double(0.20),
         tkQualityChi2Max=cms.double(1e10),
     ),
     pfIsoParametersTkEm=cms.PSet(
         tkQualityPtMin=cms.double(1.),
         dZ=cms.double(0.6),
-        dRMin=cms.double(0.03),
-        dRMax=cms.double(0.20),
+        dRMin=cms.double(0.07),
+        dRMax=cms.double(0.30),
         tkQualityChi2Max=cms.double(100),
     ),
     pfIsoParametersTkEle=cms.PSet(

--- a/L1Trigger/Phase2L1ParticleFlow/python/l1TkEgAlgo_cfi.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1TkEgAlgo_cfi.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 tkEgConfig = cms.PSet(
     debug=cms.untracked.int32(0),
     doBremRecovery=cms.bool(True),
+    doTkIsolation=cms.bool(True),
     filterHwQuality=cms.bool(True),
     caloHwQual=cms.int32(4),
     dEtaMaxBrem=cms.double(0.02),
@@ -13,5 +14,34 @@ tkEgConfig = cms.PSet(
     caloEtMin=cms.double(0.0),
     trkQualityPtMin=cms.double(10.0),
     trkQualityChi2=cms.double(1e10),
-    writeEgSta=cms.bool(True)
+    writeEgSta=cms.bool(True),
+    tkIsoParametersTkEm=cms.PSet(
+        tkQualityPtMin=cms.double(2.),
+        dZ=cms.double(0.6),
+        dRMin=cms.double(0.07),
+        dRMax=cms.double(0.30),
+        tkQualityChi2Max=cms.double(100),
+    ),
+    tkIsoParametersTkEle=cms.PSet(
+        tkQualityPtMin=cms.double(2.),
+        dZ=cms.double(0.6),
+        dRMin=cms.double(0.03),
+        dRMax=cms.double(0.30),
+        tkQualityChi2Max=cms.double(1e10),
+    ),
+    pfIsoParametersTkEm=cms.PSet(
+        tkQualityPtMin=cms.double(1.),
+        dZ=cms.double(0.6),
+        dRMin=cms.double(0.03),
+        dRMax=cms.double(0.20),
+        tkQualityChi2Max=cms.double(100),
+    ),
+    pfIsoParametersTkEle=cms.PSet(
+        tkQualityPtMin=cms.double(1.),
+        dZ=cms.double(0.6),
+        dRMin=cms.double(0.03),
+        dRMax=cms.double(0.20),
+        tkQualityChi2Max=cms.double(1e10),
+    )
+
 )

--- a/L1Trigger/Phase2L1ParticleFlow/python/l1TkEgAlgo_cfi.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1TkEgAlgo_cfi.py
@@ -1,0 +1,17 @@
+import FWCore.ParameterSet.Config as cms
+
+tkEgConfig = cms.PSet(
+    debug=cms.untracked.int32(0),
+    doBremRecovery=cms.bool(True),
+    filterHwQuality=cms.bool(True),
+    caloHwQual=cms.int32(4),
+    dEtaMaxBrem=cms.double(0.02),
+    dPhiMaxBrem=cms.double(0.1),
+    absEtaBoundaries=cms.vdouble(0.0, 0.9, 1.5),
+    dEtaValues=cms.vdouble(0.025, 0.015, 0.01),  # last was  0.0075  in TDR
+    dPhiValues=cms.vdouble(0.07, 0.07, 0.07),
+    caloEtMin=cms.double(0.0),
+    trkQualityPtMin=cms.double(10.0),
+    trkQualityChi2=cms.double(1e10),
+    writeEgSta=cms.bool(True)
+)

--- a/L1Trigger/Phase2L1ParticleFlow/python/l1pfProducer_cfi.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1pfProducer_cfi.py
@@ -7,7 +7,7 @@ l1pfProducer = cms.EDProducer("L1TPFProducer",
      muons = cms.InputTag('simGmtStage2Digis',),
      tkMuons = cms.InputTag('L1TkMuons'),
      # type of muons to be used in PF (enable only one at a time)
-     useStandaloneMuons = cms.bool(True), 
+     useStandaloneMuons = cms.bool(True),
      useTrackerMuons = cms.bool(False),
      emClusters = cms.VInputTag(cms.InputTag('pfClustersFromHGC3DClustersEM'), cms.InputTag('pfClustersFromL1EGClusters')),
      hadClusters = cms.VInputTag(cms.InputTag('pfClustersFromCombinedCalo:calibrated')),
@@ -16,11 +16,12 @@ l1pfProducer = cms.EDProducer("L1TPFProducer",
      trkPtCut    = cms.double(2.0),
      trkMinStubs = cms.uint32(4),
      trkMaxChi2  = cms.double(15),
+     trkPtNoChi2 = cms.double(5),
      etaCharged  = cms.double(2.5),
      puppiDr     = cms.double(0.3),
      puppiDrMin  = cms.double(0.1),
      puppiPtMax  = cms.double(999),
-     puppiEtaCuts       = cms.vdouble(1.5, 2.5, 3.0, 5.5), 
+     puppiEtaCuts       = cms.vdouble(1.5, 2.5, 3.0, 5.5),
      puppiPtCuts        = cms.vdouble(0.0, 3.0, 6.0, 8.0),
      puppiPtCutsPhotons = cms.vdouble(0.0, 3.0, 6.0, 8.0),
      puppiUsingBareTracks = cms.bool(False), # use PF
@@ -36,7 +37,7 @@ l1pfProducer = cms.EDProducer("L1TPFProducer",
         # track -> em linking configurables
         trackEmDR   = cms.double(0.04), # 1 Ecal crystal size is 0.02, and ~2 cm in HGCal is ~0.007
         trackEmUseAlsoTrackSigma = cms.bool(True), # also use the track uncertainty for electron linking
-        trackEmMayUseCaloMomenta = cms.bool(True), # use calo momenta for 1 emcalo to 1 track match electrons 
+        trackEmMayUseCaloMomenta = cms.bool(True), # use calo momenta for 1 emcalo to 1 track match electrons
         # em -> calo linking configurables
         emCaloDR    = cms.double(0.10),    # 1 Hcal tower size is ~0.09
         caloEmPtMinFrac = cms.double(0.5), # Calo object must have an EM Et at least half of that of the EM cluster to allow linking
@@ -47,11 +48,11 @@ l1pfProducer = cms.EDProducer("L1TPFProducer",
         #trackCaloLinkMetric = cms.string("bestByDR"),
         trackCaloDR = cms.double(0.15),
         trackCaloNSigmaLow  = cms.double(2.0),
-        trackCaloNSigmaHigh = cms.double(sqrt(1.0)), # sqrt(x) since in the hardware we use sigma squared 
+        trackCaloNSigmaHigh = cms.double(sqrt(1.0)), # sqrt(x) since in the hardware we use sigma squared
         useTrackCaloSigma = cms.bool(True), # take the uncertainty on the calo cluster from the track, for linking purposes
         sumTkCaloErr2 = cms.bool(True), # add up track calo errors in quadrature instead of linearly
         rescaleTracks = cms.bool(False), # if tracks exceed the calo, rescale the track momenta
-        useCaloTrkWeightedAverage = cms.bool(False), # do the weighted average of track & calo pTs if it's a 1-1 link 
+        useCaloTrkWeightedAverage = cms.bool(False), # do the weighted average of track & calo pTs if it's a 1-1 link
         # how to deal with unlinked tracks
         maxInvisiblePt = cms.double(10.0), # max allowed pt of a track with no calo energy
         tightTrackMinStubs = cms.uint32(6),
@@ -68,5 +69,3 @@ l1pfProducer = cms.EDProducer("L1TPFProducer",
      ),
      debug = cms.untracked.int32(0),
 )
-
-

--- a/L1Trigger/Phase2L1ParticleFlow/src/PFTkEgAlgo.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/PFTkEgAlgo.cc
@@ -7,27 +7,21 @@ using namespace l1tpf_impl;
 #include "DataFormats/Common/interface/RefToPtr.h"
 #include <algorithm>
 
-
 namespace {
   template <typename T1, typename T2>
   float floatDR(const T1 &t1, const T2 &t2) {
     return deltaR(t1.floatEta(), t1.floatPhi(), t2.floatEta(), t2.floatPhi());
   }
-}  // name
+}  // namespace
 
-PFTkEGAlgo::PFTkEGAlgo(const edm::ParameterSet &) {
-
-}
-
+PFTkEGAlgo::PFTkEGAlgo(const edm::ParameterSet &) {}
 
 PFTkEGAlgo::~PFTkEGAlgo() {}
-
 
 void PFTkEGAlgo::initRegion(Region &r) const {
   // FIXME: assume imput is sorted already
   r.egobjs.clear();
 }
-
 
 void PFTkEGAlgo::runTkEG(Region &r) const {
   initRegion(r);
@@ -37,7 +31,8 @@ void PFTkEGAlgo::runTkEG(Region &r) const {
 
   // NOTE: we run this step for all clusters (before matching) as it is done in the pre-PF algorithm
   std::vector<int> emCalo2emCalo(r.emcalo.size(), -1);
-  if(doBremRecovery) link_emCalo2emCalo(r, emCalo2emCalo);
+  if (doBremRecovery)
+    link_emCalo2emCalo(r, emCalo2emCalo);
 
   // track to EM calo matching
   std::vector<int> emCalo2tk(r.emcalo.size(), -1);
@@ -47,10 +42,7 @@ void PFTkEGAlgo::runTkEG(Region &r) const {
 
   // add tk electron to region;
   eg_algo(r, emCalo2emCalo, emCalo2tk);
-
 }
-
-
 
 void PFTkEGAlgo::eg_algo(Region &r, const std::vector<int> &emCalo2emCalo, const std::vector<int> &emCalo2tk) const {
   // FIXME: configurables
@@ -58,38 +50,40 @@ void PFTkEGAlgo::eg_algo(Region &r, const std::vector<int> &emCalo2emCalo, const
 
   for (int ic = 0, nc = r.emcalo.size(); ic < nc; ++ic) {
     auto &calo = r.emcalo[ic];
-    if(calo.hwFlags != caloHwQual_) continue;
-
+    if (calo.hwFlags != caloHwQual_)
+      continue;
 
     int itk = emCalo2tk[ic];
     // 1. create EG objects before brem recovery
     addEgObjsToPF(r.egobjs, ic, calo.hwFlags, calo.floatPt(), itk);
 
     // check if the cluster has already been used in a brem reclustering
-    if(emCalo2emCalo[ic] != -1) continue;
+    if (emCalo2emCalo[ic] != -1)
+      continue;
 
     float ptBremReco = calo.floatPt();
 
     for (int jc = ic; jc < nc; ++jc) {
-      if(emCalo2emCalo[jc] == ic) {
+      if (emCalo2emCalo[jc] == ic) {
         auto &otherCalo = r.emcalo[jc];
         ptBremReco += otherCalo.floatPt();
       }
     }
 
     // 2. create TkEle with brem recovery
-    addEgObjsToPF(r.egobjs, ic, calo.hwFlags+1, ptBremReco, itk);
+    addEgObjsToPF(r.egobjs, ic, calo.hwFlags + 1, ptBremReco, itk);
   }
 }
 
-
-
-l1tpf_impl::EgObjectIndexer& PFTkEGAlgo::addEgObjsToPF(std::vector<l1tpf_impl::EgObjectIndexer> egobjs,
-                                                       const int calo_idx, const int hwQual, const float ptCorr, const int tk_idx, const float iso) const {
+l1tpf_impl::EgObjectIndexer &PFTkEGAlgo::addEgObjsToPF(std::vector<l1tpf_impl::EgObjectIndexer> egobjs,
+                                                       const int calo_idx,
+                                                       const int hwQual,
+                                                       const float ptCorr,
+                                                       const int tk_idx,
+                                                       const float iso) const {
   egobjs.emplace_back(l1tpf_impl::EgObjectIndexer{calo_idx, hwQual, ptCorr, tk_idx, iso});
   return egobjs.back();
 }
-
 
 void PFTkEGAlgo::link_emCalo2emCalo(Region &r, std::vector<int> &emCalo2emCalo) const {
   // FIXME: configurables
@@ -100,29 +94,31 @@ void PFTkEGAlgo::link_emCalo2emCalo(Region &r, std::vector<int> &emCalo2emCalo) 
   // NOTE: we assume the input to be sorted!!!
   for (int ic = 0, nc = r.emcalo.size(); ic < nc; ++ic) {
     auto &calo = r.emcalo[ic];
-    if(calo.hwFlags != caloHwQual_) continue;
+    if (calo.hwFlags != caloHwQual_)
+      continue;
 
-    if(emCalo2emCalo[ic] != -1) continue;
+    if (emCalo2emCalo[ic] != -1)
+      continue;
 
     for (int jc = ic; jc < nc; ++jc) {
-      if(emCalo2emCalo[jc] != -1) continue;
+      if (emCalo2emCalo[jc] != -1)
+        continue;
 
       auto &otherCalo = r.emcalo[jc];
-      if(fabs(otherCalo.floatEta() - calo.floatEta()) < dEtaMax &&
-         fabs(deltaPhi(otherCalo.floatPhi(), calo.floatPhi())) < dPhiMax) {
-           emCalo2emCalo[jc] = ic;
-         }
+      if (fabs(otherCalo.floatEta() - calo.floatEta()) < dEtaMax &&
+          fabs(deltaPhi(otherCalo.floatPhi(), calo.floatPhi())) < dPhiMax) {
+        emCalo2emCalo[jc] = ic;
+      }
     }
   }
 }
 
-
 void PFTkEGAlgo::link_emCalo2tk(Region &r, std::vector<int> &emCalo2tk) const {
   // FIXME: configurable
   // configuration of the elliptic cut over the whole detector
-  std::vector<float>absEtaBountaries_{0.0, 0.9, 1.5};
-  std::vector<float>dEtaValues_{0.025, 0.015, 0.01}; // last was  0.0075  in TDR
-  std::vector<float>dPhiValues_{0.07, 0.07, 0.07};
+  std::vector<float> absEtaBountaries_{0.0, 0.9, 1.5};
+  std::vector<float> dEtaValues_{0.025, 0.015, 0.01};  // last was  0.0075  in TDR
+  std::vector<float> dPhiValues_{0.07, 0.07, 0.07};
   float caloEtMin_ = 0.0;
   // FIXME this needs configuration depending on where we are...? Or maybe a list of qualities
   int caloHwQual_ = 4;
@@ -134,13 +130,12 @@ void PFTkEGAlgo::link_emCalo2tk(Region &r, std::vector<int> &emCalo2tk) const {
   for (int ic = 0, nc = r.emcalo.size(); ic < nc; ++ic) {
     auto &calo = r.emcalo[ic];
     // std::cout << "[" << ic << "] pt: " << calo.floatPt() << std::endl;
-    if(calo.hwFlags != caloHwQual_)
+    if (calo.hwFlags != caloHwQual_)
       continue;
     // compute elliptic matching
-    auto eta_index = std::distance(absEtaBountaries_.begin(),
-                                   std::lower_bound(absEtaBountaries_.begin(),
-                                                    absEtaBountaries_.end(),
-                                                    r.globalAbsEta(calo.floatEta())));
+    auto eta_index = std::distance(
+        absEtaBountaries_.begin(),
+        std::lower_bound(absEtaBountaries_.begin(), absEtaBountaries_.end(), r.globalAbsEta(calo.floatEta())));
     float dEtaMax = dEtaValues_[eta_index];
     float dPhiMax = dPhiValues_[eta_index];
 
@@ -148,8 +143,8 @@ void PFTkEGAlgo::link_emCalo2tk(Region &r, std::vector<int> &emCalo2tk) const {
 
     for (int itk = 0, ntk = r.track.size(); itk < ntk; ++itk) {
       const auto &tk = r.track[itk];
-      if(tk.floatPt() < trkQualityPtMin_) continue;
-
+      if (tk.floatPt() < trkQualityPtMin_)
+        continue;
 
       float d_phi = deltaPhi(tk.floatPhi(), calo.floatPhi());
       float d_eta = fabs(tk.floatEta() - calo.floatEta());
@@ -157,12 +152,12 @@ void PFTkEGAlgo::link_emCalo2tk(Region &r, std::vector<int> &emCalo2tk) const {
       // std::cout << "Global abs eta: " << r.globalAbsEta(calo.floatEta())
       //           << " abs eta: " << fabs(calo.floatEta()) << std::endl;
 
-      if(((d_phi/dPhiMax)*(d_phi/dPhiMax))+((d_eta/dEtaMax)*(d_eta/dEtaMax)) < 1.) {
+      if (((d_phi / dPhiMax) * (d_phi / dPhiMax)) + ((d_eta / dEtaMax) * (d_eta / dEtaMax)) < 1.) {
         // FIXME: how to define the best match? Closest in pt? See what done in PF
         // maybe we want the highest in pT and then recover using the brem recovery???
-        if(fabs(tk.floatPt()-calo.floatPt())< dPtMin) {
+        if (fabs(tk.floatPt() - calo.floatPt()) < dPtMin) {
           emCalo2tk[ic] = itk;
-          dPtMin = fabs(tk.floatPt()-calo.floatPt());
+          dPtMin = fabs(tk.floatPt() - calo.floatPt());
         }
       }
     }

--- a/L1Trigger/Phase2L1ParticleFlow/src/PFTkEgAlgo.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/PFTkEgAlgo.cc
@@ -1,0 +1,170 @@
+#include "L1Trigger/Phase2L1ParticleFlow/interface/PFTkEGAlgo.h"
+
+using namespace l1tpf_impl;
+
+#include "DataFormats/Math/interface/deltaPhi.h"
+#include "DataFormats/L1TParticleFlow/interface/PFTrack.h"
+#include "DataFormats/Common/interface/RefToPtr.h"
+#include <algorithm>
+
+
+namespace {
+  template <typename T1, typename T2>
+  float floatDR(const T1 &t1, const T2 &t2) {
+    return deltaR(t1.floatEta(), t1.floatPhi(), t2.floatEta(), t2.floatPhi());
+  }
+}  // name
+
+PFTkEGAlgo::PFTkEGAlgo(const edm::ParameterSet &) {
+
+}
+
+
+PFTkEGAlgo::~PFTkEGAlgo() {}
+
+
+void PFTkEGAlgo::initRegion(Region &r) const {
+  // FIXME: assume imput is sorted already
+  r.egobjs.clear();
+}
+
+
+void PFTkEGAlgo::runTkEG(Region &r) const {
+  initRegion(r);
+
+  //FIXME: configurable (off for barrel)
+  bool doBremRecovery = true;
+
+  // NOTE: we run this step for all clusters (before matching) as it is done in the pre-PF algorithm
+  std::vector<int> emCalo2emCalo(r.emcalo.size(), -1);
+  if(doBremRecovery) link_emCalo2emCalo(r, emCalo2emCalo);
+
+  // track to EM calo matching
+  std::vector<int> emCalo2tk(r.emcalo.size(), -1);
+  link_emCalo2tk(r, emCalo2tk);
+
+  //FIXME: compute tk based iso
+
+  // add tk electron to region;
+  eg_algo(r, emCalo2emCalo, emCalo2tk);
+
+}
+
+
+
+void PFTkEGAlgo::eg_algo(Region &r, const std::vector<int> &emCalo2emCalo, const std::vector<int> &emCalo2tk) const {
+  // FIXME: configurables
+  int caloHwQual_ = 4;
+
+  for (int ic = 0, nc = r.emcalo.size(); ic < nc; ++ic) {
+    auto &calo = r.emcalo[ic];
+    if(calo.hwFlags != caloHwQual_) continue;
+
+
+    int itk = emCalo2tk[ic];
+    // 1. create EG objects before brem recovery
+    addEgObjsToPF(r.egobjs, ic, calo.hwFlags, calo.floatPt(), itk);
+
+    // check if the cluster has already been used in a brem reclustering
+    if(emCalo2emCalo[ic] != -1) continue;
+
+    float ptBremReco = calo.floatPt();
+
+    for (int jc = ic; jc < nc; ++jc) {
+      if(emCalo2emCalo[jc] == ic) {
+        auto &otherCalo = r.emcalo[jc];
+        ptBremReco += otherCalo.floatPt();
+      }
+    }
+
+    // 2. create TkEle with brem recovery
+    addEgObjsToPF(r.egobjs, ic, calo.hwFlags+1, ptBremReco, itk);
+  }
+}
+
+
+
+l1tpf_impl::EgObjectIndexer& PFTkEGAlgo::addEgObjsToPF(std::vector<l1tpf_impl::EgObjectIndexer> egobjs,
+                                                       const int calo_idx, const int hwQual, const float ptCorr, const int tk_idx, const float iso) const {
+  egobjs.emplace_back(l1tpf_impl::EgObjectIndexer{calo_idx, hwQual, ptCorr, tk_idx, iso});
+  return egobjs.back();
+}
+
+
+void PFTkEGAlgo::link_emCalo2emCalo(Region &r, std::vector<int> &emCalo2emCalo) const {
+  // FIXME: configurables
+  int caloHwQual_ = 4;
+  float dEtaMax = 0.02;
+  float dPhiMax = 0.1;
+
+  // NOTE: we assume the input to be sorted!!!
+  for (int ic = 0, nc = r.emcalo.size(); ic < nc; ++ic) {
+    auto &calo = r.emcalo[ic];
+    if(calo.hwFlags != caloHwQual_) continue;
+
+    if(emCalo2emCalo[ic] != -1) continue;
+
+    for (int jc = ic; jc < nc; ++jc) {
+      if(emCalo2emCalo[jc] != -1) continue;
+
+      auto &otherCalo = r.emcalo[jc];
+      if(fabs(otherCalo.floatEta() - calo.floatEta()) < dEtaMax &&
+         fabs(deltaPhi(otherCalo.floatPhi(), calo.floatPhi())) < dPhiMax) {
+           emCalo2emCalo[jc] = ic;
+         }
+    }
+  }
+}
+
+
+void PFTkEGAlgo::link_emCalo2tk(Region &r, std::vector<int> &emCalo2tk) const {
+  // FIXME: configurable
+  // configuration of the elliptic cut over the whole detector
+  std::vector<float>absEtaBountaries_{0.0, 0.9, 1.5};
+  std::vector<float>dEtaValues_{0.025, 0.015, 0.01}; // last was  0.0075  in TDR
+  std::vector<float>dPhiValues_{0.07, 0.07, 0.07};
+  float caloEtMin_ = 0.0;
+  // FIXME this needs configuration depending on where we are...? Or maybe a list of qualities
+  int caloHwQual_ = 4;
+
+  float trkQualityPtMin_ = 10.0;
+  float trkQualityChi2_ = 1e10;
+
+  // track to calo matching (first iteration, with a lower bound on the calo pt; there may be another one later)
+  for (int ic = 0, nc = r.emcalo.size(); ic < nc; ++ic) {
+    auto &calo = r.emcalo[ic];
+    // std::cout << "[" << ic << "] pt: " << calo.floatPt() << std::endl;
+    if(calo.hwFlags != caloHwQual_)
+      continue;
+    // compute elliptic matching
+    auto eta_index = std::distance(absEtaBountaries_.begin(),
+                                   std::lower_bound(absEtaBountaries_.begin(),
+                                                    absEtaBountaries_.end(),
+                                                    r.globalAbsEta(calo.floatEta())));
+    float dEtaMax = dEtaValues_[eta_index];
+    float dPhiMax = dPhiValues_[eta_index];
+
+    float dPtMin = 999;
+
+    for (int itk = 0, ntk = r.track.size(); itk < ntk; ++itk) {
+      const auto &tk = r.track[itk];
+      if(tk.floatPt() < trkQualityPtMin_) continue;
+
+
+      float d_phi = deltaPhi(tk.floatPhi(), calo.floatPhi());
+      float d_eta = fabs(tk.floatEta() - calo.floatEta());
+
+      // std::cout << "Global abs eta: " << r.globalAbsEta(calo.floatEta())
+      //           << " abs eta: " << fabs(calo.floatEta()) << std::endl;
+
+      if(((d_phi/dPhiMax)*(d_phi/dPhiMax))+((d_eta/dEtaMax)*(d_eta/dEtaMax)) < 1.) {
+        // FIXME: how to define the best match? Closest in pt? See what done in PF
+        // maybe we want the highest in pT and then recover using the brem recovery???
+        if(fabs(tk.floatPt()-calo.floatPt())< dPtMin) {
+          emCalo2tk[ic] = itk;
+          dPtMin = fabs(tk.floatPt()-calo.floatPt());
+        }
+      }
+    }
+  }
+}

--- a/L1Trigger/Phase2L1ParticleFlow/src/PFTkEgAlgo.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/PFTkEgAlgo.cc
@@ -77,12 +77,12 @@ void PFTkEGAlgo::eg_algo(Region &r, const std::vector<int> &emCalo2emCalo, const
     if (filterHwQuality_ && calo.hwFlags != caloHwQual_)
       continue;
 
-
     int itk = emCalo2tk[ic];
 
     // 1. create EG objects before brem recovery
     addEGIsoToPF(r.egphotons, calo, calo.hwFlags, calo.floatPt());
-    if(itk != -1) addEGIsoEleToPF(r.egeles, calo, r.track[itk], calo.hwFlags, calo.floatPt());
+    if (itk != -1)
+      addEGIsoEleToPF(r.egeles, calo, r.track[itk], calo.hwFlags, calo.floatPt());
     addEgObjsToPF(r, ic, calo.hwFlags, calo.floatPt(), itk);
 
     // check if brem recovery is on
@@ -107,7 +107,6 @@ void PFTkEGAlgo::eg_algo(Region &r, const std::vector<int> &emCalo2emCalo, const
     addEgObjsToPF(r, ic, calo.hwFlags + 1, ptBremReco, itk);
   }
 }
-
 
 EGIsoParticle &PFTkEGAlgo::addEGIsoToPF(std::vector<EGIsoParticle> &egobjs,
                                         const CaloCluster &calo,
@@ -135,39 +134,32 @@ EGIsoEleParticle &PFTkEGAlgo::addEGIsoEleToPF(std::vector<EGIsoEleParticle> &ego
                                               const PropagatedTrack &track,
                                               const int hwQual,
                                               const float ptCorr) const {
-    EGIsoEleParticle egiso;
-    egiso.setFloatPt(ptCorr);
-    egiso.hwEta = calo.hwEta;
-    egiso.hwPhi = calo.hwPhi;
-    egiso.cluster = calo;
+  EGIsoEleParticle egiso;
+  egiso.setFloatPt(ptCorr);
+  egiso.hwEta = calo.hwEta;
+  egiso.hwPhi = calo.hwPhi;
+  egiso.cluster = calo;
 
-    egiso.hwVtxEta = track.hwVtxEta;
-    egiso.hwVtxPhi = track.hwVtxPhi;
-    egiso.hwZ0 = track.hwZ0;
-    egiso.hwCharge = track.hwCharge;
-    egiso.track = track;
+  egiso.hwVtxEta = track.hwVtxEta;
+  egiso.hwVtxPhi = track.hwVtxPhi;
+  egiso.hwZ0 = track.hwZ0;
+  egiso.hwCharge = track.hwCharge;
+  egiso.track = track;
 
-    egiso.hwQual = hwQual;
-    egiso.hwIso = 0;
-    egiso.hwPFIso = 0;
+  egiso.hwQual = hwQual;
+  egiso.hwIso = 0;
+  egiso.hwPFIso = 0;
 
-    egobjs.push_back(egiso);
-    return egobjs.back();
-
+  egobjs.push_back(egiso);
+  return egobjs.back();
 }
 
-
-
-void PFTkEGAlgo::addEgObjsToPF(Region &r,
-                                const int calo_idx,
-                                const int hwQual,
-                                const float ptCorr,
-                                const int tk_idx) const {
-
-  EGIsoParticle &egobj = addEGIsoToPF(r.egphotons, r.emcalo[calo_idx], r.emcalo[calo_idx].hwFlags+1, ptCorr);
-  if(tk_idx != -1) {
+void PFTkEGAlgo::addEgObjsToPF(
+    Region &r, const int calo_idx, const int hwQual, const float ptCorr, const int tk_idx) const {
+  EGIsoParticle &egobj = addEGIsoToPF(r.egphotons, r.emcalo[calo_idx], r.emcalo[calo_idx].hwFlags + 1, ptCorr);
+  if (tk_idx != -1) {
     egobj.ele_idx = r.egeles.size();
-    addEGIsoEleToPF(r.egeles, r.emcalo[calo_idx], r.track[tk_idx], r.emcalo[calo_idx].hwFlags+1, ptCorr);
+    addEGIsoEleToPF(r.egeles, r.emcalo[calo_idx], r.track[tk_idx], r.emcalo[calo_idx].hwFlags + 1, ptCorr);
   } else {
     egobj.ele_idx = -1;
   }

--- a/L1Trigger/Phase2L1ParticleFlow/src/PFTkEgAlgo.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/PFTkEgAlgo.cc
@@ -146,17 +146,16 @@ EGIsoEleParticle &PFTkEGAlgo::addEGIsoEleToPF(std::vector<EGIsoEleParticle> &ego
   egiso.hwQual = hwQual;
   egiso.hwIso = 0;
   egiso.hwPFIso = 0;
-
   egobjs.push_back(egiso);
   return egobjs.back();
 }
 
 void PFTkEGAlgo::addEgObjsToPF(
     Region &r, const int calo_idx, const int hwQual, const float ptCorr, const int tk_idx) const {
-  EGIsoParticle &egobj = addEGIsoToPF(r.egphotons, r.emcalo[calo_idx], r.emcalo[calo_idx].hwFlags + 1, ptCorr);
+  EGIsoParticle &egobj = addEGIsoToPF(r.egphotons, r.emcalo[calo_idx], hwQual, ptCorr);
   if (tk_idx != -1) {
     egobj.ele_idx = r.egeles.size();
-    addEGIsoEleToPF(r.egeles, r.emcalo[calo_idx], r.track[tk_idx], r.emcalo[calo_idx].hwFlags + 1, ptCorr);
+    addEGIsoEleToPF(r.egeles, r.emcalo[calo_idx], r.track[tk_idx], hwQual, ptCorr);
   }
 }
 

--- a/L1Trigger/Phase2L1ParticleFlow/src/PFTkEgAlgo.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/PFTkEgAlgo.cc
@@ -14,20 +14,20 @@ namespace {
   }
 }  // namespace
 
-PFTkEGAlgo::PFTkEGAlgo(const edm::ParameterSet &pset):
-  debug_(pset.getUntrackedParameter<int>("debug")),
-  doBremRecovery_(pset.getParameter<bool>("doBremRecovery")),
-  filterHwQuality_(pset.getParameter<bool>("filterHwQuality")),
-  caloHwQual_(pset.getParameter<int>("caloHwQual")),
-  dEtaMaxBrem_(pset.getParameter<double>("dEtaMaxBrem")),
-  dPhiMaxBrem_(pset.getParameter<double>("dPhiMaxBrem")),
-  absEtaBoundaries_(pset.getParameter<std::vector<double>>("absEtaBoundaries")),
-  dEtaValues_(pset.getParameter<std::vector<double>>("dEtaValues")),
-  dPhiValues_(pset.getParameter<std::vector<double>>("dPhiValues")),
-  caloEtMin_(pset.getParameter<double>("caloEtMin")),
-  trkQualityPtMin_(pset.getParameter<double>("trkQualityPtMin")),
-  trkQualityChi2_(pset.getParameter<double>("trkQualityChi2")),
-  writeEgSta_(pset.getParameter<bool>("writeEgSta")) {}
+PFTkEGAlgo::PFTkEGAlgo(const edm::ParameterSet &pset)
+    : debug_(pset.getUntrackedParameter<int>("debug")),
+      doBremRecovery_(pset.getParameter<bool>("doBremRecovery")),
+      filterHwQuality_(pset.getParameter<bool>("filterHwQuality")),
+      caloHwQual_(pset.getParameter<int>("caloHwQual")),
+      dEtaMaxBrem_(pset.getParameter<double>("dEtaMaxBrem")),
+      dPhiMaxBrem_(pset.getParameter<double>("dPhiMaxBrem")),
+      absEtaBoundaries_(pset.getParameter<std::vector<double>>("absEtaBoundaries")),
+      dEtaValues_(pset.getParameter<std::vector<double>>("dEtaValues")),
+      dPhiValues_(pset.getParameter<std::vector<double>>("dPhiValues")),
+      caloEtMin_(pset.getParameter<double>("caloEtMin")),
+      trkQualityPtMin_(pset.getParameter<double>("trkQualityPtMin")),
+      trkQualityChi2_(pset.getParameter<double>("trkQualityChi2")),
+      writeEgSta_(pset.getParameter<bool>("writeEgSta")) {}
 
 PFTkEGAlgo::~PFTkEGAlgo() {}
 
@@ -39,7 +39,7 @@ void PFTkEGAlgo::initRegion(Region &r) const {
 void PFTkEGAlgo::runTkEG(Region &r) const {
   initRegion(r);
 
-  if(debug_ > 0) {
+  if (debug_ > 0) {
     std::cout << "[PFTkEGAlgo::runTkEG] START" << std::endl;
     std::cout << "   # emCalo: " << r.emcalo.size() << " # tk: " << r.track.size() << std::endl;
   }
@@ -59,7 +59,6 @@ void PFTkEGAlgo::runTkEG(Region &r) const {
 }
 
 void PFTkEGAlgo::eg_algo(Region &r, const std::vector<int> &emCalo2emCalo, const std::vector<int> &emCalo2tk) const {
-
   for (int ic = 0, nc = r.emcalo.size(); ic < nc; ++ic) {
     auto &calo = r.emcalo[ic];
     if (filterHwQuality_ && calo.hwFlags != caloHwQual_)
@@ -70,7 +69,7 @@ void PFTkEGAlgo::eg_algo(Region &r, const std::vector<int> &emCalo2emCalo, const
     addEgObjsToPF(r.egobjs, ic, calo.hwFlags, calo.floatPt(), itk);
 
     // check if brem recovery is on
-    if(!doBremRecovery_)
+    if (!doBremRecovery_)
       continue;
 
     // check if the cluster has already been used in a brem reclustering
@@ -111,7 +110,7 @@ void PFTkEGAlgo::link_emCalo2emCalo(Region &r, std::vector<int> &emCalo2emCalo) 
     if (emCalo2emCalo[ic] != -1)
       continue;
 
-    for (int jc = ic+1; jc < nc; ++jc) {
+    for (int jc = ic + 1; jc < nc; ++jc) {
       if (emCalo2emCalo[jc] != -1)
         continue;
 
@@ -135,19 +134,26 @@ void PFTkEGAlgo::link_emCalo2tk(Region &r, std::vector<int> &emCalo2tk) const {
     if (filterHwQuality_ && calo.hwFlags != caloHwQual_)
       continue;
     // compute elliptic matching
-    auto eta_index = std::distance(
-        absEtaBoundaries_.begin(),
-        std::lower_bound(absEtaBoundaries_.begin(), absEtaBoundaries_.end(), r.globalAbsEta(calo.floatEta()))) - 1;
+    auto eta_index =
+        std::distance(
+            absEtaBoundaries_.begin(),
+            std::lower_bound(absEtaBoundaries_.begin(), absEtaBoundaries_.end(), r.globalAbsEta(calo.floatEta()))) -
+        1;
     float dEtaMax = dEtaValues_[eta_index];
     float dPhiMax = dPhiValues_[eta_index];
 
-    if(debug_ > 0) std::cout << "idx: " << eta_index << " deta: " << dEtaMax << " dphi: " << dPhiMax << std::endl;
+    if (debug_ > 0)
+      std::cout << "idx: " << eta_index << " deta: " << dEtaMax << " dphi: " << dPhiMax << std::endl;
 
     float dPtMin = 999;
-    if(debug_ > 0) std::cout << "--- calo: pt: " << calo.floatPt() << " eta: " << calo.floatEta() << " phi: " << calo.floatPhi() << std::endl;
+    if (debug_ > 0)
+      std::cout << "--- calo: pt: " << calo.floatPt() << " eta: " << calo.floatEta() << " phi: " << calo.floatPhi()
+                << std::endl;
     for (int itk = 0, ntk = r.track.size(); itk < ntk; ++itk) {
       const auto &tk = r.track[itk];
-      if(debug_ > 0) std::cout << "  - tk: pt: " << tk.floatPt() << " eta: " << tk.floatEta() << " phi: " << tk.floatPhi() << std::endl;
+      if (debug_ > 0)
+        std::cout << "  - tk: pt: " << tk.floatPt() << " eta: " << tk.floatEta() << " phi: " << tk.floatPhi()
+                  << std::endl;
 
       if (tk.floatPt() < trkQualityPtMin_)
         continue;
@@ -155,15 +161,20 @@ void PFTkEGAlgo::link_emCalo2tk(Region &r, std::vector<int> &emCalo2tk) const {
       float d_phi = deltaPhi(tk.floatPhi(), calo.floatPhi());
       float d_eta = fabs(tk.floatEta() - calo.floatEta());
 
-      if(debug_ > 0) std::cout << " deta: " << d_eta << " dphi: " << d_phi << " ell: " << ((d_phi / dPhiMax) * (d_phi / dPhiMax)) + ((d_eta / dEtaMax) * (d_eta / dEtaMax))<< std::endl;
+      if (debug_ > 0)
+        std::cout << " deta: " << d_eta << " dphi: " << d_phi
+                  << " ell: " << ((d_phi / dPhiMax) * (d_phi / dPhiMax)) + ((d_eta / dEtaMax) * (d_eta / dEtaMax))
+                  << std::endl;
       // std::cout << "Global abs eta: " << r.globalAbsEta(calo.floatEta())
       //           << " abs eta: " << fabs(calo.floatEta()) << std::endl;
 
       if ((((d_phi / dPhiMax) * (d_phi / dPhiMax)) + ((d_eta / dEtaMax) * (d_eta / dEtaMax))) < 1.) {
-        if(debug_ > 0) std::cout << "    pass elliptic " << std::endl;
+        if (debug_ > 0)
+          std::cout << "    pass elliptic " << std::endl;
         // NOTE: for now we implement only best pt match. This is NOT what is done in the L1TkElectronTrackProducer
         if (fabs(tk.floatPt() - calo.floatPt()) < dPtMin) {
-          if(debug_ > 0) std::cout << "     best pt match: " << fabs(tk.floatPt() - calo.floatPt()) << std::endl;
+          if (debug_ > 0)
+            std::cout << "     best pt match: " << fabs(tk.floatPt() - calo.floatPt()) << std::endl;
           emCalo2tk[ic] = itk;
           dPtMin = fabs(tk.floatPt() - calo.floatPt());
         }

--- a/L1Trigger/Phase2L1ParticleFlow/src/PFTkEgAlgo.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/PFTkEgAlgo.cc
@@ -80,9 +80,6 @@ void PFTkEGAlgo::eg_algo(Region &r, const std::vector<int> &emCalo2emCalo, const
     int itk = emCalo2tk[ic];
 
     // 1. create EG objects before brem recovery
-    addEGIsoToPF(r.egphotons, calo, calo.hwFlags, calo.floatPt());
-    if (itk != -1)
-      addEGIsoEleToPF(r.egeles, calo, r.track[itk], calo.hwFlags, calo.floatPt());
     addEgObjsToPF(r, ic, calo.hwFlags, calo.floatPt(), itk);
 
     // check if brem recovery is on
@@ -124,7 +121,7 @@ EGIsoParticle &PFTkEGAlgo::addEGIsoToPF(std::vector<EGIsoParticle> &egobjs,
   egiso.hwIsoPV = 0;
   egiso.hwPFIso = 0;
   egiso.hwPFIsoPV = 0;
-
+  egiso.ele_idx = -1;
   egobjs.push_back(egiso);
   return egobjs.back();
 }
@@ -160,8 +157,6 @@ void PFTkEGAlgo::addEgObjsToPF(
   if (tk_idx != -1) {
     egobj.ele_idx = r.egeles.size();
     addEGIsoEleToPF(r.egeles, r.emcalo[calo_idx], r.track[tk_idx], r.emcalo[calo_idx].hwFlags + 1, ptCorr);
-  } else {
-    egobj.ele_idx = -1;
   }
 }
 

--- a/L1Trigger/Phase2L1ParticleFlow/src/RegionMapper.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/RegionMapper.cc
@@ -309,7 +309,10 @@ std::unique_ptr<l1t::PFCandidateCollection> RegionMapper::fetchTracks(float ptMi
   return ret;
 }
 
-void RegionMapper::putEgObjects(edm::Event& iEvent, std::string egLablel, std::string tkEmLabel, std::string tkEleLabel) const {
+void RegionMapper::putEgObjects(edm::Event &iEvent,
+                                std::string egLablel,
+                                std::string tkEmLabel,
+                                std::string tkEleLabel) const {
   auto egs = std::make_unique<BXVector<l1t::EGamma>>();
   auto tkems = std::make_unique<l1t::TkEmCollection>();
   auto tkeles = std::make_unique<l1t::TkElectronCollection>();
@@ -321,7 +324,7 @@ void RegionMapper::putEgObjects(edm::Event& iEvent, std::string egLablel, std::s
   // FIXME: need to handle the barrel case where the EG already exist and we only need to use edm::refToPtr() from calo.src
   // FIXME: do we need additional cuts?
   for (const Region &r : regions_) {
-    for (const l1tpf_impl::EgObjectIndexer &egidxer: r.egobjs) {
+    for (const l1tpf_impl::EgObjectIndexer &egidxer : r.egobjs) {
       const auto &calo = r.emcalo[egidxer.emCaloIdx];
 
       // FIXME: check this is fiducial
@@ -330,18 +333,15 @@ void RegionMapper::putEgObjects(edm::Event& iEvent, std::string egLablel, std::s
       eg.setHwQual(egidxer.hwQual);
       egs->push_back(0, eg);
 
-      l1t::TkEm tkem(eg.p4(),
-                     edm::Ref<BXVector<l1t::EGamma>>(ref_egs, idx),
-                     egidxer.iso, egidxer.iso);
+      l1t::TkEm tkem(eg.p4(), edm::Ref<BXVector<l1t::EGamma>>(ref_egs, idx), egidxer.iso, egidxer.iso);
       tkems->push_back(tkem);
 
-      if(egidxer.tkIdx == -1) continue;
+      if (egidxer.tkIdx == -1)
+        continue;
       const auto &tk = r.track[egidxer.tkIdx];
 
-      l1t::TkElectron tkele(eg.p4(),
-                            edm::Ref<BXVector<l1t::EGamma>>(ref_egs, idx),
-                            edm::refToPtr(tk.src->track()),
-                            egidxer.iso);
+      l1t::TkElectron tkele(
+          eg.p4(), edm::Ref<BXVector<l1t::EGamma>>(ref_egs, idx), edm::refToPtr(tk.src->track()), egidxer.iso);
       tkeles->push_back(tkele);
 
       idx++;
@@ -350,7 +350,6 @@ void RegionMapper::putEgObjects(edm::Event& iEvent, std::string egLablel, std::s
   iEvent.put(std::move(egs), egLablel);
   iEvent.put(std::move(tkems), tkEmLabel);
   iEvent.put(std::move(tkeles), tkEleLabel);
-
 }
 
 std::pair<unsigned, unsigned> RegionMapper::totAndMaxInput(int type) const {

--- a/L1Trigger/Phase2L1ParticleFlow/src/RegionMapper.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/RegionMapper.cc
@@ -330,7 +330,6 @@ void RegionMapper::putEgObjects(edm::Event &iEvent,
       if (egphoton.floatPt() < ptMin)
         continue;
 
-
       if (!r.fiducialLocal(egphoton.floatEta(), egphoton.floatPhi()))
         continue;
 
@@ -364,7 +363,8 @@ void RegionMapper::putEgObjects(edm::Event &iEvent,
       auto mom_ele = reco::Candidate::PolarLorentzVector(
           egele.floatPt(), r.globalEta(egele.floatEta()), r.globalPhi(egele.floatPhi()), 0.);
 
-      l1t::TkElectron tkele(reco::Candidate::LorentzVector(mom_ele), reg, edm::refToPtr(egele.track.src->track()), egele.floatIso());
+      l1t::TkElectron tkele(
+          reco::Candidate::LorentzVector(mom_ele), reg, edm::refToPtr(egele.track.src->track()), egele.floatIso());
       tkele.setHwQual(egele.hwQual);
       tkele.setPFIsol(egele.floatPFIso());
       tkeles->push_back(tkele);

--- a/L1Trigger/Phase2L1ParticleFlow/src/RegionMapper.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/RegionMapper.cc
@@ -352,16 +352,19 @@ void RegionMapper::putEgObjects(edm::Event &iEvent,
         hwQual = egptr->hwQual();
       }
 
-      l1t::TkEm tkem(reco::Candidate::LorentzVector(mom), reg, egidxer.iso, egidxer.iso);
+      l1t::TkEm tkem(reco::Candidate::LorentzVector(mom), reg, egidxer.iso, egidxer.isoPV);
       tkem.setHwQual(hwQual);
+      tkem.setPFIsol(egidxer.pfIso);
+      tkem.setPFIsolPV(egidxer.pfIsoPV);
       tkems->push_back(tkem);
 
       if (egidxer.tkIdx == -1)
         continue;
       const auto &tk = r.track[egidxer.tkIdx];
 
-      l1t::TkElectron tkele(reco::Candidate::LorentzVector(mom), reg, edm::refToPtr(tk.src->track()), egidxer.iso);
+      l1t::TkElectron tkele(reco::Candidate::LorentzVector(mom), reg, edm::refToPtr(tk.src->track()), egidxer.isoDZ);
       tkele.setHwQual(hwQual);
+      tkele.setPFIsol(egidxer.pfIsoDZ);
       tkeles->push_back(tkele);
     }
   }


### PR DESCRIPTION
#### PR description:

The PR implements an additional correlator algorithm building:
   * EG standalone objects (only in HGC, not in the barrel)
   * Tk matched electrons
   * Tk isolated photons

For all Tk objects: compute Tk based and PF based isolation.

*NOTE I*: I had to change the input collection for the EG clusters in the barrel...this is functional to building the TkElectrons

*NOTE II*: I added some tracks to the input in order to bring the EG efficiency on-par with the TDR implementation. In practice, I removed any chi2 requirement for tracks above 5GeV of pT (it should have a small impact on the max # of tracks per region).

* NOTE III*: the TkElectron and TkEM objects have been expanded to use more than 1 isolation variable. For now, no optimization of the PF based isolation has been performed and the current choice of parameter comes from Thomas' work in [talk @ EG P2 meeting](https://indico.cern.ch/event/933640/contributions/3923080/attachments/2066165/3467505/l1_egamma_iso_studies_20200630.pdf )


#### PR validation:

once the input track selection is fixed the efficiency of the correlator and TDR objects are equivalent. See plots below.

![canvas(214)](https://user-images.githubusercontent.com/4802196/98701722-e3839b00-2379-11eb-9f7f-64e6f83cbdd4.png)
![canvas(213)](https://user-images.githubusercontent.com/4802196/98701727-e41c3180-2379-11eb-9ce2-b59e65c55e97.png)

