### PR TITLE
L1 pf 11 1 6 x updated pf cluster producer from hgc3d clusters

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/plugins/PFClusterProducerFromHGC3DClusters.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/PFClusterProducerFromHGC3DClusters.cc
@@ -47,8 +47,7 @@ l1tpf::PFClusterProducerFromHGC3DClusters::PFClusterProducerFromHGC3DClusters(co
                  emOnly_ || iConfig.getParameter<std::string>("corrector").empty()
                      ? -1
                      : iConfig.getParameter<double>("correctorEmfMax")),
-      resol_(iConfig.getParameter<edm::ParameterSet>("resol")) {
-
+  resol_(iConfig.getParameter<edm::ParameterSet>("resol")) {
   if (!emVsPionID_.method().empty()) {
     emVsPionID_.prepareTMVA();
   }

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/PFClusterProducerFromHGC3DClusters.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/PFClusterProducerFromHGC3DClusters.cc
@@ -47,7 +47,7 @@ l1tpf::PFClusterProducerFromHGC3DClusters::PFClusterProducerFromHGC3DClusters(co
                  emOnly_ || iConfig.getParameter<std::string>("corrector").empty()
                      ? -1
                      : iConfig.getParameter<double>("correctorEmfMax")),
-  resol_(iConfig.getParameter<edm::ParameterSet>("resol")) {
+      resol_(iConfig.getParameter<edm::ParameterSet>("resol")) {
   if (!emVsPionID_.method().empty()) {
     emVsPionID_.prepareTMVA();
   }

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/PFClusterProducerFromHGC3DClusters.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/PFClusterProducerFromHGC3DClusters.cc
@@ -84,7 +84,6 @@ void l1tpf::PFClusterProducerFromHGC3DClusters::produce(edm::Event &iEvent, cons
     }
     if (pt <= etCut_)
       continue;
-    // std::cout<<"-- pt "<<pt<<" hoe "<<hoe<<"\n";
 
     if (it->hwQual()) {  // this is the EG ID shipped with the HGC TPs
       // we use the EM interpretation of the cluster energy

--- a/L1Trigger/Phase2L1ParticleFlow/python/pfClustersFromHGC3DClusters_cfi.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/pfClustersFromHGC3DClusters_cfi.py
@@ -31,7 +31,8 @@ pfClustersFromHGC3DClusters = cms.EDProducer("PFClusterProducerFromHGC3DClusters
         ),
         weightsFile = cms.string("L1Trigger/Phase2L1ParticleFlow/data/hgcal_egID/Photon_Pion_vs_Neutrino_BDTweights.xml.gz"),
         wp = cms.string("-0.02")
-    ),
+    ),                                             
+    scenario = cms.int32(0),
     emOnly = cms.bool(False),
     etMin = cms.double(1.0),
     resol = cms.PSet(

--- a/L1Trigger/Phase2L1ParticleFlow/python/pfClustersFromHGC3DClusters_cfi.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/pfClustersFromHGC3DClusters_cfi.py
@@ -31,8 +31,8 @@ pfClustersFromHGC3DClusters = cms.EDProducer("PFClusterProducerFromHGC3DClusters
         ),
         weightsFile = cms.string("L1Trigger/Phase2L1ParticleFlow/data/hgcal_egID/Photon_Pion_vs_Neutrino_BDTweights.xml.gz"),
         wp = cms.string("-0.02")
-    ),                                             
-    scenario = cms.int32(0),
+    ),                                          
+    scenario = cms.int32(0),#0, 1 or 2
     emOnly = cms.bool(False),
     etMin = cms.double(1.0),
     resol = cms.PSet(


### PR DESCRIPTION
Updated PFClusterProducerFromHGC3DClusters to use calibrated EM energy [*] for HGCal EM-interpreted clusters [**] 

[*] https://indico.cern.ch/event/920682/contributions/3868200/attachments/2042103/3420446/20-05-12_EGGeometries_TPAlgo.pdf
[**] https://indico.cern.ch/event/1016458/contributions/4265629/attachments/2205314/3731123/20210310_EMClusterInterpretationAndPF_schhibra.pdf

For HGCal clusters passing emVsPUID
(Default) scenario 0: use raw energy (raw-EM + raw-Had)

Scenario 1: for clusters passing emVsPionID, use calib-EM + 0 and hoe = 0
for other clusters, use raw-EM + raw-Had

Scenario 2: for all clusters, use calib-EM + raw-Had and hoe = h/calib-EM