### PR TITLE
Address rounding problem in creation of L1T correlator regions

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/src/PFTkEgAlgo.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/PFTkEgAlgo.cc
@@ -59,16 +59,16 @@ void PFTkEGAlgo::runTkEG(Region &r) const {
     std::cout << "[PFTkEGAlgo::runTkEG] START" << std::endl;
     std::cout << "   # emCalo: " << r.emcalo.size() << " # tk: " << r.track.size() << std::endl;
   }
-  if(debug_ > 0) {
-      for (int ic = 0, nc = r.emcalo.size(); ic < nc; ++ic) {
-        const auto &calo = r.emcalo[ic];
-        std::cout << "[OLD] IN calo[" << ic << "] pt: " << calo.floatPt() << " eta: " << r.globalEta(calo.floatEta()) << " phi: " << r.globalPhi(calo.floatPhi()) 
-        << " hwEta: " << calo.hwEta << " hwPhi: " << calo.hwPhi << " src pt: " << calo.src->pt() << " src eta: " << calo.src->eta() << " src phi: " << calo.src->phi()
-        <<  std::endl;
-      }
+  if (debug_ > 0) {
+    for (int ic = 0, nc = r.emcalo.size(); ic < nc; ++ic) {
+      const auto &calo = r.emcalo[ic];
+      std::cout << "[OLD] IN calo[" << ic << "] pt: " << calo.floatPt() << " eta: " << r.globalEta(calo.floatEta())
+                << " phi: " << r.globalPhi(calo.floatPhi()) << " hwEta: " << calo.hwEta << " hwPhi: " << calo.hwPhi
+                << " src pt: " << calo.src->pt() << " src eta: " << calo.src->eta() << " src phi: " << calo.src->phi()
+                << std::endl;
     }
+  }
 
-  
   // NOTE: we run this step for all clusters (before matching) as it is done in the pre-PF EG algorithm
   std::vector<int> emCalo2emCalo(r.emcalo.size(), -1);
   if (doBremRecovery_)

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/datatypes.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/datatypes.h
@@ -186,9 +186,9 @@ namespace l1ct {
     inline phi_t makePhi(float phi) { return round(phi / ETAPHI_LSB); }
     inline eta_t makeEta(float eta) { return round(eta / ETAPHI_LSB); }
     inline glbeta_t makeGlbEta(float eta) { return round(eta / ETAPHI_LSB); }
-    inline glbeta_t makeGlbEtaRoundEven(float eta) { 
+    inline glbeta_t makeGlbEtaRoundEven(float eta) {
       glbeta_t ghweta = round(eta / ETAPHI_LSB);
-      return (ghweta % 2) ? glbeta_t(ghweta+1) : ghweta; 
+      return (ghweta % 2) ? glbeta_t(ghweta + 1) : ghweta;
     }
 
     inline glbphi_t makeGlbPhi(float phi) { return round(phi / ETAPHI_LSB); }

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/datatypes.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/datatypes.h
@@ -186,6 +186,11 @@ namespace l1ct {
     inline phi_t makePhi(float phi) { return round(phi / ETAPHI_LSB); }
     inline eta_t makeEta(float eta) { return round(eta / ETAPHI_LSB); }
     inline glbeta_t makeGlbEta(float eta) { return round(eta / ETAPHI_LSB); }
+    inline glbeta_t makeGlbEtaRoundEven(float eta) { 
+      glbeta_t ghweta = round(eta / ETAPHI_LSB);
+      return (ghweta % 2) ? glbeta_t(ghweta+1) : ghweta; 
+    }
+
     inline glbphi_t makeGlbPhi(float phi) { return round(phi / ETAPHI_LSB); }
     inline iso_t makeIso(float iso) { return iso_t(0.25 * round(iso * 4)); }
 

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/layer1_emulator.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/layer1_emulator.cpp
@@ -92,10 +92,10 @@ l1ct::PFRegionEmu::PFRegionEmu(
     float etamin, float etamax, float phicenter, float phiwidth, float etaextra, float phiextra) {
   glbeta_t hwEtaMin = Scales::makeGlbEtaRoundEven(etamin);
   glbeta_t hwEtaMax = Scales::makeGlbEtaRoundEven(etamax);
-  
+
   hwEtaCenter = glbeta_t(0.5 * (hwEtaMin + hwEtaMax));
   hwPhiCenter = Scales::makeGlbPhi(phicenter);
-  hwEtaHalfWidth = hwEtaCenter-hwEtaMin;
+  hwEtaHalfWidth = hwEtaCenter - hwEtaMin;
   hwPhiHalfWidth = Scales::makeGlbPhi(0.5 * phiwidth);
   hwEtaExtra = Scales::makeGlbEta(etaextra);
   hwPhiExtra = Scales::makeGlbPhi(phiextra);

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/layer1_emulator.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/layer1_emulator.cpp
@@ -90,9 +90,12 @@ bool l1ct::EGIsoEleObjEmu::write(std::fstream& to) const { return writeObj<EGIso
 
 l1ct::PFRegionEmu::PFRegionEmu(
     float etamin, float etamax, float phicenter, float phiwidth, float etaextra, float phiextra) {
-  hwEtaCenter = Scales::makeGlbEta(0.5 * (etamin + etamax));
+  glbeta_t hwEtaMin = Scales::makeGlbEtaRoundEven(etamin);
+  glbeta_t hwEtaMax = Scales::makeGlbEtaRoundEven(etamax);
+  
+  hwEtaCenter = glbeta_t(0.5 * (hwEtaMin + hwEtaMax));
   hwPhiCenter = Scales::makeGlbPhi(phicenter);
-  hwEtaHalfWidth = Scales::makeGlbEta(0.5 * (etamax - etamin));
+  hwEtaHalfWidth = hwEtaCenter-hwEtaMin;
   hwPhiHalfWidth = Scales::makeGlbPhi(0.5 * phiwidth);
   hwEtaExtra = Scales::makeGlbEta(etaextra);
   hwPhiExtra = Scales::makeGlbPhi(phiextra);

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/egamma/pftkegalgo_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/egamma/pftkegalgo_ref.cpp
@@ -142,9 +142,6 @@ void PFTkEGAlgoEmulator::sel_emCalo(unsigned int nmax_sel,
 
   for (int ic = 0, nc = emcalo.size(); ic < nc; ++ic) {
     const auto &calo = emcalo[ic];
-    if (debug_ > 5)
-      std::cout << "[REF] IN calo[" << ic << "] pt: " << calo.hwPt << " eta: " << calo.hwEta << " phi: " << calo.hwPhi
-                << std::endl;
     if ((cfg.filterHwQuality && calo.hwFlags != cfg.caloHwQual) || (calo.floatPt() < cfg.emClusterPtMin))
       continue;
     emcalo_tmp.push_back(calo);
@@ -154,6 +151,16 @@ void PFTkEGAlgoEmulator::sel_emCalo(unsigned int nmax_sel,
 }
 
 void PFTkEGAlgoEmulator::run(const PFInputRegion &in, OutputRegion &out) const {
+
+  if (debug_ > 0) {
+    for (int ic = 0, nc = in.emcalo.size(); ic < nc; ++ic) {
+      const auto &calo = in.emcalo[ic];
+
+      std::cout << "[REF] IN calo[" << ic << "] pt: " << calo.hwPt << " eta: " << in.region.floatGlbEta(calo.hwEta) << " phi: " << in.region.floatGlbPhi(calo.hwPhi)
+      << std::endl;
+    }
+  }
+  
   // FIXME: this is not striclty speaking necessary but we have to avoid sorting differences
   // in the future we will do all the filtering upstream for the endcap
   std::vector<EmCaloObjEmu> emcalo_sel;
@@ -194,7 +201,7 @@ void PFTkEGAlgoEmulator::eg_algo(const std::vector<EmCaloObjEmu> &emcalo,
     if (cfg.filterHwQuality && calo.hwFlags != cfg.caloHwQual)
       continue;
 
-    if (debug_ > 1)
+    if (debug_ > 3)
       std::cout << "[REF] SEL emcalo with pt: " << calo.hwPt << " qual: " << calo.hwFlags << " eta: " << calo.hwEta
                 << " phi " << calo.hwPhi << std::endl;
 
@@ -249,7 +256,7 @@ EGIsoObjEmu &PFTkEGAlgoEmulator::addEGIsoToPF(std::vector<EGIsoObjEmu> &egobjs,
                                               const EmCaloObjEmu &calo,
                                               const int hwQual,
                                               const pt_t ptCorr) const {
-  if (debug_ > 1)
+  if (debug_ > 2)
     std::cout << "[REF] Add EGIsoObjEmu with pt: " << ptCorr << " qual: " << hwQual << " eta: " << calo.hwEta << " phi "
               << calo.hwPhi << std::endl;
 
@@ -269,7 +276,7 @@ EGIsoEleObjEmu &PFTkEGAlgoEmulator::addEGIsoEleToPF(std::vector<EGIsoEleObjEmu> 
                                                     const TkObjEmu &track,
                                                     const int hwQual,
                                                     const pt_t ptCorr) const {
-  if (debug_ > 1)
+  if (debug_ > 2)
     std::cout << "[REF] Add EGIsoEleObjEmu with pt: " << ptCorr << " qual: " << hwQual << " eta: " << calo.hwEta
               << " phi " << calo.hwPhi << std::endl;
 

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/egamma/pftkegalgo_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/egamma/pftkegalgo_ref.cpp
@@ -35,7 +35,8 @@ l1ct::PFTkEGAlgoEmuConfig::PFTkEGAlgoEmuConfig(const edm::ParameterSet &pset)
       doTkIso(pset.getParameter<bool>("doTkIso")),
       doPfIso(pset.getParameter<bool>("doPfIso")),
       hwIsoTypeTkEle(static_cast<EGIsoEleObjEmu::IsoType>(pset.getParameter<uint32_t>("hwIsoTypeTkEle"))),
-      hwIsoTypeTkEm(static_cast<EGIsoObjEmu::IsoType>(pset.getParameter<uint32_t>("hwIsoTypeTkEm"))) {}
+      hwIsoTypeTkEm(static_cast<EGIsoObjEmu::IsoType>(pset.getParameter<uint32_t>("hwIsoTypeTkEm"))),
+      debug(pset.getUntrackedParameter<uint32_t>("debug", 0)) {}
 
 l1ct::PFTkEGAlgoEmuConfig::IsoParameters::IsoParameters(const edm::ParameterSet &pset)
     : tkQualityPtMin(pset.getParameter<double>("tkQualityPtMin")),

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/egamma/pftkegalgo_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/egamma/pftkegalgo_ref.cpp
@@ -152,16 +152,15 @@ void PFTkEGAlgoEmulator::sel_emCalo(unsigned int nmax_sel,
 }
 
 void PFTkEGAlgoEmulator::run(const PFInputRegion &in, OutputRegion &out) const {
-
   if (debug_ > 0) {
     for (int ic = 0, nc = in.emcalo.size(); ic < nc; ++ic) {
       const auto &calo = in.emcalo[ic];
 
-      std::cout << "[REF] IN calo[" << ic << "] pt: " << calo.hwPt << " eta: " << in.region.floatGlbEta(calo.hwEta) << " phi: " << in.region.floatGlbPhi(calo.hwPhi)
-      << std::endl;
+      std::cout << "[REF] IN calo[" << ic << "] pt: " << calo.hwPt << " eta: " << in.region.floatGlbEta(calo.hwEta)
+                << " phi: " << in.region.floatGlbPhi(calo.hwPhi) << std::endl;
     }
   }
-  
+
   // FIXME: this is not striclty speaking necessary but we have to avoid sorting differences
   // in the future we will do all the filtering upstream for the endcap
   std::vector<EmCaloObjEmu> emcalo_sel;

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/egamma/pftkegalgo_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/egamma/pftkegalgo_ref.h
@@ -111,8 +111,7 @@ namespace l1ct {
 
   class PFTkEGAlgoEmulator {
   public:
-    PFTkEGAlgoEmulator(const PFTkEGAlgoEmuConfig &config) : cfg(config),
-                                                            debug_(cfg.debug) {}
+    PFTkEGAlgoEmulator(const PFTkEGAlgoEmuConfig &config) : cfg(config), debug_(cfg.debug) {}
 
     virtual ~PFTkEGAlgoEmulator() {}
 

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/egamma/pftkegalgo_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/egamma/pftkegalgo_ref.h
@@ -55,6 +55,7 @@ namespace l1ct {
     bool doPfIso;
     EGIsoEleObjEmu::IsoType hwIsoTypeTkEle;
     EGIsoObjEmu::IsoType hwIsoTypeTkEm;
+    int debug = 0;
 
     PFTkEGAlgoEmuConfig(const edm::ParameterSet &iConfig);
     PFTkEGAlgoEmuConfig(unsigned int nTrack,
@@ -110,7 +111,8 @@ namespace l1ct {
 
   class PFTkEGAlgoEmulator {
   public:
-    PFTkEGAlgoEmulator(const PFTkEGAlgoEmuConfig &config) : cfg(config) {}
+    PFTkEGAlgoEmulator(const PFTkEGAlgoEmuConfig &config) : cfg(config),
+                                                            debug_(cfg.debug) {}
 
     virtual ~PFTkEGAlgoEmulator() {}
 
@@ -303,7 +305,7 @@ namespace l1ct {
                            const float z0) const;
 
     PFTkEGAlgoEmuConfig cfg;
-    int debug_ = 0;
+    int debug_;
   };
 }  // namespace l1ct
 


### PR DESCRIPTION
#### PR description:

The PR addresses rounding problems in the creation of the regions/sectors which made them not contiguous and causing lost of input clusters.
Additionally, the debugging options of the EG emulator have been consolidated.

*PS*: an integration test could be added either here or in the FW CI to make sure that the region definition is always contiguous.

#### PR validation:

The new code recovers all the input particles as in previous implementations of the emulator.

