### PR TITLE
WIP: Update to dataformats and endcap regionizer

### DIFF
--- a/DataFormats/L1TParticleFlow/interface/PFCandidate.h
+++ b/DataFormats/L1TParticleFlow/interface/PFCandidate.h
@@ -6,6 +6,7 @@
 #include "DataFormats/L1Trigger/interface/Muon.h"
 #include "DataFormats/L1TParticleFlow/interface/PFCluster.h"
 #include "DataFormats/L1TParticleFlow/interface/PFTrack.h"
+#include "DataFormats/L1TParticleFlow/interface/RegionalOutput.h"
 
 namespace l1t {
 
@@ -45,11 +46,33 @@ namespace l1t {
     /// PUPPI weight (-1 if not available)
     float puppiWeight() const { return puppiWeight_; }
 
+    void setZ0(float z0) { setVertex(reco::Particle::Point(0, 0, z0)); }
+    void setDxy(float dxy) { dxy_ = dxy; }
+
+    float z0() const { return vz(); }
+    float dxy() const { return dxy_; }
+
+    int16_t hwZ0() const { return hwZ0_; }
+    int16_t hwDxy() const { return hwDxy_; }
+    uint16_t hwTkQuality() const { return hwTkQuality_; }
+    uint16_t hwPuppiWeight() const { return hwPuppiWeight_; }
+    uint64_t encodedPuppi64() const { return encodedPuppi64_; }
+
+    void setHwZ0(int16_t hwZ0) { hwZ0_ = hwZ0; }
+    void setHwDxy(int16_t hwDxy) { hwDxy_ = hwDxy; }
+    void setHwTkQuality(uint16_t hwTkQuality) { hwTkQuality_ = hwTkQuality; }
+    void setHwPuppiWeight(uint16_t hwPuppiWeight) { hwPuppiWeight_ = hwPuppiWeight; }
+    void setEncodedPuppi64(uint64_t encodedPuppi64) { encodedPuppi64_ = encodedPuppi64; }
+
   private:
     PFClusterRef clusterRef_;
     PFTrackRef trackRef_;
     MuonRef muonRef_;
-    float puppiWeight_;
+    float dxy_, puppiWeight_;
+
+    int16_t hwZ0_, hwDxy_;
+    uint16_t hwTkQuality_, hwPuppiWeight_;
+    uint64_t encodedPuppi64_;
 
     void setPdgIdFromParticleType(int charge, ParticleType kind);
   };
@@ -57,5 +80,6 @@ namespace l1t {
   typedef std::vector<l1t::PFCandidate> PFCandidateCollection;
   typedef edm::Ref<l1t::PFCandidateCollection> PFCandidateRef;
   typedef edm::RefVector<l1t::PFCandidateCollection> PFCandidateRefVector;
+  typedef l1t::RegionalOutput<l1t::PFCandidateCollection> PFCandidateRegionalOutput;
 }  // namespace l1t
 #endif

--- a/DataFormats/L1TParticleFlow/interface/RegionalOutput.h
+++ b/DataFormats/L1TParticleFlow/interface/RegionalOutput.h
@@ -63,7 +63,7 @@ namespace l1t {
       unsigned int key() const { return idx_; }
 
     private:
-      RegionalOutput<T>* src_;
+      const RegionalOutput<T>* src_;
       unsigned int idx_;
     };
     typedef iterator const_iterator;
@@ -77,8 +77,8 @@ namespace l1t {
       const value_type& operator[](unsigned int idx) const { return src_->objAt(ibegin_ + idx); }
       const value_type& front() const { return src_->objAt(ibegin_); }
       const value_type& back() const { return src_->objAt(iend_ - 1); }
-      iterator begin() const { return iterator(src_, ibegin_); }
-      iterator end() const { return iterator(src_, iend_); }
+      iterator begin() const { return iterator(*src_, ibegin_); }
+      iterator end() const { return iterator(*src_, iend_); }
       unsigned int size() const { return iend_ - ibegin_; }
       bool empty() const { return (iend_ == ibegin_); }
       // interface to get EDM refs & related stuff
@@ -86,10 +86,10 @@ namespace l1t {
       edm::ProductID id() const { return src_->id(); }
 
     private:
-      RegionalOutput<T>* src_;
+      const RegionalOutput<T>* src_;
       unsigned int ibegin_, iend_;
       friend class RegionalOutput<T>;
-      Region(RegionalOutput<T>* src, unsigned int ibegin, unsigned int iend)
+      Region(const RegionalOutput<T>* src, unsigned int ibegin, unsigned int iend)
           : src_(src), ibegin_(ibegin), iend_(iend) {}
     };
 
@@ -117,10 +117,10 @@ namespace l1t {
     const_iterator begin() const { return const_iterator(this, 0); }
     const_iterator end() const { return const_iterator(this, values_.size()); }
 
-    Region region(unsigned int ireg) { return Region(this, ireg == 0 ? 0 : regions_[ireg - 1], regions_[ireg]); }
+    Region region(unsigned int ireg) const { return Region(this, ireg == 0 ? 0 : regions_[ireg - 1], regions_[ireg]); }
 
-    ref refAt(unsigned int idx) { return ref(refprod_, values_[idx]); }
-    const value_type& objAt(unsigned int idx) { return (*refprod_)[values_[idx]]; }
+    ref refAt(unsigned int idx) const { return ref(refprod_, values_[idx]); }
+    const value_type& objAt(unsigned int idx) const { return (*refprod_)[values_[idx]]; }
 
     //Used by ROOT storage
     CMS_CLASS_VERSION(10)

--- a/DataFormats/L1TParticleFlow/interface/RegionalOutput.h
+++ b/DataFormats/L1TParticleFlow/interface/RegionalOutput.h
@@ -1,0 +1,134 @@
+#ifndef DataFormats_L1TParticleFlow_RegionalOutput_h
+#define DataFormats_L1TParticleFlow_RegionalOutput_h
+
+#include "DataFormats/Common/interface/CMS_CLASS_VERSION.h"
+#include "DataFormats/Common/interface/RefProd.h"
+#include "DataFormats/Common/interface/Ref.h"
+#include <vector>
+
+namespace l1t {
+  template <typename T>
+  class RegionalOutput {
+  public:
+    typedef typename T::value_type value_type;
+    typedef edm::Ref<T> ref;
+    typedef edm::RefProd<T> refprod;
+
+    class iterator {
+    public:
+      typedef typename T::value_type value_type;
+      typedef ptrdiff_t difference_type;
+      iterator(const RegionalOutput<T>& src, unsigned int idx) : src_(&src), idx_(idx) {}
+      iterator(iterator const& it) : src_(it.src_), idx_(it.idx_) {}
+      iterator() : src_(nullptr), idx_(0) {}
+      iterator& operator++() {
+        ++idx_;
+        return *this;
+      }
+      iterator operator++(int) {
+        iterator ci = *this;
+        ++idx_;
+        return ci;
+      }
+      iterator& operator--() {
+        --idx_;
+        return *this;
+      }
+      iterator operator--(int) {
+        iterator ci = *this;
+        --idx_;
+        return ci;
+      }
+      difference_type operator-(iterator const& o) const { return idx_ - o.idx_; }
+      iterator operator+(difference_type n) const { return iterator(src_, idx_ + n); }
+      iterator operator-(difference_type n) const { return iterator(src_, idx_ - n); }
+      bool operator<(iterator const& o) const { return idx_ < o.idx_; }
+      bool operator==(iterator const& ci) const { return idx_ == ci.idx_; }
+      bool operator!=(iterator const& ci) const { return idx_ != ci.idx_; }
+      value_type const& operator*() const { return src_->objAt(idx_); }
+      value_type const* operator->() const { return &src_->objAt(idx_); }
+      iterator& operator+=(difference_type d) {
+        idx_ += d;
+        return *this;
+      }
+      iterator& operator-=(difference_type d) {
+        idx_ -= d;
+        return *this;
+      }
+      value_type const& operator[](difference_type d) const { return src_->objAt(idx_ + d); }
+      // interface to get EDM refs & related stuff
+      edm::Ref<T> ref() const { return src_->refAt(idx_); }
+      edm::ProductID id() const { return src_->id(); }
+      unsigned int idx() const { return idx_; }
+      unsigned int key() const { return idx_; }
+
+    private:
+      RegionalOutput<T>* src_;
+      unsigned int idx_;
+    };
+    typedef iterator const_iterator;
+
+    class Region {
+    public:
+      typedef typename T::value_type value_type;
+      typedef typename RegionalOutput<T>::iterator iterator;
+      typedef typename RegionalOutput<T>::const_iterator const_iterator;
+
+      const value_type& operator[](unsigned int idx) const { return src_->objAt(ibegin_ + idx); }
+      const value_type& front() const { return src_->objAt(ibegin_); }
+      const value_type& back() const { return src_->objAt(iend_ - 1); }
+      iterator begin() const { return iterator(src_, ibegin_); }
+      iterator end() const { return iterator(src_, iend_); }
+      unsigned int size() const { return iend_ - ibegin_; }
+      bool empty() const { return (iend_ == ibegin_); }
+      // interface to get EDM refs & related stuff
+      ref refAt(unsigned int idx) const { return src_->refAt(ibegin_ + idx); }
+      edm::ProductID id() const { return src_->id(); }
+
+    private:
+      RegionalOutput<T>* src_;
+      unsigned int ibegin_, iend_;
+      friend class RegionalOutput<T>;
+      Region(RegionalOutput<T>* src, unsigned int ibegin, unsigned int iend)
+          : src_(src), ibegin_(ibegin), iend_(iend) {}
+    };
+
+    RegionalOutput() : refprod_(), values_(), regions_() {}
+    RegionalOutput(const edm::RefProd<T>& prod) : refprod_(prod), values_(), regions_() {}
+
+    void addRegion(const std::vector<int>& indices) {
+      regions_.emplace_back((regions_.empty() ? 0 : regions_.back()) + indices.size());
+      values_.insert(values_.end(), indices.begin(), indices.end());
+    }
+
+    edm::ProductID id() const { return refprod_.id(); }
+    unsigned int size() const { return values_.size(); }
+    unsigned int nRegions() const { return regions_.size(); }
+    bool empty() const { return values_.empty(); }
+    void clear() {
+      values_.clear();
+      regions_.clear();
+    }
+    void shrink_to_fit() {
+      values_.shrink_to_fit();
+      regions_.shrink_to_fit();
+    }
+
+    const_iterator begin() const { return const_iterator(this, 0); }
+    const_iterator end() const { return const_iterator(this, values_.size()); }
+
+    Region region(unsigned int ireg) { return Region(this, ireg == 0 ? 0 : regions_[ireg - 1], regions_[ireg]); }
+
+    ref refAt(unsigned int idx) { return ref(refprod_, values_[idx]); }
+    const value_type& objAt(unsigned int idx) { return (*refprod_)[values_[idx]]; }
+
+    //Used by ROOT storage
+    CMS_CLASS_VERSION(10)
+
+  protected:
+    refprod refprod_;
+    std::vector<unsigned int> values_;   // list of indices to objects in each region, flattened.
+    std::vector<unsigned int> regions_;  // for each region, store the index of one-past the last object in values
+  };
+}  // namespace l1t
+#endif

--- a/DataFormats/L1TParticleFlow/src/PFCandidate.cc
+++ b/DataFormats/L1TParticleFlow/src/PFCandidate.cc
@@ -2,7 +2,14 @@
 
 l1t::PFCandidate::PFCandidate(
     ParticleType kind, int charge, const PolarLorentzVector& p, float puppiWeight, int hwpt, int hweta, int hwphi)
-    : L1Candidate(p, hwpt, hweta, hwphi, /*hwQuality=*/int(kind)), puppiWeight_(puppiWeight) {
+    : L1Candidate(p, hwpt, hweta, hwphi, /*hwQuality=*/int(kind)),
+      dxy_(0),
+      puppiWeight_(puppiWeight),
+      hwZ0_(0),
+      hwDxy_(0),
+      hwTkQuality_(0),
+      hwPuppiWeight_(0),
+      encodedPuppi64_(0) {
   setCharge(charge);
   setPdgIdFromParticleType(charge, kind);
 }

--- a/DataFormats/L1TParticleFlow/src/classes_def.xml
+++ b/DataFormats/L1TParticleFlow/src/classes_def.xml
@@ -18,13 +18,17 @@
   <class name="edm::RefVector<l1t::PFTrackCollection>" /> 
   <class name="std::vector<edm::Ref<l1t::PFTrackCollection> >" />
 
-  <class name="l1t::PFCandidate"  ClassVersion="3">
+  <class name="l1t::PFCandidate"  ClassVersion="4">
+        <version ClassVersion="4" checksum="3798885201"/>
         <version ClassVersion="3" checksum="4253860178"/>
   </class>
   <class name="l1t::PFCandidateCollection" />
   <class name="edm::Wrapper<l1t::PFCandidateCollection>" />
   <class name="edm::Ref<l1t::PFCandidateCollection>" />
   <class name="edm::RefVector<l1t::PFCandidateCollection>" />
+  <class name="edm::RefProd<l1t::PFCandidateCollection>" />
+  <class name="l1t::RegionalOutput<l1t::PFCandidateCollection>" />
+  <class name="edm::Wrapper<l1t::RegionalOutput<l1t::PFCandidateCollection>>" />
 
   <class name="l1t::PFJet"  ClassVersion="3">
         <version ClassVersion="3" checksum="133342988"/>

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc
@@ -20,7 +20,8 @@
 #include "DataFormats/Math/interface/deltaR.h"
 
 #include "L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/layer1_emulator.h"
-#include "L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/regionizer_base_ref.h"
+#include "L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/common/regionizer_base_ref.h"
+#include "L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/multififo/multififo_regionizer_ref.h"
 #include "L1Trigger/Phase2L1ParticleFlow/src/newfirmware/pf/pfalgo2hgc_ref.h"
 #include "L1Trigger/Phase2L1ParticleFlow/src/newfirmware/pf/pfalgo3_ref.h"
 #include "L1Trigger/Phase2L1ParticleFlow/src/newfirmware/pf/pfalgo_dummy_ref.h"
@@ -167,7 +168,9 @@ L1TCorrelatorLayer1Producer::L1TCorrelatorLayer1Producer(const edm::ParameterSet
 
   const std::string &regalgo = iConfig.getParameter<std::string>("regionizerAlgo");
   if (regalgo == "Ideal") {
-    regionizer_ = std::make_unique<l1ct::RegionizerEmulator>();
+    regionizer_ = std::make_unique<l1ct::RegionizerEmulator>(iConfig.getParameter<edm::ParameterSet>("regionizerAlgoParameters"));
+  } else if (regalgo == "Multififo") {
+    regionizer_ = std::make_unique<l1ct::MultififoRegionizerEmulator>(iConfig.getParameter<edm::ParameterSet>("regionizerAlgoParameters"));
   } else
     throw cms::Exception("Configuration", "Unsupported regionizerAlgo");
 

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc
@@ -168,9 +168,11 @@ L1TCorrelatorLayer1Producer::L1TCorrelatorLayer1Producer(const edm::ParameterSet
 
   const std::string &regalgo = iConfig.getParameter<std::string>("regionizerAlgo");
   if (regalgo == "Ideal") {
-    regionizer_ = std::make_unique<l1ct::RegionizerEmulator>(iConfig.getParameter<edm::ParameterSet>("regionizerAlgoParameters"));
+    regionizer_ =
+        std::make_unique<l1ct::RegionizerEmulator>(iConfig.getParameter<edm::ParameterSet>("regionizerAlgoParameters"));
   } else if (regalgo == "Multififo") {
-    regionizer_ = std::make_unique<l1ct::MultififoRegionizerEmulator>(iConfig.getParameter<edm::ParameterSet>("regionizerAlgoParameters"));
+    regionizer_ = std::make_unique<l1ct::MultififoRegionizerEmulator>(
+        iConfig.getParameter<edm::ParameterSet>("regionizerAlgoParameters"));
   } else
     throw cms::Exception("Configuration", "Unsupported regionizerAlgo");
 

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc
@@ -151,7 +151,7 @@ L1TCorrelatorLayer1Producer::L1TCorrelatorLayer1Producer(const edm::ParameterSet
       debugR_(iConfig.getUntrackedParameter<double>("debugR", -1)) {
   produces<l1t::PFCandidateCollection>("PF");
   produces<l1t::PFCandidateCollection>("Puppi");
-  produces<l1t::PFCandidateRegionalOutput>("Puppi");
+  produces<l1t::PFCandidateRegionalOutput>("PuppiRegional");
 
   produces<l1t::PFCandidateCollection>("EmCalo");
   produces<l1t::PFCandidateCollection>("Calo");
@@ -753,7 +753,7 @@ void L1TCorrelatorLayer1Producer::putPuppi(edm::Event &iEvent) const {
     reg->addRegion(nobj);
   }
   iEvent.put(std::move(coll), "Puppi");
-  iEvent.put(std::move(reg), "Puppi");
+  iEvent.put(std::move(reg), "PuppiRegional");
 }
 
 void L1TCorrelatorLayer1Producer::putEgObjects(edm::Event &iEvent,

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TPFCandMultiMerger.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TPFCandMultiMerger.cc
@@ -16,34 +16,78 @@ public:
 private:
   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
-  std::vector<std::string> instances_;
-  std::vector<edm::EDGetTokenT<std::vector<l1t::PFCandidate>>> tokens_;
+  std::vector<std::string> instances_, regionalInstances_;
+  std::vector<bool> alsoRegional_;  // aligned with instances_
+  std::vector<edm::EDGetTokenT<l1t::PFCandidateCollection>> tokens_;
+  std::vector<edm::EDGetTokenT<l1t::PFCandidateRegionalOutput>> regionalTokens_;
 };
 
 L1TPFCandMultiMerger::L1TPFCandMultiMerger(const edm::ParameterSet& iConfig)
-    : instances_(iConfig.getParameter<std::vector<std::string>>("labelsToMerge")) {
+    : instances_(iConfig.getParameter<std::vector<std::string>>("labelsToMerge")),
+      regionalInstances_(iConfig.getParameter<std::vector<std::string>>("regionalLabelsToMerge")) {
   const std::vector<edm::InputTag>& pfProducers = iConfig.getParameter<std::vector<edm::InputTag>>("pfProducers");
   tokens_.reserve(instances_.size() * pfProducers.size());
-  for (unsigned int ii = 0, ni = instances_.size(); ii < ni; ++ii) {
+  for (const std::string& instance : instances_) {
     for (const edm::InputTag& tag : pfProducers) {
-      tokens_.push_back(
-          consumes<std::vector<l1t::PFCandidate>>(edm::InputTag(tag.label(), instances_[ii], tag.process())));
+      tokens_.push_back(consumes<l1t::PFCandidateCollection>(edm::InputTag(tag.label(), instance, tag.process())));
     }
-    produces<std::vector<l1t::PFCandidate>>(instances_[ii]);
+    produces<l1t::PFCandidateCollection>(instance);
+    // check if regional output is needed too
+    if (std::find(regionalInstances_.begin(), regionalInstances_.end(), instance) != regionalInstances_.end()) {
+      alsoRegional_.push_back(true);
+      for (const edm::InputTag& tag : pfProducers) {
+        regionalTokens_.push_back(
+            consumes<l1t::PFCandidateRegionalOutput>(edm::InputTag(tag.label(), instance + "Regional", tag.process())));
+      }
+      produces<l1t::PFCandidateRegionalOutput>(instance + "Regional");
+    } else {
+      alsoRegional_.push_back(false);
+    }
+  }
+  // check that regional output is not requested without the standard one
+  for (const std::string& instance : regionalInstances_) {
+    auto match = std::find(instances_.begin(), instances_.end(), instance);
+    if (match == instances_.end()) {
+      throw cms::Exception("Configuration", "The regional label '" + instance + "' is not in labelsToMerge\n");
+    }
   }
 }
 
 L1TPFCandMultiMerger::~L1TPFCandMultiMerger() {}
 
 void L1TPFCandMultiMerger::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup&) const {
-  edm::Handle<std::vector<l1t::PFCandidate>> handle;
-  for (unsigned int ii = 0, it = 0, ni = instances_.size(), np = tokens_.size() / ni; ii < ni; ++ii) {
-    auto out = std::make_unique<std::vector<l1t::PFCandidate>>();
-    for (unsigned int ip = 0; ip < np; ++ip, ++it) {
+  edm::Handle<l1t::PFCandidateCollection> handle;
+  edm::Handle<l1t::PFCandidateRegionalOutput> regionalHandle;
+  unsigned int ninstances = instances_.size(), nproducers = tokens_.size() / ninstances;
+  std::vector<int> keys;
+  for (unsigned int ii = 0, it = 0, irt = 0; ii < ninstances; ++ii) {
+    auto out = std::make_unique<l1t::PFCandidateCollection>();
+    std::unique_ptr<l1t::PFCandidateRegionalOutput> regout;
+    if (alsoRegional_[ii]) {
+      auto refprod = iEvent.getRefBeforePut<l1t::PFCandidateCollection>(instances_[ii]);
+      regout = std::make_unique<l1t::PFCandidateRegionalOutput>(edm::RefProd<l1t::PFCandidateCollection>(refprod));
+    }
+    for (unsigned int ip = 0; ip < nproducers; ++ip, ++it) {
       iEvent.getByToken(tokens_[it], handle);
+      unsigned int offset = out->size();
       out->insert(out->end(), handle->begin(), handle->end());
+      if (alsoRegional_[ii]) {
+        iEvent.getByToken(regionalTokens_[irt++], regionalHandle);
+        const auto& src = *regionalHandle;
+        for (unsigned int ireg = 0, nreg = src.nRegions(); ireg < nreg; ++ireg) {
+          auto region = src.region(ireg);
+          keys.clear();
+          for (auto iter = region.begin(), iend = region.end(); iter != iend; ++iter) {
+            keys.push_back(iter.idx() + offset);
+          }
+          regout->addRegion(keys);
+        }
+      }
     }
     iEvent.put(std::move(out), instances_[ii]);
+    if (alsoRegional_[ii]) {
+      iEvent.put(std::move(regout), instances_[ii] + "Regional");
+    }
   }
 }
 

--- a/L1Trigger/Phase2L1ParticleFlow/python/l1ParticleFlow_cff.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1ParticleFlow_cff.py
@@ -311,6 +311,7 @@ l1pfCandidates = cms.EDProducer("L1TPFCandMultiMerger",
         cms.InputTag("l1pfProducerHF")
     ),
     labelsToMerge = cms.vstring("Calo", "TK", "TKVtx", "PF", "Puppi"),
+    regionalLabelsToMerge = cms.vstring(),
 )
 
 l1tCorrelatorEG = cms.EDProducer(

--- a/L1Trigger/Phase2L1ParticleFlow/python/l1ctLayer1_cff.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1ctLayer1_cff.py
@@ -315,6 +315,7 @@ l1ctLayer1 = cms.EDProducer("L1TPFCandMultiMerger",
         cms.InputTag("l1ctLayer1HF")
     ),
     labelsToMerge = cms.vstring("PF", "Puppi"),
+    regionalLabelsToMerge = cms.vstring("Puppi"),
 )
 
 l1ctLayer1EG = cms.EDProducer(

--- a/L1Trigger/Phase2L1ParticleFlow/python/l1ctLayer1_cff.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1ctLayer1_cff.py
@@ -16,6 +16,9 @@ l1ctLayer1Barrel = cms.EDProducer("L1TCorrelatorLayer1Producer",
     regionizerAlgo = cms.string("Ideal"),
     pfAlgo = cms.string("PFAlgo3"),
     puAlgo = cms.string("LinearizedPuppi"),
+    regionizerAlgoParameters = cms.PSet(
+        useAlsoVtxCoords = cms.bool(True),
+    ),
     pfAlgoParameters = cms.PSet(
         nTrack = cms.uint32(50), # very large numbers for first test
         nCalo = cms.uint32(50), # very large numbers for first test
@@ -102,6 +105,9 @@ l1ctLayer1HGCal = cms.EDProducer("L1TCorrelatorLayer1Producer",
     regionizerAlgo = cms.string("Ideal"),
     pfAlgo = cms.string("PFAlgo2HGC"),
     puAlgo = cms.string("LinearizedPuppi"),
+    regionizerAlgoParameters = cms.PSet(
+        useAlsoVtxCoords = cms.bool(True),
+    ),
     pfAlgoParameters = cms.PSet(
         nTrack = cms.uint32(50), # very large numbers for first test
         nCalo = cms.uint32(50), # very large numbers for first test
@@ -176,6 +182,9 @@ l1ctLayer1HGCalNoTK = cms.EDProducer("L1TCorrelatorLayer1Producer",
     regionizerAlgo = cms.string("Ideal"),
     pfAlgo = cms.string("PFAlgoDummy"),
     puAlgo = cms.string("LinearizedPuppi"),
+    regionizerAlgoParameters = cms.PSet(
+        useAlsoVtxCoords = cms.bool(True),
+    ),
     pfAlgoParameters = cms.PSet(
         nCalo = cms.uint32(50), # very large numbers for first test
         nMu = cms.uint32(5), # very large numbers for first test
@@ -238,6 +247,9 @@ l1ctLayer1HF = cms.EDProducer("L1TCorrelatorLayer1Producer",
     regionizerAlgo = cms.string("Ideal"),
     pfAlgo = cms.string("PFAlgoDummy"),
     puAlgo = cms.string("LinearizedPuppi"),
+    regionizerAlgoParameters = cms.PSet(
+        useAlsoVtxCoords = cms.bool(True),
+    ),
     pfAlgoParameters = cms.PSet(
         nCalo = cms.uint32(50), # very large numbers for first test
         nMu = cms.uint32(5), # very large numbers for first test

--- a/L1Trigger/Phase2L1ParticleFlow/src/RegionMapper.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/RegionMapper.cc
@@ -212,8 +212,10 @@ std::unique_ptr<l1t::PFCandidateCollection> RegionMapper::fetch(bool puppi, floa
       if (p.floatPt() > ptMin) {
         reco::Particle::PolarLorentzVector p4(
             p.floatPt(), r.globalEta(p.floatVtxEta()), r.globalPhi(p.floatVtxPhi()), 0.13f);
-        ret->emplace_back(l1t::PFCandidate::ParticleType(p.hwId), p.intCharge(), p4, p.floatPuppiW());
-        ret->back().setVertex(reco::Particle::Point(0, 0, p.floatDZ()));
+        ret->emplace_back(
+            l1t::PFCandidate::ParticleType(p.hwId), p.intCharge(), p4, p.floatPuppiW(), p.hwPt, p.hwEta, p.hwPhi);
+        ret->back().setZ0(p.floatDZ());
+        ret->back().setHwZ0(p.track.hwZ0);
         ret->back().setStatus(p.hwStatus);
         if (p.cluster.src) {
           auto match = clusterRefMap_.find(p.cluster.src);
@@ -255,7 +257,7 @@ std::unique_ptr<l1t::PFCandidateCollection> RegionMapper::fetchCalo(float ptMin,
         reco::Particle::PolarLorentzVector p4(p.floatPt(), r.globalEta(p.floatEta()), r.globalPhi(p.floatPhi()), 0.13f);
         l1t::PFCandidate::ParticleType kind =
             (p.isEM || emcalo) ? l1t::PFCandidate::Photon : l1t::PFCandidate::NeutralHadron;
-        ret->emplace_back(kind, 0, p4);
+        ret->emplace_back(kind, /*charge=*/0, p4, /*puppiW=*/1, p.hwPt, p.hwEta, p.hwPhi);
         if (p.src) {
           auto match = clusterRefMap_.find(p.src);
           if (match == clusterRefMap_.end()) {
@@ -294,8 +296,9 @@ std::unique_ptr<l1t::PFCandidateCollection> RegionMapper::fetchTracks(float ptMi
         reco::Particle::PolarLorentzVector p4(
             p.floatVtxPt(), r.globalEta(p.floatVtxEta()), r.globalPhi(p.floatVtxPhi()), 0.13f);
         l1t::PFCandidate::ParticleType kind = p.muonLink ? l1t::PFCandidate::Muon : l1t::PFCandidate::ChargedHadron;
-        ret->emplace_back(kind, p.intCharge(), p4);
-        ret->back().setVertex(reco::Particle::Point(0, 0, p.floatDZ()));
+        ret->emplace_back(kind, p.intCharge(), p4, /*puppiW=*/float(p.fromPV), p.hwPt, p.hwEta, p.hwPhi);
+        ret->back().setZ0(p.floatDZ());
+        ret->back().setHwZ0(p.hwZ0);
         if (p.src) {
           auto match = trackRefMap_.find(p.src);
           if (match == trackRefMap_.end()) {

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/datatypes.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/datatypes.h
@@ -19,6 +19,7 @@
 namespace l1ct {
 
   typedef ap_ufixed<14, 12, AP_TRN, AP_SAT> pt_t;
+  typedef ap_ufixed<10, 8, AP_TRN, AP_SAT> pt10_t;
   typedef ap_fixed<16, 14, AP_TRN, AP_SAT> dpt_t;
   typedef ap_ufixed<28, 24, AP_TRN, AP_SAT> pt2_t;
   typedef ap_int<10> eta_t;

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/jets.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/jets.h
@@ -1,0 +1,57 @@
+#ifndef FIRMWARE_dataformats_jets_h
+#define FIRMWARE_dataformats_jets_h
+
+#include "datatypes.h"
+#include "bit_encoding.h"
+
+namespace l1ct {
+
+  struct Jet {
+    pt_t hwPt;
+    glbeta_t hwEta;
+    glbphi_t hwPhi;
+
+    inline bool operator==(const Jet &other) const {
+      return hwPt == other.hwPt && hwEta == other.hwEta && hwPhi == other.hwPhi;
+    }
+
+    inline bool operator>(const Jet &other) const { return hwPt > other.hwPt; }
+    inline bool operator<(const Jet &other) const { return hwPt < other.hwPt; }
+
+    inline void clear() {
+      hwPt = 0;
+      hwEta = 0;
+      hwPhi = 0;
+    }
+
+    int intPt() const { return Scales::intPt(hwPt); }
+    int intEta() const { return hwEta.to_int(); }
+    int intPhi() const { return hwPhi.to_int(); }
+    float floatPt() const { return Scales::floatPt(hwPt); }
+    float floatEta() const { return Scales::floatEta(hwEta); }
+    float floatPhi() const { return Scales::floatPhi(hwPhi); }
+
+    static const int BITWIDTH = pt_t::width + glbeta_t::width + glbphi_t::width;
+    inline ap_uint<BITWIDTH> pack() const {
+      ap_uint<BITWIDTH> ret;
+      unsigned int start = 0;
+      _pack_into_bits(ret, start, hwPt);
+      _pack_into_bits(ret, start, hwEta);
+      _pack_into_bits(ret, start, hwPhi);
+      return ret;
+    }
+    inline static Jet unpack(const ap_uint<BITWIDTH> &src) {
+      Jet ret;
+      unsigned int start = 0;
+      _unpack_from_bits(src, start, ret.hwPt);
+      _unpack_from_bits(src, start, ret.hwEta);
+      _unpack_from_bits(src, start, ret.hwPhi);
+      return ret;
+    }
+  };
+
+  inline void clear(Jet &c) { c.clear(); }
+
+}  // namespace l1ct
+
+#endif

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/layer1_emulator.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/layer1_emulator.cpp
@@ -51,12 +51,14 @@ bool l1ct::PFChargedObjEmu::read(std::fstream& from) {
   srcTrack = nullptr;    // not persistent
   srcCluster = nullptr;  // not persistent
   srcMu = nullptr;       // not persistent
+  srcCand = nullptr;     // not persistent
   return readObj<PFChargedObj>(from, *this);
 }
 bool l1ct::PFChargedObjEmu::write(std::fstream& to) const { return writeObj<PFChargedObj>(*this, to); }
 
 bool l1ct::PFNeutralObjEmu::read(std::fstream& from) {
   srcCluster = nullptr;  // not persistent
+  srcCand = nullptr;     // not persistent
   return readObj<PFNeutralObj>(from, *this);
 }
 bool l1ct::PFNeutralObjEmu::write(std::fstream& to) const { return writeObj<PFNeutralObj>(*this, to); }
@@ -65,6 +67,7 @@ bool l1ct::PuppiObjEmu::read(std::fstream& from) {
   srcTrack = nullptr;    // not persistent
   srcCluster = nullptr;  // not persistent
   srcMu = nullptr;       // not persistent
+  srcCand = nullptr;     // not persistent
   return readObj<PuppiObj>(from, *this);
 }
 bool l1ct::PuppiObjEmu::write(std::fstream& to) const { return writeObj<PuppiObj>(*this, to); }

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/layer1_emulator.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/layer1_emulator.h
@@ -64,6 +64,7 @@ namespace l1ct {
     const l1t::PFCluster *srcCluster;
     const l1t::PFTrack *srcTrack;
     const l1t::Muon *srcMu;
+    const l1t::PFCandidate *srcCand;
     bool read(std::fstream &from);
     bool write(std::fstream &to) const;
     void clear() {
@@ -71,16 +72,19 @@ namespace l1ct {
       srcCluster = nullptr;
       srcTrack = nullptr;
       srcMu = nullptr;
+      srcCand = nullptr;
     }
   };
 
   struct PFNeutralObjEmu : public PFNeutralObj {
     const l1t::PFCluster *srcCluster;
+    const l1t::PFCandidate *srcCand;
     bool read(std::fstream &from);
     bool write(std::fstream &to) const;
     void clear() {
       PFNeutralObj::clear();
       srcCluster = nullptr;
+      srcCand = nullptr;
     }
   };
 
@@ -101,6 +105,7 @@ namespace l1ct {
     const l1t::PFCluster *srcCluster;
     const l1t::PFTrack *srcTrack;
     const l1t::Muon *srcMu;
+    const l1t::PFCandidate *srcCand;
     bool read(std::fstream &from);
     bool write(std::fstream &to) const;
     void clear() {
@@ -108,24 +113,28 @@ namespace l1ct {
       srcCluster = nullptr;
       srcTrack = nullptr;
       srcMu = nullptr;
+      srcCand = nullptr;
     }
     inline void fill(const PFRegionEmu &region, const PFChargedObjEmu &src) {
       PuppiObj::fill(region, src);
       srcCluster = src.srcCluster;
       srcTrack = src.srcTrack;
       srcMu = src.srcMu;
+      srcCand = src.srcCand;
     }
     inline void fill(const PFRegionEmu &region, const PFNeutralObjEmu &src, pt_t puppiPt, puppiWgt_t puppiWgt) {
       PuppiObj::fill(region, src, puppiPt, puppiWgt);
       srcCluster = src.srcCluster;
       srcTrack = nullptr;
       srcMu = nullptr;
+      srcCand = src.srcCand;
     }
     inline void fill(const PFRegionEmu &region, const HadCaloObjEmu &src, pt_t puppiPt, puppiWgt_t puppiWgt) {
       PuppiObj::fill(region, src, puppiPt, puppiWgt);
       srcCluster = src.src;
       srcTrack = nullptr;
       srcMu = nullptr;
+      srcCand = nullptr;
     }
   };
 

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/pf.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/pf.h
@@ -183,7 +183,8 @@ namespace l1ct {
     }
 
     inline glbeta_t hwGlbEta(eta_t hwEta) const { return hwEtaCenter + hwEta; }
-    inline glbphi_t hwGlbPhi(phi_t hwPhi) const {
+    inline glbeta_t hwGlbEta(glbeta_t hwEta) const { return hwEtaCenter + hwEta; }
+    inline glbphi_t hwGlbPhi(glbphi_t hwPhi) const {
       ap_int<glbphi_t::width + 1> ret = hwPhiCenter + hwPhi;
       if (ret > Scales::INTPHI_PI)
         return ret - Scales::INTPHI_TWOPI;
@@ -204,6 +205,8 @@ namespace l1ct {
 
     inline float floatGlbEta(eta_t hwEta) const { return Scales::floatEta(hwGlbEta(hwEta)); }
     inline float floatGlbPhi(phi_t hwPhi) const { return Scales::floatPhi(hwGlbPhi(hwPhi)); }
+    inline float floatGlbEta(glbeta_t hwEta) const { return Scales::floatEta(hwGlbEta(hwEta)); }
+    inline float floatGlbPhi(glbphi_t hwPhi) const { return Scales::floatPhi(hwGlbPhi(hwPhi)); }
 
     template <typename T>
     inline float floatGlbEtaOf(const T &t) const {

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/sums.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/sums.h
@@ -1,0 +1,54 @@
+#ifndef FIRMWARE_dataformats_sums_h
+#define FIRMWARE_dataformats_sums_h
+
+#include "datatypes.h"
+#include "bit_encoding.h"
+
+namespace l1ct {
+
+  struct Sum {
+    pt_t hwPt;
+    glbphi_t hwPhi;
+    pt_t hwSumPt;
+
+    inline bool operator==(const Sum &other) const {
+      return hwPt == other.hwPt && hwPhi == other.hwPhi && hwSumPt == other.hwSumPt;
+    }
+
+    inline void clear() {
+      hwPt = 0;
+      hwPhi = 0;
+      hwSumPt = 0;
+    }
+
+    int intPt() const { return Scales::intPt(hwPt); }
+    int intPhi() const { return hwPhi.to_int(); }
+    int intSumPt() const { return Scales::intPt(hwSumPt); }
+    float floatPt() const { return Scales::floatPt(hwPt); }
+    float floatPhi() const { return Scales::floatPhi(hwPhi); }
+    float floatSumPt() const { return Scales::floatPt(hwSumPt); }
+
+    static const int BITWIDTH = pt_t::width + glbphi_t::width + pt_t::width;
+    inline ap_uint<BITWIDTH> pack() const {
+      ap_uint<BITWIDTH> ret;
+      unsigned int start = 0;
+      _pack_into_bits(ret, start, hwPt);
+      _pack_into_bits(ret, start, hwPhi);
+      _pack_into_bits(ret, start, hwSumPt);
+      return ret;
+    }
+    inline static Sum unpack(const ap_uint<BITWIDTH> &src) {
+      Sum ret;
+      unsigned int start = 0;
+      _unpack_from_bits(src, start, ret.hwPt);
+      _unpack_from_bits(src, start, ret.hwPhi);
+      _unpack_from_bits(src, start, ret.hwSumPt);
+      return ret;
+    }
+  };
+
+  inline void clear(Sum &c) { c.clear(); }
+
+}  // namespace l1ct
+
+#endif

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/taus.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/taus.h
@@ -1,0 +1,107 @@
+#ifndef FIRMWARE_dataformats_jets_h
+#define FIRMWARE_dataformats_jets_h
+
+#include "datatypes.h"
+#include "bit_encoding.h"
+
+namespace l1ct {
+
+  struct Tau {
+    typedef ap_uint<2> type_t;
+    typedef ap_uint<10> rawid_t;
+    typedef ap_uint<2> lepid_t;
+
+    pt_t hwPt;
+    glbeta_t hwEta;
+    glbphi_t hwPhi;
+    pt10_t hwSeedPt;
+    z0_t hwSeedZ0;
+    bool hwCharge;
+    type_t hwType;
+    rawid_t hwRawId;  // will contain isolation or MVA output
+    lepid_t hwIdVsMu;
+    lepid_t hwIdVsEle;
+
+    inline bool operator==(const Tau &other) const {
+      return hwPt == other.hwPt && hwEta == other.hwEta && hwPhi == other.hwPhi && hwSeedPt == other.hwSeedPt &&
+             hwSeedZ0 == other.hwSeedZ0 && hwCharge == other.hwCharge && hwType == other.hwType &&
+             hwIsoOrMVA == other.hwIsoOrMVA && hwIdVsMu == other.hwIdVsMu && hwIdVsEle == other.hwIdVsEle;
+    }
+
+    inline bool operator>(const Tau &other) const { return hwPt > other.hwPt; }
+    inline bool operator<(const Tau &other) const { return hwPt < other.hwPt; }
+
+    inline pt10_t hwAbsIso() const {
+      pt10_t ret;
+      ret(9, 0) = hwRawId(9, 0);
+      return ret;
+    }
+
+    inline void setAbsIso(pt10_t absIso) { hwRawId(9, 0) = absIso(9, 0); }
+
+    inline void clear() {
+      hwPt = 0;
+      hwEta = 0;
+      hwPhi = 0;
+      hwSeedPt = 0;
+      hwSeedZ0 = 0;
+      hwCharge = 0;
+      hwType = 0;
+      hwIsoOrMVA = 0;
+      hwIdVsMu = 0;
+      hwIdVsEle = 0;
+    }
+
+    int intPt() const { return Scales::intPt(hwPt); }
+    int intEta() const { return hwEta.to_int(); }
+    int intPhi() const { return hwPhi.to_int(); }
+    int intSeedPt() const { return Scales::intPt(hwSeedPt); }
+    float floatPt() const { return Scales::floatPt(hwPt); }
+    float floatEta() const { return Scales::floatEta(hwEta); }
+    float floatPhi() const { return Scales::floatPhi(hwPhi); }
+    float floatSeedPt() const { return Scales::floatPt(hwSeedPt); }
+    float floatSeedZ0() const { return Scales::floatZ0(hwSeedZ0); }
+    int intCharge() const { return hwCharge ? +1 : -1; }
+    int pdgId() const { return -15 * intCharge(); }
+    int intType() const { return hwType.to_int(); }
+
+    float floatAbsIso() const { return Scales::floatPt(hwAbsIso()); }
+
+    static const int BITWIDTH = pt_t::width + glbeta_t::width + glbphi_t::width + pt10_t::width + z0_t::width + 1 +
+                                type_t::width + rawid_t::width + 2 * lepid_t::width;
+    inline ap_uint<BITWIDTH> pack() const {
+      ap_uint<BITWIDTH> ret;
+      unsigned int start = 0;
+      _pack_into_bits(ret, start, hwPt);
+      _pack_into_bits(ret, start, hwEta);
+      _pack_into_bits(ret, start, hwPhi);
+      _pack_into_bits(ret, start, hwSeedPt);
+      _pack_into_bits(ret, start, hwSeedZ0);
+      _pack_bool_into_bits(ret, start, hwCharge);
+      _pack_into_bits(ret, start, hwType);
+      _pack_into_bits(ret, start, hwRawId);
+      _pack_into_bits(ret, start, hwIdVsMu);
+      _pack_into_bits(ret, start, hwIdVsEle);
+      return ret;
+    }
+    inline static Tau unpack(const ap_uint<BITWIDTH> &src) {
+      Tau ret;
+      unsigned int start = 0;
+      _unpack_from_bits(src, start, ret.hwPt);
+      _unpack_from_bits(src, start, ret.hwEta);
+      _unpack_from_bits(src, start, ret.hwPhi);
+      _unpack_from_bits(src, start, ret.hwSeedPt);
+      _unpack_from_bits(src, start, ret.hwSeedZ0);
+      _unpack_from_bits(src, start, ret.hwType);
+      _unpack_from_bits(src, start, ret.hwRawId);
+      _unpack_from_bits(src, start, ret.hwIdVsMu);
+      _unpack_from_bits(src, start, ret.hwIdVsEle);
+      return ret;
+    }
+  };
+
+  inline void clear(Tau &c) { c.clear(); }
+
+}  // namespace l1ct
+
+#endif

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/puppi/linpuppi_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/puppi/linpuppi_ref.cpp
@@ -21,7 +21,7 @@ l1ct::LinPuppiEmulator::LinPuppiEmulator(unsigned int nTrack,
                                          unsigned int nOut,
                                          unsigned int dR2Min,
                                          unsigned int dR2Max,
-                                         unsigned int ptMax,
+                                         unsigned int iptMax,
                                          unsigned int dzCut,
                                          glbeta_t etaCut,
                                          double ptSlopeNe_0,
@@ -49,7 +49,7 @@ l1ct::LinPuppiEmulator::LinPuppiEmulator(unsigned int nTrack,
       nOut_(nOut),
       dR2Min_(dR2Min),
       dR2Max_(dR2Max),
-      ptMax_(ptMax),
+      iptMax_(iptMax),
       dzCut_(dzCut),
       absEtaBins_(1, etaCut),
       ptSlopeNe_(2),
@@ -92,7 +92,7 @@ l1ct::LinPuppiEmulator::LinPuppiEmulator(const edm::ParameterSet &iConfig)
       nOut_(iConfig.getParameter<uint32_t>("nOut")),
       dR2Min_(l1ct::Scales::makeDR2FromFloatDR(iConfig.getParameter<double>("drMin"))),
       dR2Max_(l1ct::Scales::makeDR2FromFloatDR(iConfig.getParameter<double>("dr"))),
-      ptMax_(l1ct::Scales::makePtFromFloat(iConfig.getParameter<double>("ptMax"))),
+      iptMax_(l1ct::Scales::intPt(l1ct::Scales::makePtFromFloat(iConfig.getParameter<double>("ptMax")))),
       dzCut_(l1ct::Scales::makeZ0(iConfig.getParameter<double>("dZ"))),
       absEtaBins_(
           edm::vector_transform(iConfig.getParameter<std::vector<double>>("absEtaCuts"), l1ct::Scales::makeGlbEta)),
@@ -306,7 +306,7 @@ void l1ct::LinPuppiEmulator::fwdlinpuppi_ref(const PFRegionEmu &region,
                                              std::vector<PuppiObjEmu> &outallne /*[nIn]*/,
                                              std::vector<PuppiObjEmu> &outselne /*[nOut]*/) const {
   const unsigned int nIn = std::min<unsigned int>(nIn_, caloin.size());
-  const int PTMAX2 = (ptMax_ * ptMax_);
+  const int PTMAX2 = (iptMax_ * iptMax_);
 
   const int sum_bitShift = LINPUPPI_sum_bitShift;
 
@@ -360,7 +360,7 @@ void l1ct::LinPuppiEmulator::linpuppi_ref(const PFRegionEmu &region,
                                           std::vector<PuppiObjEmu> &outselne /*[nOut]*/) const {
   const unsigned int nIn = std::min<unsigned>(nIn_, pfallne.size());
   const unsigned int nTrack = std::min<unsigned int>(nTrack_, track.size());
-  const int PTMAX2 = (ptMax_ * ptMax_);
+  const int PTMAX2 = (iptMax_ * iptMax_);
 
   const int sum_bitShift = LINPUPPI_sum_bitShift;
 
@@ -449,7 +449,7 @@ void l1ct::LinPuppiEmulator::fwdlinpuppi_flt(const PFRegionEmu &region,
                                              std::vector<PuppiObjEmu> &outallne /*[nIn]*/,
                                              std::vector<PuppiObjEmu> &outselne /*[nOut]*/) const {
   const unsigned int nIn = std::min<unsigned int>(nIn_, caloin.size());
-  const float f_ptMax = Scales::floatPt(Scales::makePt(ptMax_));
+  const float f_ptMax = Scales::floatPt(Scales::makePt(iptMax_));
 
   outallne_nocut.resize(nIn);
   outallne.resize(nIn);
@@ -490,7 +490,7 @@ void l1ct::LinPuppiEmulator::linpuppi_flt(const PFRegionEmu &region,
                                           std::vector<PuppiObjEmu> &outselne /*[nOut]*/) const {
   const unsigned int nIn = std::min<unsigned>(nIn_, pfallne.size());
   const unsigned int nTrack = std::min<unsigned int>(nTrack_, track.size());
-  const float f_ptMax = Scales::floatPt(Scales::makePt(ptMax_));
+  const float f_ptMax = Scales::floatPt(Scales::makePt(iptMax_));
 
   outallne_nocut.resize(nIn);
   outallne.resize(nIn);

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/puppi/linpuppi_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/puppi/linpuppi_ref.h
@@ -18,7 +18,7 @@ namespace l1ct {
                      unsigned int nOut,
                      unsigned int dR2Min,
                      unsigned int dR2Max,
-                     unsigned int ptMax,
+                     unsigned int iptMax,
                      unsigned int dzCut,
                      double ptSlopeNe,
                      double ptSlopePh,
@@ -35,7 +35,7 @@ namespace l1ct {
           nOut_(nOut),
           dR2Min_(dR2Min),
           dR2Max_(dR2Max),
-          ptMax_(ptMax),
+          iptMax_(iptMax),
           dzCut_(dzCut),
           absEtaBins_(),
           ptSlopeNe_(1, ptSlopeNe),
@@ -55,7 +55,7 @@ namespace l1ct {
                      unsigned int nOut,
                      unsigned int dR2Min,
                      unsigned int dR2Max,
-                     unsigned int ptMax,
+                     unsigned int iptMax,
                      unsigned int dzCut,
                      glbeta_t etaCut,
                      double ptSlopeNe_0,
@@ -84,7 +84,7 @@ namespace l1ct {
                      unsigned int nOut,
                      unsigned int dR2Min,
                      unsigned int dR2Max,
-                     unsigned int ptMax,
+                     unsigned int iptMax,
                      unsigned int dzCut,
                      const std::vector<glbeta_t> &absEtaBins,
                      const std::vector<double> &ptSlopeNe,
@@ -102,7 +102,7 @@ namespace l1ct {
           nOut_(nOut),
           dR2Min_(dR2Min),
           dR2Max_(dR2Max),
-          ptMax_(ptMax),
+          iptMax_(iptMax),
           dzCut_(dzCut),
           absEtaBins_(absEtaBins),
           ptSlopeNe_(ptSlopeNe),
@@ -174,7 +174,7 @@ namespace l1ct {
   protected:
     unsigned int nTrack_, nIn_,
         nOut_;  // nIn_, nOut refer to the calorimeter clusters or neutral PF candidates as input and as output (after sorting)
-    unsigned int dR2Min_, dR2Max_, ptMax_, dzCut_;
+    unsigned int dR2Min_, dR2Max_, iptMax_, dzCut_;
     std::vector<glbeta_t> absEtaBins_;
     std::vector<double> ptSlopeNe_, ptSlopePh_, ptZeroNe_, ptZeroPh_;
     std::vector<double> alphaSlope_, alphaZero_, alphaCrop_;

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/common/regionizer_base_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/common/regionizer_base_ref.cpp
@@ -4,6 +4,15 @@
 #include <cstdio>
 #include <algorithm>
 
+#ifdef CMSSW_GIT_HASH
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+l1ct::RegionizerEmulator::RegionizerEmulator(const edm::ParameterSet& iConfig) :
+    useAlsoVtxCoords_(iConfig.getParameter<bool>("useAlsoVtxCoords")),
+    debug_(iConfig.getUntrackedParameter<bool>("debug", false))
+{
+}
+#endif
+
 l1ct::RegionizerEmulator::~RegionizerEmulator() {}
 
 void l1ct::RegionizerEmulator::run(const RegionizerDecodedInputs& in, std::vector<PFInputRegion>& out) {

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/common/regionizer_base_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/common/regionizer_base_ref.cpp
@@ -6,11 +6,9 @@
 
 #ifdef CMSSW_GIT_HASH
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-l1ct::RegionizerEmulator::RegionizerEmulator(const edm::ParameterSet& iConfig) :
-    useAlsoVtxCoords_(iConfig.getParameter<bool>("useAlsoVtxCoords")),
-    debug_(iConfig.getUntrackedParameter<bool>("debug", false))
-{
-}
+l1ct::RegionizerEmulator::RegionizerEmulator(const edm::ParameterSet& iConfig)
+    : useAlsoVtxCoords_(iConfig.getParameter<bool>("useAlsoVtxCoords")),
+      debug_(iConfig.getUntrackedParameter<bool>("debug", false)) {}
 #endif
 
 l1ct::RegionizerEmulator::~RegionizerEmulator() {}

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/common/regionizer_base_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/common/regionizer_base_ref.h
@@ -11,8 +11,8 @@ namespace l1ct {
 
   class RegionizerEmulator {
   public:
-    RegionizerEmulator(bool useAlsoVtxCoords=true) : useAlsoVtxCoords_(useAlsoVtxCoords), debug_(false) {}
-    RegionizerEmulator(const edm::ParameterSet& iConfig) ;
+    RegionizerEmulator(bool useAlsoVtxCoords = true) : useAlsoVtxCoords_(useAlsoVtxCoords), debug_(false) {}
+    RegionizerEmulator(const edm::ParameterSet& iConfig);
 
     virtual ~RegionizerEmulator();
 

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/common/regionizer_base_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/common/regionizer_base_ref.h
@@ -1,17 +1,18 @@
 #ifndef REGIONIZER_BASE_REF_H
 #define REGIONIZER_BASE_REF_H
 
-#ifdef CMSSW_GIT_HASH
-#include "../dataformats/layer1_emulator.h"
-#else
 #include "../../dataformats/layer1_emulator.h"
-#endif
+
+namespace edm {
+  class ParameterSet;
+}
 
 namespace l1ct {
 
   class RegionizerEmulator {
   public:
-    RegionizerEmulator() : debug_(false) {}
+    RegionizerEmulator(bool useAlsoVtxCoords=true) : useAlsoVtxCoords_(useAlsoVtxCoords), debug_(false) {}
+    RegionizerEmulator(const edm::ParameterSet& iConfig) ;
 
     virtual ~RegionizerEmulator();
 
@@ -21,6 +22,7 @@ namespace l1ct {
     virtual void run(const RegionizerDecodedInputs& in, std::vector<PFInputRegion>& out);
 
   protected:
+    bool useAlsoVtxCoords_;
     bool debug_;
   };
 

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/multififo/multififo_regionizer_elements_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/multififo/multififo_regionizer_elements_ref.h
@@ -1,0 +1,122 @@
+#ifndef multififo_regionizer_elements_ref_h
+#define multififo_regionizer_elements_ref_h
+
+#include "../../dataformats/layer1_emulator.h"
+
+#include <list>
+#include <vector>
+#include <cassert>
+
+namespace l1ct {
+    namespace multififo_regionizer {
+        template<typename T>
+            inline void shift(T & from, T & to) {
+                to = from; from.clear();
+            }
+        template<typename TL, typename T>
+            inline void pop_back(TL & from, T & to) {
+                assert(!from.empty());
+                to = from.back(); from.pop_back();
+            }
+
+        template<typename T>
+            class RegionBuffer {
+                public:
+                    RegionBuffer() : nfifos_(0) {}
+                    void initFifos(unsigned int nfifos) ;
+                    void initRegion(const l1ct::PFRegionEmu & region) { region_ = region; }
+                    void flush() ;
+                    void maybe_push(int fifo, const T & t, const l1ct::PFRegionEmu & sector) ;
+                    T pop() ;
+
+                private:
+                    unsigned int nfifos_;
+                    l1ct::PFRegionEmu region_;
+                    std::vector<std::list<T>> fifos_;
+                    std::vector<T> staging_area_, queue_, staging_area2_, queue2_;
+
+                    T pop_next_trivial_() ;
+                    T pop_next_6to1_() ;
+                    T pop_next_8to1_() ;
+                    void stage_to_queue_();
+                    void pop_queue_(std::vector<T> & queue, T & ret) ;
+            };
+
+        // forward decl for later
+        template<typename T>
+            class RegionMux;
+
+        template<typename T>
+            class RegionBuilder {
+                public:
+                    RegionBuilder() {}
+                    RegionBuilder(unsigned int iregion, unsigned int nsort) : iregion_(iregion), sortbuffer_(nsort) {}
+                    void push(const T & in) ;
+                    void pop(RegionMux<T> & out) ;
+                private:
+                    unsigned int iregion_;
+                    std::vector<T> sortbuffer_;
+            };
+
+        template<typename T>
+            class RegionMux {
+                public:
+                    RegionMux() : nregions_(0) {}
+                    RegionMux(unsigned int nregions, unsigned int nsort, unsigned int nout, bool streaming, unsigned int outii=0) :
+                        nregions_(nregions), nsort_(nsort), nout_(nout), outii_(outii), 
+                        streaming_(streaming), 
+                        buffer_(nregions*nsort),
+                        iter_(0), ireg_(nregions)
+                {
+                    assert(streaming ? (outii * nout >= nsort) : (nout == nsort));
+                    for (auto & t : buffer_) t.clear();
+                }
+                    void push(unsigned int region, std::vector<T> & in);
+                    bool stream(bool newevt, std::vector<T> & out) ;
+                private:
+                    unsigned int nregions_, nsort_, nout_, outii_;
+                    bool streaming_;
+                    std::vector<T> buffer_;
+                    unsigned int iter_, ireg_;
+            };
+
+        // out of the Regionizer<T> since it doesn't depend on T and may be shared
+        struct Route {
+            unsigned short int sector, link, region, fifo;
+            Route(unsigned short int from_sector, unsigned short int from_link, unsigned short int to_region, unsigned short int to_fifo) :
+                sector(from_sector), link(from_link), region(to_region), fifo(to_fifo) {}
+        };
+
+        template<typename T>
+            class Regionizer {
+                public:
+                    Regionizer() {}
+                    Regionizer(unsigned int nsorted, unsigned int nout, bool streaming, unsigned int outii=0) ;
+                    void initSectors(const std::vector<DetectorSector<T>> & sectors) ;
+                    void initSectors(const DetectorSector<T> & sector) ;
+                    void initRegions(const std::vector<PFInputRegion> & regions) ;
+                    void initRouting(const std::vector<Route> routes);
+
+                    void reset() { flush(); nevt_ = 0; }
+
+                    // single clock emulation
+                    bool step(bool newEvent, const std::vector<T> & links, std::vector<T> & out, bool mux=true) ;
+
+                    void destream(int iclock, const std::vector<T> & streams, std::vector<T> & out);
+                private:
+                    unsigned int nsectors_, nregions_, nsorted_, nout_, outii_;
+                    bool streaming_;
+                    std::vector<l1ct::PFRegionEmu> sectors_;
+                    std::vector<RegionBuffer<T>> buffers_;
+                    std::vector<RegionBuilder<T>> builders_;
+                    RegionMux<T> bigmux_;
+                    std::vector<Route> routes_;
+                    unsigned int nevt_;
+
+                    void flush() { for (auto & b : buffers_) b.flush(); }
+            }; 
+
+    } // namespace  multififo_regionizer
+} // namespace l1ct
+
+#endif

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/multififo/multififo_regionizer_elements_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/multififo/multififo_regionizer_elements_ref.h
@@ -8,115 +8,133 @@
 #include <cassert>
 
 namespace l1ct {
-    namespace multififo_regionizer {
-        template<typename T>
-            inline void shift(T & from, T & to) {
-                to = from; from.clear();
-            }
-        template<typename TL, typename T>
-            inline void pop_back(TL & from, T & to) {
-                assert(!from.empty());
-                to = from.back(); from.pop_back();
-            }
+  namespace multififo_regionizer {
+    template <typename T>
+    inline void shift(T& from, T& to) {
+      to = from;
+      from.clear();
+    }
+    template <typename TL, typename T>
+    inline void pop_back(TL& from, T& to) {
+      assert(!from.empty());
+      to = from.back();
+      from.pop_back();
+    }
 
-        template<typename T>
-            class RegionBuffer {
-                public:
-                    RegionBuffer() : nfifos_(0) {}
-                    void initFifos(unsigned int nfifos) ;
-                    void initRegion(const l1ct::PFRegionEmu & region) { region_ = region; }
-                    void flush() ;
-                    void maybe_push(int fifo, const T & t, const l1ct::PFRegionEmu & sector) ;
-                    T pop() ;
+    template <typename T>
+    class RegionBuffer {
+    public:
+      RegionBuffer() : nfifos_(0) {}
+      void initFifos(unsigned int nfifos);
+      void initRegion(const l1ct::PFRegionEmu& region) { region_ = region; }
+      void flush();
+      void maybe_push(int fifo, const T& t, const l1ct::PFRegionEmu& sector);
+      T pop();
 
-                private:
-                    unsigned int nfifos_;
-                    l1ct::PFRegionEmu region_;
-                    std::vector<std::list<T>> fifos_;
-                    std::vector<T> staging_area_, queue_, staging_area2_, queue2_;
+    private:
+      unsigned int nfifos_;
+      l1ct::PFRegionEmu region_;
+      std::vector<std::list<T>> fifos_;
+      std::vector<T> staging_area_, queue_, staging_area2_, queue2_;
 
-                    T pop_next_trivial_() ;
-                    T pop_next_6to1_() ;
-                    T pop_next_8to1_() ;
-                    void stage_to_queue_();
-                    void pop_queue_(std::vector<T> & queue, T & ret) ;
-            };
+      T pop_next_trivial_();
+      T pop_next_6to1_();
+      T pop_next_8to1_();
+      void stage_to_queue_();
+      void pop_queue_(std::vector<T>& queue, T& ret);
+    };
 
-        // forward decl for later
-        template<typename T>
-            class RegionMux;
+    // forward decl for later
+    template <typename T>
+    class RegionMux;
 
-        template<typename T>
-            class RegionBuilder {
-                public:
-                    RegionBuilder() {}
-                    RegionBuilder(unsigned int iregion, unsigned int nsort) : iregion_(iregion), sortbuffer_(nsort) {}
-                    void push(const T & in) ;
-                    void pop(RegionMux<T> & out) ;
-                private:
-                    unsigned int iregion_;
-                    std::vector<T> sortbuffer_;
-            };
+    template <typename T>
+    class RegionBuilder {
+    public:
+      RegionBuilder() {}
+      RegionBuilder(unsigned int iregion, unsigned int nsort) : iregion_(iregion), sortbuffer_(nsort) {}
+      void push(const T& in);
+      void pop(RegionMux<T>& out);
 
-        template<typename T>
-            class RegionMux {
-                public:
-                    RegionMux() : nregions_(0) {}
-                    RegionMux(unsigned int nregions, unsigned int nsort, unsigned int nout, bool streaming, unsigned int outii=0) :
-                        nregions_(nregions), nsort_(nsort), nout_(nout), outii_(outii), 
-                        streaming_(streaming), 
-                        buffer_(nregions*nsort),
-                        iter_(0), ireg_(nregions)
-                {
-                    assert(streaming ? (outii * nout >= nsort) : (nout == nsort));
-                    for (auto & t : buffer_) t.clear();
-                }
-                    void push(unsigned int region, std::vector<T> & in);
-                    bool stream(bool newevt, std::vector<T> & out) ;
-                private:
-                    unsigned int nregions_, nsort_, nout_, outii_;
-                    bool streaming_;
-                    std::vector<T> buffer_;
-                    unsigned int iter_, ireg_;
-            };
+    private:
+      unsigned int iregion_;
+      std::vector<T> sortbuffer_;
+    };
 
-        // out of the Regionizer<T> since it doesn't depend on T and may be shared
-        struct Route {
-            unsigned short int sector, link, region, fifo;
-            Route(unsigned short int from_sector, unsigned short int from_link, unsigned short int to_region, unsigned short int to_fifo) :
-                sector(from_sector), link(from_link), region(to_region), fifo(to_fifo) {}
-        };
+    template <typename T>
+    class RegionMux {
+    public:
+      RegionMux() : nregions_(0) {}
+      RegionMux(unsigned int nregions, unsigned int nsort, unsigned int nout, bool streaming, unsigned int outii = 0)
+          : nregions_(nregions),
+            nsort_(nsort),
+            nout_(nout),
+            outii_(outii),
+            streaming_(streaming),
+            buffer_(nregions * nsort),
+            iter_(0),
+            ireg_(nregions) {
+        assert(streaming ? (outii * nout >= nsort) : (nout == nsort));
+        for (auto& t : buffer_)
+          t.clear();
+      }
+      void push(unsigned int region, std::vector<T>& in);
+      bool stream(bool newevt, std::vector<T>& out);
 
-        template<typename T>
-            class Regionizer {
-                public:
-                    Regionizer() {}
-                    Regionizer(unsigned int nsorted, unsigned int nout, bool streaming, unsigned int outii=0) ;
-                    void initSectors(const std::vector<DetectorSector<T>> & sectors) ;
-                    void initSectors(const DetectorSector<T> & sector) ;
-                    void initRegions(const std::vector<PFInputRegion> & regions) ;
-                    void initRouting(const std::vector<Route> routes);
+    private:
+      unsigned int nregions_, nsort_, nout_, outii_;
+      bool streaming_;
+      std::vector<T> buffer_;
+      unsigned int iter_, ireg_;
+    };
 
-                    void reset() { flush(); nevt_ = 0; }
+    // out of the Regionizer<T> since it doesn't depend on T and may be shared
+    struct Route {
+      unsigned short int sector, link, region, fifo;
+      Route(unsigned short int from_sector,
+            unsigned short int from_link,
+            unsigned short int to_region,
+            unsigned short int to_fifo)
+          : sector(from_sector), link(from_link), region(to_region), fifo(to_fifo) {}
+    };
 
-                    // single clock emulation
-                    bool step(bool newEvent, const std::vector<T> & links, std::vector<T> & out, bool mux=true) ;
+    template <typename T>
+    class Regionizer {
+    public:
+      Regionizer() {}
+      Regionizer(unsigned int nsorted, unsigned int nout, bool streaming, unsigned int outii = 0);
+      void initSectors(const std::vector<DetectorSector<T>>& sectors);
+      void initSectors(const DetectorSector<T>& sector);
+      void initRegions(const std::vector<PFInputRegion>& regions);
+      void initRouting(const std::vector<Route> routes);
 
-                    void destream(int iclock, const std::vector<T> & streams, std::vector<T> & out);
-                private:
-                    unsigned int nsectors_, nregions_, nsorted_, nout_, outii_;
-                    bool streaming_;
-                    std::vector<l1ct::PFRegionEmu> sectors_;
-                    std::vector<RegionBuffer<T>> buffers_;
-                    std::vector<RegionBuilder<T>> builders_;
-                    RegionMux<T> bigmux_;
-                    std::vector<Route> routes_;
-                    unsigned int nevt_;
+      void reset() {
+        flush();
+        nevt_ = 0;
+      }
 
-                    void flush() { for (auto & b : buffers_) b.flush(); }
-            }; 
+      // single clock emulation
+      bool step(bool newEvent, const std::vector<T>& links, std::vector<T>& out, bool mux = true);
 
-    } // namespace  multififo_regionizer
-} // namespace l1ct
+      void destream(int iclock, const std::vector<T>& streams, std::vector<T>& out);
+
+    private:
+      unsigned int nsectors_, nregions_, nsorted_, nout_, outii_;
+      bool streaming_;
+      std::vector<l1ct::PFRegionEmu> sectors_;
+      std::vector<RegionBuffer<T>> buffers_;
+      std::vector<RegionBuilder<T>> builders_;
+      RegionMux<T> bigmux_;
+      std::vector<Route> routes_;
+      unsigned int nevt_;
+
+      void flush() {
+        for (auto& b : buffers_)
+          b.flush();
+      }
+    };
+
+  }  // namespace  multififo_regionizer
+}  // namespace l1ct
 
 #endif

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/multififo/multififo_regionizer_elements_ref.icc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/multififo/multififo_regionizer_elements_ref.icc
@@ -1,0 +1,282 @@
+template<typename T>
+void l1ct::multififo_regionizer::RegionBuffer<T>::initFifos(unsigned int nfifos) 
+{
+    assert(nfifos_ == 0);
+    nfifos_ = nfifos;
+    fifos_.resize(nfifos);
+    if (nfifos > 2) {
+        staging_area_.resize(nfifos/2);
+        queue_.resize(nfifos/2);
+        if (nfifos >= 4) {
+            staging_area2_.resize(nfifos/4);
+            queue2_.resize(nfifos/4);
+        }
+    }
+    if (!(nfifos == 1 || nfifos == 2 || nfifos == 4 || nfifos == 6 || nfifos == 8)) {
+        std::cerr << "Error, created regionizer for nfifos == " << nfifos << ", not supported." << std::endl;
+    }
+    assert(nfifos == 1 || nfifos == 2 || nfifos == 4 || nfifos == 6 || nfifos == 8);
+}
+
+
+template<typename T>
+void l1ct::multififo_regionizer::RegionBuffer<T>::flush() {
+    for (auto & f : fifos_) f.clear(); 
+    for (auto & t : staging_area_) t.clear();
+    for (auto & t : queue_) t.clear();
+    for (auto & t : staging_area2_) t.clear();
+    for (auto & t : queue2_) t.clear();
+}
+
+template<typename T>
+void l1ct::multififo_regionizer::RegionBuffer<T>::maybe_push(int fifo, const T & t, const l1ct::PFRegionEmu & sector) {
+    if (t.hwPt == 0) return;
+    int local_eta = sector.hwGlbEtaOf(t).to_int() - region_.hwEtaCenter.to_int();
+    int local_phi = sector.hwGlbPhiOf(t).to_int() - region_.hwPhiCenter.to_int();
+    if      (local_phi >   l1ct::Scales::INTPHI_PI) local_phi -= l1ct::Scales::INTPHI_TWOPI;
+    else if (local_phi <= -l1ct::Scales::INTPHI_PI) local_phi += l1ct::Scales::INTPHI_TWOPI;
+    if (region_.isInside(local_eta, local_phi)) {
+        fifos_[fifo].push_front(t);
+        fifos_[fifo].front().hwEta = local_eta;
+        fifos_[fifo].front().hwPhi = local_phi;
+    }
+}
+
+template<typename T>
+T l1ct::multififo_regionizer::RegionBuffer<T>::pop() {
+    if      (nfifos_ <= 2) return pop_next_trivial_();
+    else if (nfifos_ == 4) return pop_next_8to1_(); // this works also for 4 to 1
+    else if (nfifos_ == 6) return pop_next_6to1_();
+    else if (nfifos_ == 8) return pop_next_8to1_();
+    assert(false); 
+}
+
+
+template<typename T>
+T l1ct::multififo_regionizer::RegionBuffer<T>::pop_next_trivial_() {
+    T ret; ret.clear();
+    for (unsigned int j = 0; j < nfifos_; ++j) {
+        if (!fifos_[j].empty()) {
+            pop_back(fifos_[j], ret);
+            break;
+        }
+    }
+    return ret;
+}
+
+template<typename T>
+void l1ct::multififo_regionizer::RegionBuffer<T>::stage_to_queue_() {
+    // shift data from each pair of fifos to the staging area
+    for (unsigned int j = 0; j < nfifos_/2; ++j) {
+        if (staging_area_[j].hwPt != 0) continue;
+        for (unsigned int i = 2*j; i <= 2*j+1; ++i) {
+            if (!fifos_[i].empty()) {
+                pop_back(fifos_[i], staging_area_[j]);
+                break;
+            }
+        }
+    }
+    // then from staging area to queue
+    for (unsigned int j = 0; j < nfifos_/2; ++j) {
+        if (staging_area_[j].hwPt != 0 && queue_[j].hwPt == 0) {
+            shift(staging_area_[j], queue_[j]);
+        }
+    }    
+}
+
+template<typename T>
+void l1ct::multififo_regionizer::RegionBuffer<T>::pop_queue_(std::vector<T> & queue, T & ret) {
+    for (T & t : queue) {
+        if (t.hwPt != 0) {
+            ret = t;
+            t.clear();
+            break;
+        }
+    }
+}
+
+template<typename T>
+T l1ct::multififo_regionizer::RegionBuffer<T>::pop_next_6to1_() {
+    T ret; ret.clear();
+    // shift data from each pair of fifos to the staging area, and then to queue
+    stage_to_queue_();
+    // finally merge the queues
+    pop_queue_(queue_, ret);
+    return ret;
+}
+
+
+template<typename T>
+T l1ct::multififo_regionizer::RegionBuffer<T>::pop_next_8to1_() {
+    T ret; ret.clear();
+    // shift data from each pair of fifos to the staging area, and then to queue
+    stage_to_queue_();
+    // then from queue to staging2
+    for (unsigned int j = 0; j < nfifos_/4; ++j) {
+        if (staging_area2_[j].hwPt != 0) continue;
+        for (unsigned int i = 2*j; i <= 2*j+1; ++i) {
+            if (queue_[i].hwPt != 0) {
+                shift(queue_[i], staging_area2_[j]);
+                break;
+            }
+        }
+    }
+    // then from staging2 to queue2
+    for (unsigned int j = 0; j < nfifos_/4; ++j) {
+        if (staging_area2_[j].hwPt != 0 && queue2_[j].hwPt == 0) {
+            shift(staging_area2_[j], queue2_[j]);
+        }
+    }
+    // and finally out
+    pop_queue_(queue2_, ret);
+    return ret;
+}
+
+template<typename T>
+void l1ct::multififo_regionizer::RegionBuilder<T>::push(const T & in) {
+    unsigned int i = 0, nsort = sortbuffer_.size(); 
+    T work = in;
+    while (i < nsort && in.hwPt <= sortbuffer_[i].hwPt) i++;
+    while (i < nsort) { std::swap(work, sortbuffer_[i]); i++; } 
+}
+
+template<typename T>
+void l1ct::multififo_regionizer::RegionBuilder<T>::pop(RegionMux<T> & out) { 
+    out.push(iregion_, sortbuffer_); 
+}
+
+template<typename T>
+void l1ct::multififo_regionizer::RegionMux<T>::push(unsigned int region, std::vector<T> & in) {
+    assert(nregions_ > 0);
+    assert(region < nregions_);
+    assert(in.size() == nsort_);
+    for (unsigned int i = 0, n= in.size(); i < n; ++i) {
+        shift(in[i], buffer_[region*nsort_+i]);
+    }
+}
+ 
+
+template<typename T>
+bool l1ct::multififo_regionizer::RegionMux<T>::stream(bool newevt, std::vector<T> & out) {
+    assert(out.size() == nout_);
+    if (newevt) { iter_ = 0; ireg_ = 0; }
+    if (ireg_ < nregions_) {
+        if (!streaming_) {
+            for (unsigned int i = 0; i < nout_; ++i) {
+                out[i] = buffer_[ireg_*nsort_+i];
+            }
+        } else {
+            for (unsigned int i = 0, j = 0; i < nout_; ++i, j += outii_) {
+                if (j < nsort_) {
+                    out[i] = buffer_[ireg_*nsort_ + j];
+                } else {
+                    out[i].clear();
+                }
+            }
+            for (unsigned int i = 1; i < nsort_; ++i) {
+                shift(buffer_[ireg_*nsort_ + i], buffer_[ireg_*nsort_ + i-1]);
+            }
+        }
+        if (++iter_ == outii_) {
+            ireg_++; iter_ = 0;
+        }
+        return true;
+    } else {
+        for (unsigned int i = 0; i < nout_; ++i) {
+            out[i].clear();
+        }
+        return false;
+    }
+}
+
+template<typename T>
+l1ct::multififo_regionizer::Regionizer<T>::Regionizer(unsigned int nsorted, unsigned int nout, bool streaming, unsigned int outii) :
+    nsectors_(0), nregions_(0), nsorted_(nsorted), nout_(nout), outii_(outii), streaming_(streaming), nevt_(0) 
+{
+}
+
+template<typename T>
+void l1ct::multififo_regionizer::Regionizer<T>::initSectors(const std::vector<DetectorSector<T>> & sectors) {
+    assert(nsectors_ == 0);
+    nsectors_ = sectors.size();
+    sectors_.resize(nsectors_);
+    for (unsigned int i = 0; i < nsectors_; ++i) {
+        sectors_[i] = sectors[i].region;
+    }
+}
+
+template<typename T>
+void l1ct::multififo_regionizer::Regionizer<T>::initSectors(const DetectorSector<T> & sector) {
+    assert(nsectors_ == 0);
+    nsectors_ = 1;
+    sectors_.resize(1, sector.region);
+}
+
+template<typename T>
+void l1ct::multififo_regionizer::Regionizer<T>::initRegions(const std::vector<PFInputRegion> & regions) {
+    assert(nregions_ == 0);
+    unsigned int nregions = regions.size();
+    nregions_ = nregions;
+    // buffers and builders
+    buffers_.resize(nregions);
+    builders_.resize(nregions);
+    for (unsigned int i = 0; i < nregions; ++i) {
+        buffers_[i].initRegion(regions[i].region);
+        builders_[i] = RegionBuilder<T>(i, nsorted_);
+    }
+    // bigmux
+    bigmux_ = RegionMux<T>(nregions, nsorted_, nout_, streaming_, outii_);
+}
+
+template<typename T>
+void l1ct::multififo_regionizer::Regionizer<T>::initRouting(const std::vector<Route> routes) {
+    assert(nregions_ > 0 && routes_.empty());
+    routes_ = routes;
+    std::vector<unsigned int> nfifos(nregions_, 0);
+    for (const auto & r : routes) {
+        assert(r.region < nregions_);
+        nfifos[r.region] = std::max<unsigned int>(nfifos[r.region], r.fifo+1);
+    }
+    for (unsigned int i = 0; i < nregions_; ++i) {
+        buffers_[i].initFifos(nfifos[i]);
+    }
+}
+
+template<typename T>
+bool l1ct::multififo_regionizer::Regionizer<T>::step(bool newEvent, const std::vector<T> & links, std::vector<T> & out, bool mux) {
+    if (newEvent) { flush(); nevt_++; }
+    unsigned int nlinks_sector = links.size()/nsectors_;
+    for (const auto & r : routes_) {
+        unsigned int index = nlinks_sector * r.sector + r.link;
+        buffers_[r.region].maybe_push(r.fifo, links[index], sectors_[r.sector]);
+    }
+    if (mux) {
+        out.resize(nout_);
+        for (unsigned int i = 0; i < nregions_; ++i) {
+            if (newEvent) builders_[i].pop(bigmux_);
+            builders_[i].push(buffers_[i].pop());
+        }
+        return bigmux_.stream(newEvent && (nevt_ > 1), out);
+    } else {
+        out.resize(nregions_);
+        for (unsigned int i = 0; i < nregions_; ++i) {
+            out[i] = buffers_[i].pop();
+        }
+        return true;
+    }
+}
+
+template<typename T>
+void l1ct::multififo_regionizer::Regionizer<T>::destream(int iclock, const std::vector<T> & streams, std::vector<T> & out) {
+    assert(streaming_ && outii_ > 0);
+    assert(streams.size() == nout_);
+    int local_clk = iclock % outii_;
+    if (local_clk == 0) {
+        out.resize(nsorted_);
+        for (auto & o : out) o.clear();
+    }
+    for (unsigned int i = 0, j = local_clk; j < nsorted_; ++i, j += outii_) {
+        out[j] = streams[i];
+    }
+}
+

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/multififo/multififo_regionizer_elements_ref.icc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/multififo/multififo_regionizer_elements_ref.icc
@@ -1,282 +1,312 @@
-template<typename T>
-void l1ct::multififo_regionizer::RegionBuffer<T>::initFifos(unsigned int nfifos) 
-{
-    assert(nfifos_ == 0);
-    nfifos_ = nfifos;
-    fifos_.resize(nfifos);
-    if (nfifos > 2) {
-        staging_area_.resize(nfifos/2);
-        queue_.resize(nfifos/2);
-        if (nfifos >= 4) {
-            staging_area2_.resize(nfifos/4);
-            queue2_.resize(nfifos/4);
-        }
+template <typename T>
+void l1ct::multififo_regionizer::RegionBuffer<T>::initFifos(unsigned int nfifos) {
+  assert(nfifos_ == 0);
+  nfifos_ = nfifos;
+  fifos_.resize(nfifos);
+  if (nfifos > 2) {
+    staging_area_.resize(nfifos / 2);
+    queue_.resize(nfifos / 2);
+    if (nfifos >= 4) {
+      staging_area2_.resize(nfifos / 4);
+      queue2_.resize(nfifos / 4);
     }
-    if (!(nfifos == 1 || nfifos == 2 || nfifos == 4 || nfifos == 6 || nfifos == 8)) {
-        std::cerr << "Error, created regionizer for nfifos == " << nfifos << ", not supported." << std::endl;
-    }
-    assert(nfifos == 1 || nfifos == 2 || nfifos == 4 || nfifos == 6 || nfifos == 8);
+  }
+  if (!(nfifos == 1 || nfifos == 2 || nfifos == 4 || nfifos == 6 || nfifos == 8)) {
+    std::cerr << "Error, created regionizer for nfifos == " << nfifos << ", not supported." << std::endl;
+  }
+  assert(nfifos == 1 || nfifos == 2 || nfifos == 4 || nfifos == 6 || nfifos == 8);
 }
 
-
-template<typename T>
+template <typename T>
 void l1ct::multififo_regionizer::RegionBuffer<T>::flush() {
-    for (auto & f : fifos_) f.clear(); 
-    for (auto & t : staging_area_) t.clear();
-    for (auto & t : queue_) t.clear();
-    for (auto & t : staging_area2_) t.clear();
-    for (auto & t : queue2_) t.clear();
+  for (auto& f : fifos_)
+    f.clear();
+  for (auto& t : staging_area_)
+    t.clear();
+  for (auto& t : queue_)
+    t.clear();
+  for (auto& t : staging_area2_)
+    t.clear();
+  for (auto& t : queue2_)
+    t.clear();
 }
 
-template<typename T>
-void l1ct::multififo_regionizer::RegionBuffer<T>::maybe_push(int fifo, const T & t, const l1ct::PFRegionEmu & sector) {
-    if (t.hwPt == 0) return;
-    int local_eta = sector.hwGlbEtaOf(t).to_int() - region_.hwEtaCenter.to_int();
-    int local_phi = sector.hwGlbPhiOf(t).to_int() - region_.hwPhiCenter.to_int();
-    if      (local_phi >   l1ct::Scales::INTPHI_PI) local_phi -= l1ct::Scales::INTPHI_TWOPI;
-    else if (local_phi <= -l1ct::Scales::INTPHI_PI) local_phi += l1ct::Scales::INTPHI_TWOPI;
-    if (region_.isInside(local_eta, local_phi)) {
-        fifos_[fifo].push_front(t);
-        fifos_[fifo].front().hwEta = local_eta;
-        fifos_[fifo].front().hwPhi = local_phi;
-    }
+template <typename T>
+void l1ct::multififo_regionizer::RegionBuffer<T>::maybe_push(int fifo, const T& t, const l1ct::PFRegionEmu& sector) {
+  if (t.hwPt == 0)
+    return;
+  int local_eta = sector.hwGlbEtaOf(t).to_int() - region_.hwEtaCenter.to_int();
+  int local_phi = sector.hwGlbPhiOf(t).to_int() - region_.hwPhiCenter.to_int();
+  if (local_phi > l1ct::Scales::INTPHI_PI)
+    local_phi -= l1ct::Scales::INTPHI_TWOPI;
+  else if (local_phi <= -l1ct::Scales::INTPHI_PI)
+    local_phi += l1ct::Scales::INTPHI_TWOPI;
+  if (region_.isInside(local_eta, local_phi)) {
+    fifos_[fifo].push_front(t);
+    fifos_[fifo].front().hwEta = local_eta;
+    fifos_[fifo].front().hwPhi = local_phi;
+  }
 }
 
-template<typename T>
+template <typename T>
 T l1ct::multififo_regionizer::RegionBuffer<T>::pop() {
-    if      (nfifos_ <= 2) return pop_next_trivial_();
-    else if (nfifos_ == 4) return pop_next_8to1_(); // this works also for 4 to 1
-    else if (nfifos_ == 6) return pop_next_6to1_();
-    else if (nfifos_ == 8) return pop_next_8to1_();
-    assert(false); 
+  if (nfifos_ <= 2)
+    return pop_next_trivial_();
+  else if (nfifos_ == 4)
+    return pop_next_8to1_();  // this works also for 4 to 1
+  else if (nfifos_ == 6)
+    return pop_next_6to1_();
+  else if (nfifos_ == 8)
+    return pop_next_8to1_();
+  assert(false);
 }
 
-
-template<typename T>
+template <typename T>
 T l1ct::multififo_regionizer::RegionBuffer<T>::pop_next_trivial_() {
-    T ret; ret.clear();
-    for (unsigned int j = 0; j < nfifos_; ++j) {
-        if (!fifos_[j].empty()) {
-            pop_back(fifos_[j], ret);
-            break;
-        }
+  T ret;
+  ret.clear();
+  for (unsigned int j = 0; j < nfifos_; ++j) {
+    if (!fifos_[j].empty()) {
+      pop_back(fifos_[j], ret);
+      break;
     }
-    return ret;
+  }
+  return ret;
 }
 
-template<typename T>
+template <typename T>
 void l1ct::multififo_regionizer::RegionBuffer<T>::stage_to_queue_() {
-    // shift data from each pair of fifos to the staging area
-    for (unsigned int j = 0; j < nfifos_/2; ++j) {
-        if (staging_area_[j].hwPt != 0) continue;
-        for (unsigned int i = 2*j; i <= 2*j+1; ++i) {
-            if (!fifos_[i].empty()) {
-                pop_back(fifos_[i], staging_area_[j]);
-                break;
-            }
-        }
+  // shift data from each pair of fifos to the staging area
+  for (unsigned int j = 0; j < nfifos_ / 2; ++j) {
+    if (staging_area_[j].hwPt != 0)
+      continue;
+    for (unsigned int i = 2 * j; i <= 2 * j + 1; ++i) {
+      if (!fifos_[i].empty()) {
+        pop_back(fifos_[i], staging_area_[j]);
+        break;
+      }
     }
-    // then from staging area to queue
-    for (unsigned int j = 0; j < nfifos_/2; ++j) {
-        if (staging_area_[j].hwPt != 0 && queue_[j].hwPt == 0) {
-            shift(staging_area_[j], queue_[j]);
-        }
-    }    
+  }
+  // then from staging area to queue
+  for (unsigned int j = 0; j < nfifos_ / 2; ++j) {
+    if (staging_area_[j].hwPt != 0 && queue_[j].hwPt == 0) {
+      shift(staging_area_[j], queue_[j]);
+    }
+  }
 }
 
-template<typename T>
-void l1ct::multififo_regionizer::RegionBuffer<T>::pop_queue_(std::vector<T> & queue, T & ret) {
-    for (T & t : queue) {
-        if (t.hwPt != 0) {
-            ret = t;
-            t.clear();
-            break;
-        }
+template <typename T>
+void l1ct::multififo_regionizer::RegionBuffer<T>::pop_queue_(std::vector<T>& queue, T& ret) {
+  for (T& t : queue) {
+    if (t.hwPt != 0) {
+      ret = t;
+      t.clear();
+      break;
     }
+  }
 }
 
-template<typename T>
+template <typename T>
 T l1ct::multififo_regionizer::RegionBuffer<T>::pop_next_6to1_() {
-    T ret; ret.clear();
-    // shift data from each pair of fifos to the staging area, and then to queue
-    stage_to_queue_();
-    // finally merge the queues
-    pop_queue_(queue_, ret);
-    return ret;
+  T ret;
+  ret.clear();
+  // shift data from each pair of fifos to the staging area, and then to queue
+  stage_to_queue_();
+  // finally merge the queues
+  pop_queue_(queue_, ret);
+  return ret;
 }
 
-
-template<typename T>
+template <typename T>
 T l1ct::multififo_regionizer::RegionBuffer<T>::pop_next_8to1_() {
-    T ret; ret.clear();
-    // shift data from each pair of fifos to the staging area, and then to queue
-    stage_to_queue_();
-    // then from queue to staging2
-    for (unsigned int j = 0; j < nfifos_/4; ++j) {
-        if (staging_area2_[j].hwPt != 0) continue;
-        for (unsigned int i = 2*j; i <= 2*j+1; ++i) {
-            if (queue_[i].hwPt != 0) {
-                shift(queue_[i], staging_area2_[j]);
-                break;
-            }
-        }
+  T ret;
+  ret.clear();
+  // shift data from each pair of fifos to the staging area, and then to queue
+  stage_to_queue_();
+  // then from queue to staging2
+  for (unsigned int j = 0; j < nfifos_ / 4; ++j) {
+    if (staging_area2_[j].hwPt != 0)
+      continue;
+    for (unsigned int i = 2 * j; i <= 2 * j + 1; ++i) {
+      if (queue_[i].hwPt != 0) {
+        shift(queue_[i], staging_area2_[j]);
+        break;
+      }
     }
-    // then from staging2 to queue2
-    for (unsigned int j = 0; j < nfifos_/4; ++j) {
-        if (staging_area2_[j].hwPt != 0 && queue2_[j].hwPt == 0) {
-            shift(staging_area2_[j], queue2_[j]);
-        }
+  }
+  // then from staging2 to queue2
+  for (unsigned int j = 0; j < nfifos_ / 4; ++j) {
+    if (staging_area2_[j].hwPt != 0 && queue2_[j].hwPt == 0) {
+      shift(staging_area2_[j], queue2_[j]);
     }
-    // and finally out
-    pop_queue_(queue2_, ret);
-    return ret;
+  }
+  // and finally out
+  pop_queue_(queue2_, ret);
+  return ret;
 }
 
-template<typename T>
-void l1ct::multififo_regionizer::RegionBuilder<T>::push(const T & in) {
-    unsigned int i = 0, nsort = sortbuffer_.size(); 
-    T work = in;
-    while (i < nsort && in.hwPt <= sortbuffer_[i].hwPt) i++;
-    while (i < nsort) { std::swap(work, sortbuffer_[i]); i++; } 
+template <typename T>
+void l1ct::multififo_regionizer::RegionBuilder<T>::push(const T& in) {
+  unsigned int i = 0, nsort = sortbuffer_.size();
+  T work = in;
+  while (i < nsort && in.hwPt <= sortbuffer_[i].hwPt)
+    i++;
+  while (i < nsort) {
+    std::swap(work, sortbuffer_[i]);
+    i++;
+  }
 }
 
-template<typename T>
-void l1ct::multififo_regionizer::RegionBuilder<T>::pop(RegionMux<T> & out) { 
-    out.push(iregion_, sortbuffer_); 
+template <typename T>
+void l1ct::multififo_regionizer::RegionBuilder<T>::pop(RegionMux<T>& out) {
+  out.push(iregion_, sortbuffer_);
 }
 
-template<typename T>
-void l1ct::multififo_regionizer::RegionMux<T>::push(unsigned int region, std::vector<T> & in) {
-    assert(nregions_ > 0);
-    assert(region < nregions_);
-    assert(in.size() == nsort_);
-    for (unsigned int i = 0, n= in.size(); i < n; ++i) {
-        shift(in[i], buffer_[region*nsort_+i]);
-    }
+template <typename T>
+void l1ct::multififo_regionizer::RegionMux<T>::push(unsigned int region, std::vector<T>& in) {
+  assert(nregions_ > 0);
+  assert(region < nregions_);
+  assert(in.size() == nsort_);
+  for (unsigned int i = 0, n = in.size(); i < n; ++i) {
+    shift(in[i], buffer_[region * nsort_ + i]);
+  }
 }
- 
 
-template<typename T>
-bool l1ct::multififo_regionizer::RegionMux<T>::stream(bool newevt, std::vector<T> & out) {
-    assert(out.size() == nout_);
-    if (newevt) { iter_ = 0; ireg_ = 0; }
-    if (ireg_ < nregions_) {
-        if (!streaming_) {
-            for (unsigned int i = 0; i < nout_; ++i) {
-                out[i] = buffer_[ireg_*nsort_+i];
-            }
+template <typename T>
+bool l1ct::multififo_regionizer::RegionMux<T>::stream(bool newevt, std::vector<T>& out) {
+  assert(out.size() == nout_);
+  if (newevt) {
+    iter_ = 0;
+    ireg_ = 0;
+  }
+  if (ireg_ < nregions_) {
+    if (!streaming_) {
+      for (unsigned int i = 0; i < nout_; ++i) {
+        out[i] = buffer_[ireg_ * nsort_ + i];
+      }
+    } else {
+      for (unsigned int i = 0, j = 0; i < nout_; ++i, j += outii_) {
+        if (j < nsort_) {
+          out[i] = buffer_[ireg_ * nsort_ + j];
         } else {
-            for (unsigned int i = 0, j = 0; i < nout_; ++i, j += outii_) {
-                if (j < nsort_) {
-                    out[i] = buffer_[ireg_*nsort_ + j];
-                } else {
-                    out[i].clear();
-                }
-            }
-            for (unsigned int i = 1; i < nsort_; ++i) {
-                shift(buffer_[ireg_*nsort_ + i], buffer_[ireg_*nsort_ + i-1]);
-            }
+          out[i].clear();
         }
-        if (++iter_ == outii_) {
-            ireg_++; iter_ = 0;
-        }
-        return true;
-    } else {
-        for (unsigned int i = 0; i < nout_; ++i) {
-            out[i].clear();
-        }
-        return false;
+      }
+      for (unsigned int i = 1; i < nsort_; ++i) {
+        shift(buffer_[ireg_ * nsort_ + i], buffer_[ireg_ * nsort_ + i - 1]);
+      }
     }
-}
-
-template<typename T>
-l1ct::multififo_regionizer::Regionizer<T>::Regionizer(unsigned int nsorted, unsigned int nout, bool streaming, unsigned int outii) :
-    nsectors_(0), nregions_(0), nsorted_(nsorted), nout_(nout), outii_(outii), streaming_(streaming), nevt_(0) 
-{
-}
-
-template<typename T>
-void l1ct::multififo_regionizer::Regionizer<T>::initSectors(const std::vector<DetectorSector<T>> & sectors) {
-    assert(nsectors_ == 0);
-    nsectors_ = sectors.size();
-    sectors_.resize(nsectors_);
-    for (unsigned int i = 0; i < nsectors_; ++i) {
-        sectors_[i] = sectors[i].region;
+    if (++iter_ == outii_) {
+      ireg_++;
+      iter_ = 0;
     }
-}
-
-template<typename T>
-void l1ct::multififo_regionizer::Regionizer<T>::initSectors(const DetectorSector<T> & sector) {
-    assert(nsectors_ == 0);
-    nsectors_ = 1;
-    sectors_.resize(1, sector.region);
-}
-
-template<typename T>
-void l1ct::multififo_regionizer::Regionizer<T>::initRegions(const std::vector<PFInputRegion> & regions) {
-    assert(nregions_ == 0);
-    unsigned int nregions = regions.size();
-    nregions_ = nregions;
-    // buffers and builders
-    buffers_.resize(nregions);
-    builders_.resize(nregions);
-    for (unsigned int i = 0; i < nregions; ++i) {
-        buffers_[i].initRegion(regions[i].region);
-        builders_[i] = RegionBuilder<T>(i, nsorted_);
+    return true;
+  } else {
+    for (unsigned int i = 0; i < nout_; ++i) {
+      out[i].clear();
     }
-    // bigmux
-    bigmux_ = RegionMux<T>(nregions, nsorted_, nout_, streaming_, outii_);
+    return false;
+  }
 }
 
-template<typename T>
+template <typename T>
+l1ct::multififo_regionizer::Regionizer<T>::Regionizer(unsigned int nsorted,
+                                                      unsigned int nout,
+                                                      bool streaming,
+                                                      unsigned int outii)
+    : nsectors_(0), nregions_(0), nsorted_(nsorted), nout_(nout), outii_(outii), streaming_(streaming), nevt_(0) {}
+
+template <typename T>
+void l1ct::multififo_regionizer::Regionizer<T>::initSectors(const std::vector<DetectorSector<T>>& sectors) {
+  assert(nsectors_ == 0);
+  nsectors_ = sectors.size();
+  sectors_.resize(nsectors_);
+  for (unsigned int i = 0; i < nsectors_; ++i) {
+    sectors_[i] = sectors[i].region;
+  }
+}
+
+template <typename T>
+void l1ct::multififo_regionizer::Regionizer<T>::initSectors(const DetectorSector<T>& sector) {
+  assert(nsectors_ == 0);
+  nsectors_ = 1;
+  sectors_.resize(1, sector.region);
+}
+
+template <typename T>
+void l1ct::multififo_regionizer::Regionizer<T>::initRegions(const std::vector<PFInputRegion>& regions) {
+  assert(nregions_ == 0);
+  unsigned int nregions = regions.size();
+  nregions_ = nregions;
+  // buffers and builders
+  buffers_.resize(nregions);
+  builders_.resize(nregions);
+  for (unsigned int i = 0; i < nregions; ++i) {
+    buffers_[i].initRegion(regions[i].region);
+    builders_[i] = RegionBuilder<T>(i, nsorted_);
+  }
+  // bigmux
+  bigmux_ = RegionMux<T>(nregions, nsorted_, nout_, streaming_, outii_);
+}
+
+template <typename T>
 void l1ct::multififo_regionizer::Regionizer<T>::initRouting(const std::vector<Route> routes) {
-    assert(nregions_ > 0 && routes_.empty());
-    routes_ = routes;
-    std::vector<unsigned int> nfifos(nregions_, 0);
-    for (const auto & r : routes) {
-        assert(r.region < nregions_);
-        nfifos[r.region] = std::max<unsigned int>(nfifos[r.region], r.fifo+1);
-    }
+  assert(nregions_ > 0 && routes_.empty());
+  routes_ = routes;
+  std::vector<unsigned int> nfifos(nregions_, 0);
+  for (const auto& r : routes) {
+    assert(r.region < nregions_);
+    nfifos[r.region] = std::max<unsigned int>(nfifos[r.region], r.fifo + 1);
+  }
+  for (unsigned int i = 0; i < nregions_; ++i) {
+    buffers_[i].initFifos(nfifos[i]);
+  }
+}
+
+template <typename T>
+bool l1ct::multififo_regionizer::Regionizer<T>::step(bool newEvent,
+                                                     const std::vector<T>& links,
+                                                     std::vector<T>& out,
+                                                     bool mux) {
+  if (newEvent) {
+    flush();
+    nevt_++;
+  }
+  unsigned int nlinks_sector = links.size() / nsectors_;
+  for (const auto& r : routes_) {
+    unsigned int index = nlinks_sector * r.sector + r.link;
+    buffers_[r.region].maybe_push(r.fifo, links[index], sectors_[r.sector]);
+  }
+  if (mux) {
+    out.resize(nout_);
     for (unsigned int i = 0; i < nregions_; ++i) {
-        buffers_[i].initFifos(nfifos[i]);
+      if (newEvent)
+        builders_[i].pop(bigmux_);
+      builders_[i].push(buffers_[i].pop());
     }
+    return bigmux_.stream(newEvent && (nevt_ > 1), out);
+  } else {
+    out.resize(nregions_);
+    for (unsigned int i = 0; i < nregions_; ++i) {
+      out[i] = buffers_[i].pop();
+    }
+    return true;
+  }
 }
 
-template<typename T>
-bool l1ct::multififo_regionizer::Regionizer<T>::step(bool newEvent, const std::vector<T> & links, std::vector<T> & out, bool mux) {
-    if (newEvent) { flush(); nevt_++; }
-    unsigned int nlinks_sector = links.size()/nsectors_;
-    for (const auto & r : routes_) {
-        unsigned int index = nlinks_sector * r.sector + r.link;
-        buffers_[r.region].maybe_push(r.fifo, links[index], sectors_[r.sector]);
-    }
-    if (mux) {
-        out.resize(nout_);
-        for (unsigned int i = 0; i < nregions_; ++i) {
-            if (newEvent) builders_[i].pop(bigmux_);
-            builders_[i].push(buffers_[i].pop());
-        }
-        return bigmux_.stream(newEvent && (nevt_ > 1), out);
-    } else {
-        out.resize(nregions_);
-        for (unsigned int i = 0; i < nregions_; ++i) {
-            out[i] = buffers_[i].pop();
-        }
-        return true;
-    }
+template <typename T>
+void l1ct::multififo_regionizer::Regionizer<T>::destream(int iclock,
+                                                         const std::vector<T>& streams,
+                                                         std::vector<T>& out) {
+  assert(streaming_ && outii_ > 0);
+  assert(streams.size() == nout_);
+  int local_clk = iclock % outii_;
+  if (local_clk == 0) {
+    out.resize(nsorted_);
+    for (auto& o : out)
+      o.clear();
+  }
+  for (unsigned int i = 0, j = local_clk; j < nsorted_; ++i, j += outii_) {
+    out[j] = streams[i];
+  }
 }
-
-template<typename T>
-void l1ct::multififo_regionizer::Regionizer<T>::destream(int iclock, const std::vector<T> & streams, std::vector<T> & out) {
-    assert(streaming_ && outii_ > 0);
-    assert(streams.size() == nout_);
-    int local_clk = iclock % outii_;
-    if (local_clk == 0) {
-        out.resize(nsorted_);
-        for (auto & o : out) o.clear();
-    }
-    for (unsigned int i = 0, j = local_clk; j < nsorted_; ++i, j += outii_) {
-        out[j] = streams[i];
-    }
-}
-

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/multififo/multififo_regionizer_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/multififo/multififo_regionizer_ref.cpp
@@ -1,0 +1,279 @@
+#include "multififo_regionizer_ref.h"
+
+#include <iostream>
+
+#include "multififo_regionizer_elements_ref.icc"
+
+#ifdef CMSSW_GIT_HASH
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+l1ct::MultififoRegionizerEmulator::MultififoRegionizerEmulator(const edm::ParameterSet& iConfig) :
+        MultififoRegionizerEmulator( 
+                /*nendcaps=*/2,
+                iConfig.getParameter<uint32_t>("nClocks"),
+                iConfig.getParameter<uint32_t>("nTrack"),
+                iConfig.getParameter<uint32_t>("nCalo"),
+                iConfig.getParameter<uint32_t>("nEmCalo"),
+                iConfig.getParameter<uint32_t>("nMu"),
+                /*streaming=*/false,
+                /*outii=*/1)
+    {
+        debug_ = iConfig.getUntrackedParameter<bool>("debug", false);
+    }
+#endif
+
+l1ct::MultififoRegionizerEmulator::MultififoRegionizerEmulator(unsigned int nendcaps, unsigned int nclocks, unsigned int ntk, unsigned int ncalo, unsigned int nem, unsigned int nmu, bool streaming, unsigned int outii) :
+    RegionizerEmulator(false),
+    nendcaps_(nendcaps), nclocks_(nclocks), ntk_(ntk), ncalo_(ncalo), nem_(nem), nmu_(nmu), outii_(outii), streaming_(streaming), init_(false),
+    tkRegionizer_(ntk, streaming ? (ntk+outii-1)/outii : ntk, streaming, outii),
+    hadCaloRegionizer_(ncalo, streaming ? (ncalo+outii-1)/outii : ncalo, streaming, outii),
+    emCaloRegionizer_(nem, streaming ? (nem+outii-1)/outii : nem, streaming, outii),
+    muRegionizer_(nmu, streaming ? std::max(1u,(nmu+outii-1)/outii) : nmu, streaming, outii)
+{
+    // now we initialize the routes: track finder
+    for (unsigned int ie = 0; ie < nendcaps && ntk > 0; ++ie) {
+        for (unsigned int is = 0; is < NTK_SECTORS; ++is) { // 9 tf sectors
+            for (unsigned int il = 0; il < NTK_LINKS; ++il) { // max tracks per sector per clock
+                unsigned int isp = (is+1)%NTK_SECTORS, ism = (is+NTK_SECTORS-1)%NTK_SECTORS;
+                tkRoutes_.emplace_back(is + NTK_SECTORS*ie, il, is  + NTK_SECTORS*ie, il);
+                tkRoutes_.emplace_back(is + NTK_SECTORS*ie, il, isp + NTK_SECTORS*ie, il+2);
+                tkRoutes_.emplace_back(is + NTK_SECTORS*ie, il, ism + NTK_SECTORS*ie, il+4);
+            }
+        }
+    }
+    // hgcal
+    assert(NCALO_SECTORS == 3 && NTK_SECTORS == 9); // otherwise math below is broken, but it's hard to make it generic
+    for (unsigned int ie = 0; ie < nendcaps; ++ie) {
+        for (unsigned int is = 0; is < NCALO_SECTORS; ++is) { // NCALO_SECTORS sectors
+            for (unsigned int il = 0; il < NCALO_LINKS; ++il) { // max clusters per sector per clock
+                for (unsigned int j = 0; j < 3; ++j) {
+                    caloRoutes_.emplace_back(is + 3*ie, il, 3*is+j + 9*ie, il);
+                    if (j) {
+                        caloRoutes_.emplace_back((is+1)%3 + 3*ie, il, 3*is+j + 9*ie, il+4);
+                    }
+                }
+            }
+        }
+    }
+    // mu
+    for (unsigned int il = 0; il < NMU_LINKS && nmu > 0; ++il) { // max clusters per sector per clock
+        for (unsigned int j = 0; j < NTK_SECTORS*nendcaps; ++j) {
+            muRoutes_.emplace_back(0, il, j, il);
+        }
+    }
+}
+
+l1ct::MultififoRegionizerEmulator::~MultififoRegionizerEmulator()
+{
+}
+
+void l1ct::MultififoRegionizerEmulator::initSectorsAndRegions(const RegionizerDecodedInputs & in, const std::vector<PFInputRegion> & out) {
+    assert(!init_); init_ = true;
+    assert(out.size() == NTK_SECTORS*nendcaps_);
+    nregions_ = out.size();
+    if (ntk_) {
+        assert(in.track.size() == NTK_SECTORS*nendcaps_);
+        tkRegionizer_.initSectors(in.track);
+        tkRegionizer_.initRegions(out);
+        tkRegionizer_.initRouting(tkRoutes_);
+    }
+    if (ncalo_) {
+        assert(in.hadcalo.size() == NCALO_SECTORS*nendcaps_);
+        hadCaloRegionizer_.initSectors(in.hadcalo);
+        hadCaloRegionizer_.initRegions(out);
+        hadCaloRegionizer_.initRouting(caloRoutes_);
+    }
+    if (nem_) {
+        assert(in.emcalo.size() == NCALO_SECTORS*nendcaps_);
+        emCaloRegionizer_.initSectors(in.emcalo);
+        emCaloRegionizer_.initRegions(out);
+        emCaloRegionizer_.initRouting(caloRoutes_);
+    }
+    if (nmu_) {
+        muRegionizer_.initSectors(in.muon);
+        muRegionizer_.initRegions(out);
+        muRegionizer_.initRouting(muRoutes_);
+    }
+}
+
+// clock-cycle emulation
+bool l1ct::MultififoRegionizerEmulator::step(bool newEvent, const std::vector<l1ct::TkObjEmu> & links, std::vector<l1ct::TkObjEmu> & out, bool mux ) {
+    return ntk_ ? tkRegionizer_.step(newEvent, links, out, mux) : false;
+}
+bool l1ct::MultififoRegionizerEmulator::step(bool newEvent, const std::vector<l1ct::EmCaloObjEmu> & links, std::vector<l1ct::EmCaloObjEmu> & out, bool mux ) {
+    return nem_ ? emCaloRegionizer_.step(newEvent, links, out, mux) : false;
+}
+bool l1ct::MultififoRegionizerEmulator::step(bool newEvent, const std::vector<l1ct::HadCaloObjEmu> & links, std::vector<l1ct::HadCaloObjEmu> & out, bool mux ) {
+    return ncalo_ ? hadCaloRegionizer_.step(newEvent, links, out, mux) : false;
+}
+bool l1ct::MultififoRegionizerEmulator::step(bool newEvent, const std::vector<l1ct::MuObjEmu> & links, std::vector<l1ct::MuObjEmu> & out, bool mux ) {
+    return nmu_ ? muRegionizer_.step(newEvent, links, out, mux) : false;
+}
+
+
+void l1ct::MultififoRegionizerEmulator::fillLinks(unsigned int iclock, const l1ct::RegionizerDecodedInputs & in, std::vector<l1ct::TkObjEmu> & links) {
+    if (ntk_ == 0) return;
+    links.resize(NTK_SECTORS*NTK_LINKS*nendcaps_);
+    for (unsigned int is = 0, idx = 0; is < NTK_SECTORS*nendcaps_; ++is) { // tf sectors
+        const l1ct::DetectorSector<l1ct::TkObjEmu> & sec = in.track[is];
+        for (unsigned int il = 0; il < NTK_LINKS; ++il, ++idx) { 
+            unsigned int ioffs = iclock * NTK_LINKS + il; 
+            if (ioffs < sec.size() && iclock < nclocks_-1) {
+                links[idx] = sec[ioffs];
+            } else {
+                links[idx].clear();
+            }
+        }
+    }
+}
+
+template<typename T>
+void l1ct::MultififoRegionizerEmulator::fillCaloLinks_(unsigned int iclock, const std::vector<DetectorSector<T>> & in, std::vector<T> & links) {
+    links.resize(NCALO_SECTORS*NCALO_LINKS*nendcaps_);
+    for (unsigned int is = 0, idx = 0; is < NCALO_SECTORS*nendcaps_; ++is) { 
+        for (unsigned int il = 0; il < NCALO_LINKS; ++il, ++idx) { 
+            unsigned int ioffs = iclock * NCALO_LINKS + il; 
+            if (ioffs < in[is].size() && iclock < nclocks_-1) {
+                links[idx] = in[is][ioffs];
+            } else {
+                links[idx].clear();
+            }
+        }
+    }
+}
+
+void l1ct::MultififoRegionizerEmulator::fillLinks(unsigned int iclock, const l1ct::RegionizerDecodedInputs & in, std::vector<l1ct::HadCaloObjEmu> & links) {
+    if (ncalo_ == 0) return;
+    fillCaloLinks_(iclock, in.hadcalo, links);
+}
+
+void l1ct::MultififoRegionizerEmulator::fillLinks(unsigned int iclock, const l1ct::RegionizerDecodedInputs & in, std::vector<l1ct::EmCaloObjEmu> & links) {
+    if (nem_ == 0) return;
+    fillCaloLinks_(iclock, in.emcalo, links);
+}
+
+void l1ct::MultififoRegionizerEmulator::fillLinks(unsigned int iclock, const l1ct::RegionizerDecodedInputs & in, std::vector<l1ct::MuObjEmu> & links) {
+    if (nmu_ == 0) return;
+    links.resize(NMU_LINKS);
+    // we have 2 muons on odd clock cycles, and 1 muon on even clock cycles.
+    assert(NMU_LINKS == 2);  
+    for (unsigned int il = 0, idx = 0; il < NMU_LINKS; ++il, ++idx) { 
+        unsigned int ioffs = (iclock * 3)/2 + il; 
+        if (ioffs < in.muon.size() && (il == 0 || iclock % 2 == 1) && iclock < nclocks_-1) {
+            links[idx] = in.muon[ioffs];
+        } else {
+            links[idx].clear();
+        }
+    }
+}
+
+void l1ct::MultififoRegionizerEmulator::toFirmware(const std::vector<l1ct::TkObjEmu> & emu, TkObj fw[NTK_SECTORS][NTK_LINKS]) {
+    if (ntk_ == 0) return;
+    assert(emu.size() == NTK_SECTORS*NTK_LINKS*nendcaps_);
+    for (unsigned int is = 0, idx = 0; is < NTK_SECTORS*nendcaps_; ++is) { // tf sectors
+        for (unsigned int il = 0; il < NTK_LINKS; ++il, ++idx) { 
+            fw[is][il] = emu[idx];
+        }
+    }
+}
+void l1ct::MultififoRegionizerEmulator::toFirmware(const std::vector<l1ct::HadCaloObjEmu> & emu, HadCaloObj fw[NCALO_SECTORS][NCALO_LINKS]) {
+    if (ncalo_ == 0) return;
+    assert(emu.size() == NCALO_SECTORS*NCALO_LINKS*nendcaps_);
+    for (unsigned int is = 0, idx = 0; is < NCALO_SECTORS*nendcaps_; ++is) { // tf sectors
+        for (unsigned int il = 0; il < NCALO_LINKS; ++il, ++idx) { 
+            fw[is][il] = emu[idx];
+        }
+    }
+}
+
+void l1ct::MultififoRegionizerEmulator::toFirmware(const std::vector<l1ct::EmCaloObjEmu> & emu, EmCaloObj fw[NCALO_SECTORS][NCALO_LINKS]) {
+    if (nem_ == 0) return;
+    assert(emu.size() == NCALO_SECTORS*NCALO_LINKS*nendcaps_);
+    for (unsigned int is = 0, idx = 0; is < NCALO_SECTORS*nendcaps_; ++is) { // tf sectors
+        for (unsigned int il = 0; il < NCALO_LINKS; ++il, ++idx) { 
+            fw[is][il] = emu[idx];
+        }
+    }
+}
+
+void l1ct::MultififoRegionizerEmulator::toFirmware(const std::vector<l1ct::MuObjEmu> & emu, MuObj fw[NMU_LINKS]) {
+    if (nmu_ == 0) return;
+    assert(emu.size() == NMU_LINKS);
+    for (unsigned int il = 0, idx = 0; il < NMU_LINKS; ++il, ++idx) { 
+        fw[il] = emu[idx];
+    }
+}
+
+void l1ct::MultififoRegionizerEmulator::destream(int iclock, const std::vector<l1ct::TkObjEmu> & tk_out, 
+                                      const std::vector<l1ct::EmCaloObjEmu> & em_out, 
+                                      const std::vector<l1ct::HadCaloObjEmu> & calo_out,
+                                      const std::vector<l1ct::MuObjEmu> & mu_out,
+                                      PFInputRegion & out) {
+    if (ntk_) tkRegionizer_.destream(iclock, tk_out, out.track);
+    if (ncalo_) hadCaloRegionizer_.destream(iclock, calo_out, out.hadcalo);
+    if (nem_) emCaloRegionizer_.destream(iclock, em_out, out.emcalo);
+    if (nmu_) muRegionizer_.destream(iclock, mu_out, out.muon);
+}
+
+
+void l1ct::MultififoRegionizerEmulator::run(const RegionizerDecodedInputs & in, std::vector<PFInputRegion> & out) {
+    if (!init_) initSectorsAndRegions(in, out);
+    tkRegionizer_.reset();
+    emCaloRegionizer_.reset();
+    hadCaloRegionizer_.reset();
+    muRegionizer_.reset();
+    std::vector<l1ct::TkObjEmu> tk_links_in, tk_out;
+    std::vector<l1ct::EmCaloObjEmu> em_links_in, em_out;
+    std::vector<l1ct::HadCaloObjEmu> calo_links_in, calo_out;
+    std::vector<l1ct::MuObjEmu> mu_links_in, mu_out;
+
+    // read and sort the inputs
+    for (unsigned int iclock = 0; iclock < nclocks_; ++iclock) {
+        fillLinks(iclock, in, tk_links_in);
+        fillLinks(iclock, in, em_links_in);
+        fillLinks(iclock, in, calo_links_in);
+        fillLinks(iclock, in, mu_links_in);
+
+        bool newevt = (iclock == 0), mux = true;
+        step(newevt, tk_links_in, tk_out, mux);
+        step(newevt, em_links_in, em_out, mux);
+        step(newevt, calo_links_in, calo_out, mux);
+        step(newevt, mu_links_in, mu_out, mux);
+    }
+
+    // set up an empty event
+    for (auto & l: tk_links_in) l.clear();
+    for (auto & l: em_links_in) l.clear();
+    for (auto & l: calo_links_in) l.clear();
+    for (auto & l: mu_links_in) l.clear();
+
+    // read and put the inputs in the regions
+    assert(out.size() == nregions_);
+    for (unsigned int iclock = 0; iclock < nclocks_; ++iclock) {
+        bool newevt = (iclock == 0), mux = true;
+        step(newevt, tk_links_in, tk_out, mux);
+        step(newevt, em_links_in, em_out, mux);
+        step(newevt, calo_links_in, calo_out, mux);
+        step(newevt, mu_links_in, mu_out, mux);
+
+        unsigned int ireg = iclock/outii_; 
+        if (ireg >= nregions_) break;
+
+        if (streaming_) {
+            destream(iclock, tk_out, em_out, calo_out, mu_out, out[ireg]);
+        } else {
+            if (iclock % outii_ == 0) {
+                out[ireg].track   = tk_out;
+                out[ireg].emcalo  = em_out;
+                out[ireg].hadcalo = calo_out;
+                out[ireg].muon    = mu_out;
+            }
+        }
+    }
+
+    tkRegionizer_.reset();
+    emCaloRegionizer_.reset();
+    hadCaloRegionizer_.reset();
+    muRegionizer_.reset();
+}
+

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/multififo/multififo_regionizer_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/multififo/multififo_regionizer_ref.cpp
@@ -7,273 +7,327 @@
 #ifdef CMSSW_GIT_HASH
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-l1ct::MultififoRegionizerEmulator::MultififoRegionizerEmulator(const edm::ParameterSet& iConfig) :
-        MultififoRegionizerEmulator( 
-                /*nendcaps=*/2,
-                iConfig.getParameter<uint32_t>("nClocks"),
-                iConfig.getParameter<uint32_t>("nTrack"),
-                iConfig.getParameter<uint32_t>("nCalo"),
-                iConfig.getParameter<uint32_t>("nEmCalo"),
-                iConfig.getParameter<uint32_t>("nMu"),
-                /*streaming=*/false,
-                /*outii=*/1)
-    {
-        debug_ = iConfig.getUntrackedParameter<bool>("debug", false);
-    }
+l1ct::MultififoRegionizerEmulator::MultififoRegionizerEmulator(const edm::ParameterSet& iConfig)
+    : MultififoRegionizerEmulator(
+          /*nendcaps=*/2,
+          iConfig.getParameter<uint32_t>("nClocks"),
+          iConfig.getParameter<uint32_t>("nTrack"),
+          iConfig.getParameter<uint32_t>("nCalo"),
+          iConfig.getParameter<uint32_t>("nEmCalo"),
+          iConfig.getParameter<uint32_t>("nMu"),
+          /*streaming=*/false,
+          /*outii=*/1) {
+  debug_ = iConfig.getUntrackedParameter<bool>("debug", false);
+}
 #endif
 
-l1ct::MultififoRegionizerEmulator::MultififoRegionizerEmulator(unsigned int nendcaps, unsigned int nclocks, unsigned int ntk, unsigned int ncalo, unsigned int nem, unsigned int nmu, bool streaming, unsigned int outii) :
-    RegionizerEmulator(false),
-    nendcaps_(nendcaps), nclocks_(nclocks), ntk_(ntk), ncalo_(ncalo), nem_(nem), nmu_(nmu), outii_(outii), streaming_(streaming), init_(false),
-    tkRegionizer_(ntk, streaming ? (ntk+outii-1)/outii : ntk, streaming, outii),
-    hadCaloRegionizer_(ncalo, streaming ? (ncalo+outii-1)/outii : ncalo, streaming, outii),
-    emCaloRegionizer_(nem, streaming ? (nem+outii-1)/outii : nem, streaming, outii),
-    muRegionizer_(nmu, streaming ? std::max(1u,(nmu+outii-1)/outii) : nmu, streaming, outii)
-{
-    // now we initialize the routes: track finder
-    for (unsigned int ie = 0; ie < nendcaps && ntk > 0; ++ie) {
-        for (unsigned int is = 0; is < NTK_SECTORS; ++is) { // 9 tf sectors
-            for (unsigned int il = 0; il < NTK_LINKS; ++il) { // max tracks per sector per clock
-                unsigned int isp = (is+1)%NTK_SECTORS, ism = (is+NTK_SECTORS-1)%NTK_SECTORS;
-                tkRoutes_.emplace_back(is + NTK_SECTORS*ie, il, is  + NTK_SECTORS*ie, il);
-                tkRoutes_.emplace_back(is + NTK_SECTORS*ie, il, isp + NTK_SECTORS*ie, il+2);
-                tkRoutes_.emplace_back(is + NTK_SECTORS*ie, il, ism + NTK_SECTORS*ie, il+4);
-            }
-        }
+l1ct::MultififoRegionizerEmulator::MultififoRegionizerEmulator(unsigned int nendcaps,
+                                                               unsigned int nclocks,
+                                                               unsigned int ntk,
+                                                               unsigned int ncalo,
+                                                               unsigned int nem,
+                                                               unsigned int nmu,
+                                                               bool streaming,
+                                                               unsigned int outii)
+    : RegionizerEmulator(false),
+      nendcaps_(nendcaps),
+      nclocks_(nclocks),
+      ntk_(ntk),
+      ncalo_(ncalo),
+      nem_(nem),
+      nmu_(nmu),
+      outii_(outii),
+      streaming_(streaming),
+      init_(false),
+      tkRegionizer_(ntk, streaming ? (ntk + outii - 1) / outii : ntk, streaming, outii),
+      hadCaloRegionizer_(ncalo, streaming ? (ncalo + outii - 1) / outii : ncalo, streaming, outii),
+      emCaloRegionizer_(nem, streaming ? (nem + outii - 1) / outii : nem, streaming, outii),
+      muRegionizer_(nmu, streaming ? std::max(1u, (nmu + outii - 1) / outii) : nmu, streaming, outii) {
+  // now we initialize the routes: track finder
+  for (unsigned int ie = 0; ie < nendcaps && ntk > 0; ++ie) {
+    for (unsigned int is = 0; is < NTK_SECTORS; ++is) {  // 9 tf sectors
+      for (unsigned int il = 0; il < NTK_LINKS; ++il) {  // max tracks per sector per clock
+        unsigned int isp = (is + 1) % NTK_SECTORS, ism = (is + NTK_SECTORS - 1) % NTK_SECTORS;
+        tkRoutes_.emplace_back(is + NTK_SECTORS * ie, il, is + NTK_SECTORS * ie, il);
+        tkRoutes_.emplace_back(is + NTK_SECTORS * ie, il, isp + NTK_SECTORS * ie, il + 2);
+        tkRoutes_.emplace_back(is + NTK_SECTORS * ie, il, ism + NTK_SECTORS * ie, il + 4);
+      }
     }
-    // hgcal
-    assert(NCALO_SECTORS == 3 && NTK_SECTORS == 9); // otherwise math below is broken, but it's hard to make it generic
-    for (unsigned int ie = 0; ie < nendcaps; ++ie) {
-        for (unsigned int is = 0; is < NCALO_SECTORS; ++is) { // NCALO_SECTORS sectors
-            for (unsigned int il = 0; il < NCALO_LINKS; ++il) { // max clusters per sector per clock
-                for (unsigned int j = 0; j < 3; ++j) {
-                    caloRoutes_.emplace_back(is + 3*ie, il, 3*is+j + 9*ie, il);
-                    if (j) {
-                        caloRoutes_.emplace_back((is+1)%3 + 3*ie, il, 3*is+j + 9*ie, il+4);
-                    }
-                }
-            }
+  }
+  // hgcal
+  assert(NCALO_SECTORS == 3 && NTK_SECTORS == 9);  // otherwise math below is broken, but it's hard to make it generic
+  for (unsigned int ie = 0; ie < nendcaps; ++ie) {
+    for (unsigned int is = 0; is < NCALO_SECTORS; ++is) {  // NCALO_SECTORS sectors
+      for (unsigned int il = 0; il < NCALO_LINKS; ++il) {  // max clusters per sector per clock
+        for (unsigned int j = 0; j < 3; ++j) {
+          caloRoutes_.emplace_back(is + 3 * ie, il, 3 * is + j + 9 * ie, il);
+          if (j) {
+            caloRoutes_.emplace_back((is + 1) % 3 + 3 * ie, il, 3 * is + j + 9 * ie, il + 4);
+          }
         }
+      }
     }
-    // mu
-    for (unsigned int il = 0; il < NMU_LINKS && nmu > 0; ++il) { // max clusters per sector per clock
-        for (unsigned int j = 0; j < NTK_SECTORS*nendcaps; ++j) {
-            muRoutes_.emplace_back(0, il, j, il);
-        }
+  }
+  // mu
+  for (unsigned int il = 0; il < NMU_LINKS && nmu > 0; ++il) {  // max clusters per sector per clock
+    for (unsigned int j = 0; j < NTK_SECTORS * nendcaps; ++j) {
+      muRoutes_.emplace_back(0, il, j, il);
     }
+  }
 }
 
-l1ct::MultififoRegionizerEmulator::~MultififoRegionizerEmulator()
-{
-}
+l1ct::MultififoRegionizerEmulator::~MultififoRegionizerEmulator() {}
 
-void l1ct::MultififoRegionizerEmulator::initSectorsAndRegions(const RegionizerDecodedInputs & in, const std::vector<PFInputRegion> & out) {
-    assert(!init_); init_ = true;
-    assert(out.size() == NTK_SECTORS*nendcaps_);
-    nregions_ = out.size();
-    if (ntk_) {
-        assert(in.track.size() == NTK_SECTORS*nendcaps_);
-        tkRegionizer_.initSectors(in.track);
-        tkRegionizer_.initRegions(out);
-        tkRegionizer_.initRouting(tkRoutes_);
-    }
-    if (ncalo_) {
-        assert(in.hadcalo.size() == NCALO_SECTORS*nendcaps_);
-        hadCaloRegionizer_.initSectors(in.hadcalo);
-        hadCaloRegionizer_.initRegions(out);
-        hadCaloRegionizer_.initRouting(caloRoutes_);
-    }
-    if (nem_) {
-        assert(in.emcalo.size() == NCALO_SECTORS*nendcaps_);
-        emCaloRegionizer_.initSectors(in.emcalo);
-        emCaloRegionizer_.initRegions(out);
-        emCaloRegionizer_.initRouting(caloRoutes_);
-    }
-    if (nmu_) {
-        muRegionizer_.initSectors(in.muon);
-        muRegionizer_.initRegions(out);
-        muRegionizer_.initRouting(muRoutes_);
-    }
+void l1ct::MultififoRegionizerEmulator::initSectorsAndRegions(const RegionizerDecodedInputs& in,
+                                                              const std::vector<PFInputRegion>& out) {
+  assert(!init_);
+  init_ = true;
+  assert(out.size() == NTK_SECTORS * nendcaps_);
+  nregions_ = out.size();
+  if (ntk_) {
+    assert(in.track.size() == NTK_SECTORS * nendcaps_);
+    tkRegionizer_.initSectors(in.track);
+    tkRegionizer_.initRegions(out);
+    tkRegionizer_.initRouting(tkRoutes_);
+  }
+  if (ncalo_) {
+    assert(in.hadcalo.size() == NCALO_SECTORS * nendcaps_);
+    hadCaloRegionizer_.initSectors(in.hadcalo);
+    hadCaloRegionizer_.initRegions(out);
+    hadCaloRegionizer_.initRouting(caloRoutes_);
+  }
+  if (nem_) {
+    assert(in.emcalo.size() == NCALO_SECTORS * nendcaps_);
+    emCaloRegionizer_.initSectors(in.emcalo);
+    emCaloRegionizer_.initRegions(out);
+    emCaloRegionizer_.initRouting(caloRoutes_);
+  }
+  if (nmu_) {
+    muRegionizer_.initSectors(in.muon);
+    muRegionizer_.initRegions(out);
+    muRegionizer_.initRouting(muRoutes_);
+  }
 }
 
 // clock-cycle emulation
-bool l1ct::MultififoRegionizerEmulator::step(bool newEvent, const std::vector<l1ct::TkObjEmu> & links, std::vector<l1ct::TkObjEmu> & out, bool mux ) {
-    return ntk_ ? tkRegionizer_.step(newEvent, links, out, mux) : false;
+bool l1ct::MultififoRegionizerEmulator::step(bool newEvent,
+                                             const std::vector<l1ct::TkObjEmu>& links,
+                                             std::vector<l1ct::TkObjEmu>& out,
+                                             bool mux) {
+  return ntk_ ? tkRegionizer_.step(newEvent, links, out, mux) : false;
 }
-bool l1ct::MultififoRegionizerEmulator::step(bool newEvent, const std::vector<l1ct::EmCaloObjEmu> & links, std::vector<l1ct::EmCaloObjEmu> & out, bool mux ) {
-    return nem_ ? emCaloRegionizer_.step(newEvent, links, out, mux) : false;
+bool l1ct::MultififoRegionizerEmulator::step(bool newEvent,
+                                             const std::vector<l1ct::EmCaloObjEmu>& links,
+                                             std::vector<l1ct::EmCaloObjEmu>& out,
+                                             bool mux) {
+  return nem_ ? emCaloRegionizer_.step(newEvent, links, out, mux) : false;
 }
-bool l1ct::MultififoRegionizerEmulator::step(bool newEvent, const std::vector<l1ct::HadCaloObjEmu> & links, std::vector<l1ct::HadCaloObjEmu> & out, bool mux ) {
-    return ncalo_ ? hadCaloRegionizer_.step(newEvent, links, out, mux) : false;
+bool l1ct::MultififoRegionizerEmulator::step(bool newEvent,
+                                             const std::vector<l1ct::HadCaloObjEmu>& links,
+                                             std::vector<l1ct::HadCaloObjEmu>& out,
+                                             bool mux) {
+  return ncalo_ ? hadCaloRegionizer_.step(newEvent, links, out, mux) : false;
 }
-bool l1ct::MultififoRegionizerEmulator::step(bool newEvent, const std::vector<l1ct::MuObjEmu> & links, std::vector<l1ct::MuObjEmu> & out, bool mux ) {
-    return nmu_ ? muRegionizer_.step(newEvent, links, out, mux) : false;
+bool l1ct::MultififoRegionizerEmulator::step(bool newEvent,
+                                             const std::vector<l1ct::MuObjEmu>& links,
+                                             std::vector<l1ct::MuObjEmu>& out,
+                                             bool mux) {
+  return nmu_ ? muRegionizer_.step(newEvent, links, out, mux) : false;
 }
 
-
-void l1ct::MultififoRegionizerEmulator::fillLinks(unsigned int iclock, const l1ct::RegionizerDecodedInputs & in, std::vector<l1ct::TkObjEmu> & links) {
-    if (ntk_ == 0) return;
-    links.resize(NTK_SECTORS*NTK_LINKS*nendcaps_);
-    for (unsigned int is = 0, idx = 0; is < NTK_SECTORS*nendcaps_; ++is) { // tf sectors
-        const l1ct::DetectorSector<l1ct::TkObjEmu> & sec = in.track[is];
-        for (unsigned int il = 0; il < NTK_LINKS; ++il, ++idx) { 
-            unsigned int ioffs = iclock * NTK_LINKS + il; 
-            if (ioffs < sec.size() && iclock < nclocks_-1) {
-                links[idx] = sec[ioffs];
-            } else {
-                links[idx].clear();
-            }
-        }
+void l1ct::MultififoRegionizerEmulator::fillLinks(unsigned int iclock,
+                                                  const l1ct::RegionizerDecodedInputs& in,
+                                                  std::vector<l1ct::TkObjEmu>& links) {
+  if (ntk_ == 0)
+    return;
+  links.resize(NTK_SECTORS * NTK_LINKS * nendcaps_);
+  for (unsigned int is = 0, idx = 0; is < NTK_SECTORS * nendcaps_; ++is) {  // tf sectors
+    const l1ct::DetectorSector<l1ct::TkObjEmu>& sec = in.track[is];
+    for (unsigned int il = 0; il < NTK_LINKS; ++il, ++idx) {
+      unsigned int ioffs = iclock * NTK_LINKS + il;
+      if (ioffs < sec.size() && iclock < nclocks_ - 1) {
+        links[idx] = sec[ioffs];
+      } else {
+        links[idx].clear();
+      }
     }
+  }
 }
 
-template<typename T>
-void l1ct::MultififoRegionizerEmulator::fillCaloLinks_(unsigned int iclock, const std::vector<DetectorSector<T>> & in, std::vector<T> & links) {
-    links.resize(NCALO_SECTORS*NCALO_LINKS*nendcaps_);
-    for (unsigned int is = 0, idx = 0; is < NCALO_SECTORS*nendcaps_; ++is) { 
-        for (unsigned int il = 0; il < NCALO_LINKS; ++il, ++idx) { 
-            unsigned int ioffs = iclock * NCALO_LINKS + il; 
-            if (ioffs < in[is].size() && iclock < nclocks_-1) {
-                links[idx] = in[is][ioffs];
-            } else {
-                links[idx].clear();
-            }
-        }
+template <typename T>
+void l1ct::MultififoRegionizerEmulator::fillCaloLinks_(unsigned int iclock,
+                                                       const std::vector<DetectorSector<T>>& in,
+                                                       std::vector<T>& links) {
+  links.resize(NCALO_SECTORS * NCALO_LINKS * nendcaps_);
+  for (unsigned int is = 0, idx = 0; is < NCALO_SECTORS * nendcaps_; ++is) {
+    for (unsigned int il = 0; il < NCALO_LINKS; ++il, ++idx) {
+      unsigned int ioffs = iclock * NCALO_LINKS + il;
+      if (ioffs < in[is].size() && iclock < nclocks_ - 1) {
+        links[idx] = in[is][ioffs];
+      } else {
+        links[idx].clear();
+      }
     }
+  }
 }
 
-void l1ct::MultififoRegionizerEmulator::fillLinks(unsigned int iclock, const l1ct::RegionizerDecodedInputs & in, std::vector<l1ct::HadCaloObjEmu> & links) {
-    if (ncalo_ == 0) return;
-    fillCaloLinks_(iclock, in.hadcalo, links);
+void l1ct::MultififoRegionizerEmulator::fillLinks(unsigned int iclock,
+                                                  const l1ct::RegionizerDecodedInputs& in,
+                                                  std::vector<l1ct::HadCaloObjEmu>& links) {
+  if (ncalo_ == 0)
+    return;
+  fillCaloLinks_(iclock, in.hadcalo, links);
 }
 
-void l1ct::MultififoRegionizerEmulator::fillLinks(unsigned int iclock, const l1ct::RegionizerDecodedInputs & in, std::vector<l1ct::EmCaloObjEmu> & links) {
-    if (nem_ == 0) return;
-    fillCaloLinks_(iclock, in.emcalo, links);
+void l1ct::MultififoRegionizerEmulator::fillLinks(unsigned int iclock,
+                                                  const l1ct::RegionizerDecodedInputs& in,
+                                                  std::vector<l1ct::EmCaloObjEmu>& links) {
+  if (nem_ == 0)
+    return;
+  fillCaloLinks_(iclock, in.emcalo, links);
 }
 
-void l1ct::MultififoRegionizerEmulator::fillLinks(unsigned int iclock, const l1ct::RegionizerDecodedInputs & in, std::vector<l1ct::MuObjEmu> & links) {
-    if (nmu_ == 0) return;
-    links.resize(NMU_LINKS);
-    // we have 2 muons on odd clock cycles, and 1 muon on even clock cycles.
-    assert(NMU_LINKS == 2);  
-    for (unsigned int il = 0, idx = 0; il < NMU_LINKS; ++il, ++idx) { 
-        unsigned int ioffs = (iclock * 3)/2 + il; 
-        if (ioffs < in.muon.size() && (il == 0 || iclock % 2 == 1) && iclock < nclocks_-1) {
-            links[idx] = in.muon[ioffs];
-        } else {
-            links[idx].clear();
-        }
+void l1ct::MultififoRegionizerEmulator::fillLinks(unsigned int iclock,
+                                                  const l1ct::RegionizerDecodedInputs& in,
+                                                  std::vector<l1ct::MuObjEmu>& links) {
+  if (nmu_ == 0)
+    return;
+  links.resize(NMU_LINKS);
+  // we have 2 muons on odd clock cycles, and 1 muon on even clock cycles.
+  assert(NMU_LINKS == 2);
+  for (unsigned int il = 0, idx = 0; il < NMU_LINKS; ++il, ++idx) {
+    unsigned int ioffs = (iclock * 3) / 2 + il;
+    if (ioffs < in.muon.size() && (il == 0 || iclock % 2 == 1) && iclock < nclocks_ - 1) {
+      links[idx] = in.muon[ioffs];
+    } else {
+      links[idx].clear();
     }
+  }
 }
 
-void l1ct::MultififoRegionizerEmulator::toFirmware(const std::vector<l1ct::TkObjEmu> & emu, TkObj fw[NTK_SECTORS][NTK_LINKS]) {
-    if (ntk_ == 0) return;
-    assert(emu.size() == NTK_SECTORS*NTK_LINKS*nendcaps_);
-    for (unsigned int is = 0, idx = 0; is < NTK_SECTORS*nendcaps_; ++is) { // tf sectors
-        for (unsigned int il = 0; il < NTK_LINKS; ++il, ++idx) { 
-            fw[is][il] = emu[idx];
-        }
+void l1ct::MultififoRegionizerEmulator::toFirmware(const std::vector<l1ct::TkObjEmu>& emu,
+                                                   TkObj fw[NTK_SECTORS][NTK_LINKS]) {
+  if (ntk_ == 0)
+    return;
+  assert(emu.size() == NTK_SECTORS * NTK_LINKS * nendcaps_);
+  for (unsigned int is = 0, idx = 0; is < NTK_SECTORS * nendcaps_; ++is) {  // tf sectors
+    for (unsigned int il = 0; il < NTK_LINKS; ++il, ++idx) {
+      fw[is][il] = emu[idx];
     }
+  }
 }
-void l1ct::MultififoRegionizerEmulator::toFirmware(const std::vector<l1ct::HadCaloObjEmu> & emu, HadCaloObj fw[NCALO_SECTORS][NCALO_LINKS]) {
-    if (ncalo_ == 0) return;
-    assert(emu.size() == NCALO_SECTORS*NCALO_LINKS*nendcaps_);
-    for (unsigned int is = 0, idx = 0; is < NCALO_SECTORS*nendcaps_; ++is) { // tf sectors
-        for (unsigned int il = 0; il < NCALO_LINKS; ++il, ++idx) { 
-            fw[is][il] = emu[idx];
-        }
+void l1ct::MultififoRegionizerEmulator::toFirmware(const std::vector<l1ct::HadCaloObjEmu>& emu,
+                                                   HadCaloObj fw[NCALO_SECTORS][NCALO_LINKS]) {
+  if (ncalo_ == 0)
+    return;
+  assert(emu.size() == NCALO_SECTORS * NCALO_LINKS * nendcaps_);
+  for (unsigned int is = 0, idx = 0; is < NCALO_SECTORS * nendcaps_; ++is) {  // tf sectors
+    for (unsigned int il = 0; il < NCALO_LINKS; ++il, ++idx) {
+      fw[is][il] = emu[idx];
     }
+  }
 }
 
-void l1ct::MultififoRegionizerEmulator::toFirmware(const std::vector<l1ct::EmCaloObjEmu> & emu, EmCaloObj fw[NCALO_SECTORS][NCALO_LINKS]) {
-    if (nem_ == 0) return;
-    assert(emu.size() == NCALO_SECTORS*NCALO_LINKS*nendcaps_);
-    for (unsigned int is = 0, idx = 0; is < NCALO_SECTORS*nendcaps_; ++is) { // tf sectors
-        for (unsigned int il = 0; il < NCALO_LINKS; ++il, ++idx) { 
-            fw[is][il] = emu[idx];
-        }
+void l1ct::MultififoRegionizerEmulator::toFirmware(const std::vector<l1ct::EmCaloObjEmu>& emu,
+                                                   EmCaloObj fw[NCALO_SECTORS][NCALO_LINKS]) {
+  if (nem_ == 0)
+    return;
+  assert(emu.size() == NCALO_SECTORS * NCALO_LINKS * nendcaps_);
+  for (unsigned int is = 0, idx = 0; is < NCALO_SECTORS * nendcaps_; ++is) {  // tf sectors
+    for (unsigned int il = 0; il < NCALO_LINKS; ++il, ++idx) {
+      fw[is][il] = emu[idx];
     }
+  }
 }
 
-void l1ct::MultififoRegionizerEmulator::toFirmware(const std::vector<l1ct::MuObjEmu> & emu, MuObj fw[NMU_LINKS]) {
-    if (nmu_ == 0) return;
-    assert(emu.size() == NMU_LINKS);
-    for (unsigned int il = 0, idx = 0; il < NMU_LINKS; ++il, ++idx) { 
-        fw[il] = emu[idx];
+void l1ct::MultififoRegionizerEmulator::toFirmware(const std::vector<l1ct::MuObjEmu>& emu, MuObj fw[NMU_LINKS]) {
+  if (nmu_ == 0)
+    return;
+  assert(emu.size() == NMU_LINKS);
+  for (unsigned int il = 0, idx = 0; il < NMU_LINKS; ++il, ++idx) {
+    fw[il] = emu[idx];
+  }
+}
+
+void l1ct::MultififoRegionizerEmulator::destream(int iclock,
+                                                 const std::vector<l1ct::TkObjEmu>& tk_out,
+                                                 const std::vector<l1ct::EmCaloObjEmu>& em_out,
+                                                 const std::vector<l1ct::HadCaloObjEmu>& calo_out,
+                                                 const std::vector<l1ct::MuObjEmu>& mu_out,
+                                                 PFInputRegion& out) {
+  if (ntk_)
+    tkRegionizer_.destream(iclock, tk_out, out.track);
+  if (ncalo_)
+    hadCaloRegionizer_.destream(iclock, calo_out, out.hadcalo);
+  if (nem_)
+    emCaloRegionizer_.destream(iclock, em_out, out.emcalo);
+  if (nmu_)
+    muRegionizer_.destream(iclock, mu_out, out.muon);
+}
+
+void l1ct::MultififoRegionizerEmulator::run(const RegionizerDecodedInputs& in, std::vector<PFInputRegion>& out) {
+  if (!init_)
+    initSectorsAndRegions(in, out);
+  tkRegionizer_.reset();
+  emCaloRegionizer_.reset();
+  hadCaloRegionizer_.reset();
+  muRegionizer_.reset();
+  std::vector<l1ct::TkObjEmu> tk_links_in, tk_out;
+  std::vector<l1ct::EmCaloObjEmu> em_links_in, em_out;
+  std::vector<l1ct::HadCaloObjEmu> calo_links_in, calo_out;
+  std::vector<l1ct::MuObjEmu> mu_links_in, mu_out;
+
+  // read and sort the inputs
+  for (unsigned int iclock = 0; iclock < nclocks_; ++iclock) {
+    fillLinks(iclock, in, tk_links_in);
+    fillLinks(iclock, in, em_links_in);
+    fillLinks(iclock, in, calo_links_in);
+    fillLinks(iclock, in, mu_links_in);
+
+    bool newevt = (iclock == 0), mux = true;
+    step(newevt, tk_links_in, tk_out, mux);
+    step(newevt, em_links_in, em_out, mux);
+    step(newevt, calo_links_in, calo_out, mux);
+    step(newevt, mu_links_in, mu_out, mux);
+  }
+
+  // set up an empty event
+  for (auto& l : tk_links_in)
+    l.clear();
+  for (auto& l : em_links_in)
+    l.clear();
+  for (auto& l : calo_links_in)
+    l.clear();
+  for (auto& l : mu_links_in)
+    l.clear();
+
+  // read and put the inputs in the regions
+  assert(out.size() == nregions_);
+  for (unsigned int iclock = 0; iclock < nclocks_; ++iclock) {
+    bool newevt = (iclock == 0), mux = true;
+    step(newevt, tk_links_in, tk_out, mux);
+    step(newevt, em_links_in, em_out, mux);
+    step(newevt, calo_links_in, calo_out, mux);
+    step(newevt, mu_links_in, mu_out, mux);
+
+    unsigned int ireg = iclock / outii_;
+    if (ireg >= nregions_)
+      break;
+
+    if (streaming_) {
+      destream(iclock, tk_out, em_out, calo_out, mu_out, out[ireg]);
+    } else {
+      if (iclock % outii_ == 0) {
+        out[ireg].track = tk_out;
+        out[ireg].emcalo = em_out;
+        out[ireg].hadcalo = calo_out;
+        out[ireg].muon = mu_out;
+      }
     }
+  }
+
+  tkRegionizer_.reset();
+  emCaloRegionizer_.reset();
+  hadCaloRegionizer_.reset();
+  muRegionizer_.reset();
 }
-
-void l1ct::MultififoRegionizerEmulator::destream(int iclock, const std::vector<l1ct::TkObjEmu> & tk_out, 
-                                      const std::vector<l1ct::EmCaloObjEmu> & em_out, 
-                                      const std::vector<l1ct::HadCaloObjEmu> & calo_out,
-                                      const std::vector<l1ct::MuObjEmu> & mu_out,
-                                      PFInputRegion & out) {
-    if (ntk_) tkRegionizer_.destream(iclock, tk_out, out.track);
-    if (ncalo_) hadCaloRegionizer_.destream(iclock, calo_out, out.hadcalo);
-    if (nem_) emCaloRegionizer_.destream(iclock, em_out, out.emcalo);
-    if (nmu_) muRegionizer_.destream(iclock, mu_out, out.muon);
-}
-
-
-void l1ct::MultififoRegionizerEmulator::run(const RegionizerDecodedInputs & in, std::vector<PFInputRegion> & out) {
-    if (!init_) initSectorsAndRegions(in, out);
-    tkRegionizer_.reset();
-    emCaloRegionizer_.reset();
-    hadCaloRegionizer_.reset();
-    muRegionizer_.reset();
-    std::vector<l1ct::TkObjEmu> tk_links_in, tk_out;
-    std::vector<l1ct::EmCaloObjEmu> em_links_in, em_out;
-    std::vector<l1ct::HadCaloObjEmu> calo_links_in, calo_out;
-    std::vector<l1ct::MuObjEmu> mu_links_in, mu_out;
-
-    // read and sort the inputs
-    for (unsigned int iclock = 0; iclock < nclocks_; ++iclock) {
-        fillLinks(iclock, in, tk_links_in);
-        fillLinks(iclock, in, em_links_in);
-        fillLinks(iclock, in, calo_links_in);
-        fillLinks(iclock, in, mu_links_in);
-
-        bool newevt = (iclock == 0), mux = true;
-        step(newevt, tk_links_in, tk_out, mux);
-        step(newevt, em_links_in, em_out, mux);
-        step(newevt, calo_links_in, calo_out, mux);
-        step(newevt, mu_links_in, mu_out, mux);
-    }
-
-    // set up an empty event
-    for (auto & l: tk_links_in) l.clear();
-    for (auto & l: em_links_in) l.clear();
-    for (auto & l: calo_links_in) l.clear();
-    for (auto & l: mu_links_in) l.clear();
-
-    // read and put the inputs in the regions
-    assert(out.size() == nregions_);
-    for (unsigned int iclock = 0; iclock < nclocks_; ++iclock) {
-        bool newevt = (iclock == 0), mux = true;
-        step(newevt, tk_links_in, tk_out, mux);
-        step(newevt, em_links_in, em_out, mux);
-        step(newevt, calo_links_in, calo_out, mux);
-        step(newevt, mu_links_in, mu_out, mux);
-
-        unsigned int ireg = iclock/outii_; 
-        if (ireg >= nregions_) break;
-
-        if (streaming_) {
-            destream(iclock, tk_out, em_out, calo_out, mu_out, out[ireg]);
-        } else {
-            if (iclock % outii_ == 0) {
-                out[ireg].track   = tk_out;
-                out[ireg].emcalo  = em_out;
-                out[ireg].hadcalo = calo_out;
-                out[ireg].muon    = mu_out;
-            }
-        }
-    }
-
-    tkRegionizer_.reset();
-    emCaloRegionizer_.reset();
-    hadCaloRegionizer_.reset();
-    muRegionizer_.reset();
-}
-

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/multififo/multififo_regionizer_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/multififo/multififo_regionizer_ref.h
@@ -1,0 +1,72 @@
+#ifndef multififo_regionizer_ref_h
+#define multififo_regionizer_ref_h
+
+#include "../common/regionizer_base_ref.h"
+
+#include "multififo_regionizer_elements_ref.h"
+
+namespace edm {
+  class ParameterSet;
+}
+
+namespace l1ct {
+    class MultififoRegionizerEmulator : public RegionizerEmulator {
+        public:
+
+            MultififoRegionizerEmulator(unsigned int nendcaps, unsigned int nclocks, unsigned int ntk, unsigned int ncalo, unsigned int nem, unsigned int nmu, bool streaming, unsigned int outii=0) ;
+
+            // note: this one will work only in CMSSW
+            MultififoRegionizerEmulator(const edm::ParameterSet& iConfig) ;
+
+            ~MultififoRegionizerEmulator() override ;
+
+            static const int NTK_SECTORS = 9, NTK_LINKS = 2; // max objects per sector per clock cycle
+            static const int NCALO_SECTORS = 3, NCALO_LINKS = 4;
+            static const int NMU_LINKS = 2;
+
+            void initSectorsAndRegions(const RegionizerDecodedInputs & in, const std::vector<PFInputRegion> & out) override ;
+
+            // TODO: implement
+            void run(const RegionizerDecodedInputs & in, std::vector<PFInputRegion> & out) override ;
+
+            // clock-cycle emulation
+            bool step(bool newEvent, const std::vector<l1ct::TkObjEmu> & links, std::vector<l1ct::TkObjEmu> & out , bool mux=true) ;
+            bool step(bool newEvent, const std::vector<l1ct::EmCaloObjEmu> & links, std::vector<l1ct::EmCaloObjEmu> & out , bool mux=true) ;
+            bool step(bool newEvent, const std::vector<l1ct::HadCaloObjEmu> & links, std::vector<l1ct::HadCaloObjEmu> & out , bool mux=true) ;
+            bool step(bool newEvent, const std::vector<l1ct::MuObjEmu> & links, std::vector<l1ct::MuObjEmu> & out , bool mux=true) ;
+            void destream(int iclock, const std::vector<l1ct::TkObjEmu> & tk_out, 
+                                      const std::vector<l1ct::EmCaloObjEmu> & em_out, 
+                                      const std::vector<l1ct::HadCaloObjEmu> & calo_out,
+                                      const std::vector<l1ct::MuObjEmu> & mu_out,
+                                      PFInputRegion & out);
+
+            // link emulation from decoded inputs (for simulation)
+            void fillLinks(unsigned int iclock, const RegionizerDecodedInputs & in, std::vector<l1ct::TkObjEmu> & links);
+            void fillLinks(unsigned int iclock, const RegionizerDecodedInputs & in, std::vector<l1ct::HadCaloObjEmu> & links);
+            void fillLinks(unsigned int iclock, const RegionizerDecodedInputs & in, std::vector<l1ct::EmCaloObjEmu> & links);
+            void fillLinks(unsigned int iclock, const RegionizerDecodedInputs & in, std::vector<l1ct::MuObjEmu> & links);
+
+            // convert links to firmware
+            void toFirmware(const std::vector<l1ct::TkObjEmu> & emu, TkObj fw[NTK_SECTORS][NTK_LINKS]) ;
+            void toFirmware(const std::vector<l1ct::HadCaloObjEmu> & emu, HadCaloObj fw[NCALO_SECTORS][NCALO_LINKS]) ;
+            void toFirmware(const std::vector<l1ct::EmCaloObjEmu> & emu, EmCaloObj fw[NCALO_SECTORS][NCALO_LINKS]) ;
+            void toFirmware(const std::vector<l1ct::MuObjEmu> & emu, MuObj fw[NMU_LINKS]) ;
+            
+        private:
+            unsigned int nendcaps_, nclocks_, ntk_, ncalo_, nem_, nmu_, outii_, nregions_;
+            bool streaming_;
+            bool init_;
+
+            multififo_regionizer::Regionizer<l1ct::TkObjEmu> tkRegionizer_;
+            multififo_regionizer::Regionizer<l1ct::HadCaloObjEmu> hadCaloRegionizer_;
+            multififo_regionizer::Regionizer<l1ct::EmCaloObjEmu> emCaloRegionizer_;
+            multififo_regionizer::Regionizer<l1ct::MuObjEmu> muRegionizer_;
+            std::vector<l1ct::multififo_regionizer::Route> tkRoutes_, caloRoutes_, muRoutes_;
+
+            template<typename T>
+            void fillCaloLinks_(unsigned int iclock, const std::vector<DetectorSector<T>> & in, std::vector<T> & links);
+    };
+
+} // namespace
+
+#endif

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/multififo/multififo_regionizer_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/multififo/multififo_regionizer_ref.h
@@ -10,63 +10,82 @@ namespace edm {
 }
 
 namespace l1ct {
-    class MultififoRegionizerEmulator : public RegionizerEmulator {
-        public:
+  class MultififoRegionizerEmulator : public RegionizerEmulator {
+  public:
+    MultififoRegionizerEmulator(unsigned int nendcaps,
+                                unsigned int nclocks,
+                                unsigned int ntk,
+                                unsigned int ncalo,
+                                unsigned int nem,
+                                unsigned int nmu,
+                                bool streaming,
+                                unsigned int outii = 0);
 
-            MultififoRegionizerEmulator(unsigned int nendcaps, unsigned int nclocks, unsigned int ntk, unsigned int ncalo, unsigned int nem, unsigned int nmu, bool streaming, unsigned int outii=0) ;
+    // note: this one will work only in CMSSW
+    MultififoRegionizerEmulator(const edm::ParameterSet& iConfig);
 
-            // note: this one will work only in CMSSW
-            MultififoRegionizerEmulator(const edm::ParameterSet& iConfig) ;
+    ~MultififoRegionizerEmulator() override;
 
-            ~MultififoRegionizerEmulator() override ;
+    static const int NTK_SECTORS = 9, NTK_LINKS = 2;  // max objects per sector per clock cycle
+    static const int NCALO_SECTORS = 3, NCALO_LINKS = 4;
+    static const int NMU_LINKS = 2;
 
-            static const int NTK_SECTORS = 9, NTK_LINKS = 2; // max objects per sector per clock cycle
-            static const int NCALO_SECTORS = 3, NCALO_LINKS = 4;
-            static const int NMU_LINKS = 2;
+    void initSectorsAndRegions(const RegionizerDecodedInputs& in, const std::vector<PFInputRegion>& out) override;
 
-            void initSectorsAndRegions(const RegionizerDecodedInputs & in, const std::vector<PFInputRegion> & out) override ;
+    // TODO: implement
+    void run(const RegionizerDecodedInputs& in, std::vector<PFInputRegion>& out) override;
 
-            // TODO: implement
-            void run(const RegionizerDecodedInputs & in, std::vector<PFInputRegion> & out) override ;
+    // clock-cycle emulation
+    bool step(bool newEvent,
+              const std::vector<l1ct::TkObjEmu>& links,
+              std::vector<l1ct::TkObjEmu>& out,
+              bool mux = true);
+    bool step(bool newEvent,
+              const std::vector<l1ct::EmCaloObjEmu>& links,
+              std::vector<l1ct::EmCaloObjEmu>& out,
+              bool mux = true);
+    bool step(bool newEvent,
+              const std::vector<l1ct::HadCaloObjEmu>& links,
+              std::vector<l1ct::HadCaloObjEmu>& out,
+              bool mux = true);
+    bool step(bool newEvent,
+              const std::vector<l1ct::MuObjEmu>& links,
+              std::vector<l1ct::MuObjEmu>& out,
+              bool mux = true);
+    void destream(int iclock,
+                  const std::vector<l1ct::TkObjEmu>& tk_out,
+                  const std::vector<l1ct::EmCaloObjEmu>& em_out,
+                  const std::vector<l1ct::HadCaloObjEmu>& calo_out,
+                  const std::vector<l1ct::MuObjEmu>& mu_out,
+                  PFInputRegion& out);
 
-            // clock-cycle emulation
-            bool step(bool newEvent, const std::vector<l1ct::TkObjEmu> & links, std::vector<l1ct::TkObjEmu> & out , bool mux=true) ;
-            bool step(bool newEvent, const std::vector<l1ct::EmCaloObjEmu> & links, std::vector<l1ct::EmCaloObjEmu> & out , bool mux=true) ;
-            bool step(bool newEvent, const std::vector<l1ct::HadCaloObjEmu> & links, std::vector<l1ct::HadCaloObjEmu> & out , bool mux=true) ;
-            bool step(bool newEvent, const std::vector<l1ct::MuObjEmu> & links, std::vector<l1ct::MuObjEmu> & out , bool mux=true) ;
-            void destream(int iclock, const std::vector<l1ct::TkObjEmu> & tk_out, 
-                                      const std::vector<l1ct::EmCaloObjEmu> & em_out, 
-                                      const std::vector<l1ct::HadCaloObjEmu> & calo_out,
-                                      const std::vector<l1ct::MuObjEmu> & mu_out,
-                                      PFInputRegion & out);
+    // link emulation from decoded inputs (for simulation)
+    void fillLinks(unsigned int iclock, const RegionizerDecodedInputs& in, std::vector<l1ct::TkObjEmu>& links);
+    void fillLinks(unsigned int iclock, const RegionizerDecodedInputs& in, std::vector<l1ct::HadCaloObjEmu>& links);
+    void fillLinks(unsigned int iclock, const RegionizerDecodedInputs& in, std::vector<l1ct::EmCaloObjEmu>& links);
+    void fillLinks(unsigned int iclock, const RegionizerDecodedInputs& in, std::vector<l1ct::MuObjEmu>& links);
 
-            // link emulation from decoded inputs (for simulation)
-            void fillLinks(unsigned int iclock, const RegionizerDecodedInputs & in, std::vector<l1ct::TkObjEmu> & links);
-            void fillLinks(unsigned int iclock, const RegionizerDecodedInputs & in, std::vector<l1ct::HadCaloObjEmu> & links);
-            void fillLinks(unsigned int iclock, const RegionizerDecodedInputs & in, std::vector<l1ct::EmCaloObjEmu> & links);
-            void fillLinks(unsigned int iclock, const RegionizerDecodedInputs & in, std::vector<l1ct::MuObjEmu> & links);
+    // convert links to firmware
+    void toFirmware(const std::vector<l1ct::TkObjEmu>& emu, TkObj fw[NTK_SECTORS][NTK_LINKS]);
+    void toFirmware(const std::vector<l1ct::HadCaloObjEmu>& emu, HadCaloObj fw[NCALO_SECTORS][NCALO_LINKS]);
+    void toFirmware(const std::vector<l1ct::EmCaloObjEmu>& emu, EmCaloObj fw[NCALO_SECTORS][NCALO_LINKS]);
+    void toFirmware(const std::vector<l1ct::MuObjEmu>& emu, MuObj fw[NMU_LINKS]);
 
-            // convert links to firmware
-            void toFirmware(const std::vector<l1ct::TkObjEmu> & emu, TkObj fw[NTK_SECTORS][NTK_LINKS]) ;
-            void toFirmware(const std::vector<l1ct::HadCaloObjEmu> & emu, HadCaloObj fw[NCALO_SECTORS][NCALO_LINKS]) ;
-            void toFirmware(const std::vector<l1ct::EmCaloObjEmu> & emu, EmCaloObj fw[NCALO_SECTORS][NCALO_LINKS]) ;
-            void toFirmware(const std::vector<l1ct::MuObjEmu> & emu, MuObj fw[NMU_LINKS]) ;
-            
-        private:
-            unsigned int nendcaps_, nclocks_, ntk_, ncalo_, nem_, nmu_, outii_, nregions_;
-            bool streaming_;
-            bool init_;
+  private:
+    unsigned int nendcaps_, nclocks_, ntk_, ncalo_, nem_, nmu_, outii_, nregions_;
+    bool streaming_;
+    bool init_;
 
-            multififo_regionizer::Regionizer<l1ct::TkObjEmu> tkRegionizer_;
-            multififo_regionizer::Regionizer<l1ct::HadCaloObjEmu> hadCaloRegionizer_;
-            multififo_regionizer::Regionizer<l1ct::EmCaloObjEmu> emCaloRegionizer_;
-            multififo_regionizer::Regionizer<l1ct::MuObjEmu> muRegionizer_;
-            std::vector<l1ct::multififo_regionizer::Route> tkRoutes_, caloRoutes_, muRoutes_;
+    multififo_regionizer::Regionizer<l1ct::TkObjEmu> tkRegionizer_;
+    multififo_regionizer::Regionizer<l1ct::HadCaloObjEmu> hadCaloRegionizer_;
+    multififo_regionizer::Regionizer<l1ct::EmCaloObjEmu> emCaloRegionizer_;
+    multififo_regionizer::Regionizer<l1ct::MuObjEmu> muRegionizer_;
+    std::vector<l1ct::multififo_regionizer::Route> tkRoutes_, caloRoutes_, muRoutes_;
 
-            template<typename T>
-            void fillCaloLinks_(unsigned int iclock, const std::vector<DetectorSector<T>> & in, std::vector<T> & links);
-    };
+    template <typename T>
+    void fillCaloLinks_(unsigned int iclock, const std::vector<DetectorSector<T>>& in, std::vector<T>& links);
+  };
 
-} // namespace
+}  // namespace l1ct
 
 #endif


### PR DESCRIPTION
* add firmware dataformats for layer-2 objects, in line with [correlator-common merge request 12](https://gitlab.cern.ch/cms-cactus/phase2/firmware/correlator-common/-/merge_requests/12)
* add regional Puppi output to CMSSW (not yet tested)
* endcap multififo regionizer added (from [correlator-common merge request 9](https://gitlab.cern.ch/cms-cactus/phase2/firmware/correlator-common/-/merge_requests/9), merged) but not yet set as a default
