### PR TITLE
L1Puppi: regional output, and more encoded datamembers

### DIFF
--- a/DataFormats/L1TParticleFlow/interface/PFCandidate.h
+++ b/DataFormats/L1TParticleFlow/interface/PFCandidate.h
@@ -6,6 +6,7 @@
 #include "DataFormats/L1Trigger/interface/Muon.h"
 #include "DataFormats/L1TParticleFlow/interface/PFCluster.h"
 #include "DataFormats/L1TParticleFlow/interface/PFTrack.h"
+#include "DataFormats/L1TParticleFlow/interface/RegionalOutput.h"
 
 namespace l1t {
 
@@ -45,11 +46,33 @@ namespace l1t {
     /// PUPPI weight (-1 if not available)
     float puppiWeight() const { return puppiWeight_; }
 
+    void setZ0(float z0) { setVertex(reco::Particle::Point(0, 0, z0)); }
+    void setDxy(float dxy) { dxy_ = dxy; }
+
+    float z0() const { return vz(); }
+    float dxy() const { return dxy_; }
+
+    int16_t hwZ0() const { return hwZ0_; }
+    int16_t hwDxy() const { return hwDxy_; }
+    uint16_t hwTkQuality() const { return hwTkQuality_; }
+    uint16_t hwPuppiWeight() const { return hwPuppiWeight_; }
+    uint64_t encodedPuppi64() const { return encodedPuppi64_; }
+
+    void setHwZ0(int16_t hwZ0) { hwZ0_ = hwZ0; }
+    void setHwDxy(int16_t hwDxy) { hwDxy_ = hwDxy; }
+    void setHwTkQuality(uint16_t hwTkQuality) { hwTkQuality_ = hwTkQuality; }
+    void setHwPuppiWeight(uint16_t hwPuppiWeight) { hwPuppiWeight_ = hwPuppiWeight; }
+    void setEncodedPuppi64(uint64_t encodedPuppi64) { encodedPuppi64_ = encodedPuppi64; }
+
   private:
     PFClusterRef clusterRef_;
     PFTrackRef trackRef_;
     MuonRef muonRef_;
-    float puppiWeight_;
+    float dxy_, puppiWeight_;
+
+    int16_t hwZ0_, hwDxy_;
+    uint16_t hwTkQuality_, hwPuppiWeight_;
+    uint64_t encodedPuppi64_;
 
     void setPdgIdFromParticleType(int charge, ParticleType kind);
   };
@@ -57,5 +80,6 @@ namespace l1t {
   typedef std::vector<l1t::PFCandidate> PFCandidateCollection;
   typedef edm::Ref<l1t::PFCandidateCollection> PFCandidateRef;
   typedef edm::RefVector<l1t::PFCandidateCollection> PFCandidateRefVector;
+  typedef l1t::RegionalOutput<l1t::PFCandidateCollection> PFCandidateRegionalOutput;
 }  // namespace l1t
 #endif

--- a/DataFormats/L1TParticleFlow/interface/RegionalOutput.h
+++ b/DataFormats/L1TParticleFlow/interface/RegionalOutput.h
@@ -63,7 +63,7 @@ namespace l1t {
       unsigned int key() const { return idx_; }
 
     private:
-      RegionalOutput<T>* src_;
+      const RegionalOutput<T>* src_;
       unsigned int idx_;
     };
     typedef iterator const_iterator;
@@ -77,8 +77,8 @@ namespace l1t {
       const value_type& operator[](unsigned int idx) const { return src_->objAt(ibegin_ + idx); }
       const value_type& front() const { return src_->objAt(ibegin_); }
       const value_type& back() const { return src_->objAt(iend_ - 1); }
-      iterator begin() const { return iterator(src_, ibegin_); }
-      iterator end() const { return iterator(src_, iend_); }
+      iterator begin() const { return iterator(*src_, ibegin_); }
+      iterator end() const { return iterator(*src_, iend_); }
       unsigned int size() const { return iend_ - ibegin_; }
       bool empty() const { return (iend_ == ibegin_); }
       // interface to get EDM refs & related stuff
@@ -86,10 +86,10 @@ namespace l1t {
       edm::ProductID id() const { return src_->id(); }
 
     private:
-      RegionalOutput<T>* src_;
+      const RegionalOutput<T>* src_;
       unsigned int ibegin_, iend_;
       friend class RegionalOutput<T>;
-      Region(RegionalOutput<T>* src, unsigned int ibegin, unsigned int iend)
+      Region(const RegionalOutput<T>* src, unsigned int ibegin, unsigned int iend)
           : src_(src), ibegin_(ibegin), iend_(iend) {}
     };
 
@@ -117,10 +117,10 @@ namespace l1t {
     const_iterator begin() const { return const_iterator(this, 0); }
     const_iterator end() const { return const_iterator(this, values_.size()); }
 
-    Region region(unsigned int ireg) { return Region(this, ireg == 0 ? 0 : regions_[ireg - 1], regions_[ireg]); }
+    Region region(unsigned int ireg) const { return Region(this, ireg == 0 ? 0 : regions_[ireg - 1], regions_[ireg]); }
 
-    ref refAt(unsigned int idx) { return ref(refprod_, values_[idx]); }
-    const value_type& objAt(unsigned int idx) { return (*refprod_)[values_[idx]]; }
+    ref refAt(unsigned int idx) const { return ref(refprod_, values_[idx]); }
+    const value_type& objAt(unsigned int idx) const { return (*refprod_)[values_[idx]]; }
 
     //Used by ROOT storage
     CMS_CLASS_VERSION(10)

--- a/DataFormats/L1TParticleFlow/interface/RegionalOutput.h
+++ b/DataFormats/L1TParticleFlow/interface/RegionalOutput.h
@@ -1,0 +1,134 @@
+#ifndef DataFormats_L1TParticleFlow_RegionalOutput_h
+#define DataFormats_L1TParticleFlow_RegionalOutput_h
+
+#include "DataFormats/Common/interface/CMS_CLASS_VERSION.h"
+#include "DataFormats/Common/interface/RefProd.h"
+#include "DataFormats/Common/interface/Ref.h"
+#include <vector>
+
+namespace l1t {
+  template <typename T>
+  class RegionalOutput {
+  public:
+    typedef typename T::value_type value_type;
+    typedef edm::Ref<T> ref;
+    typedef edm::RefProd<T> refprod;
+
+    class iterator {
+    public:
+      typedef typename T::value_type value_type;
+      typedef ptrdiff_t difference_type;
+      iterator(const RegionalOutput<T>& src, unsigned int idx) : src_(&src), idx_(idx) {}
+      iterator(iterator const& it) : src_(it.src_), idx_(it.idx_) {}
+      iterator() : src_(nullptr), idx_(0) {}
+      iterator& operator++() {
+        ++idx_;
+        return *this;
+      }
+      iterator operator++(int) {
+        iterator ci = *this;
+        ++idx_;
+        return ci;
+      }
+      iterator& operator--() {
+        --idx_;
+        return *this;
+      }
+      iterator operator--(int) {
+        iterator ci = *this;
+        --idx_;
+        return ci;
+      }
+      difference_type operator-(iterator const& o) const { return idx_ - o.idx_; }
+      iterator operator+(difference_type n) const { return iterator(src_, idx_ + n); }
+      iterator operator-(difference_type n) const { return iterator(src_, idx_ - n); }
+      bool operator<(iterator const& o) const { return idx_ < o.idx_; }
+      bool operator==(iterator const& ci) const { return idx_ == ci.idx_; }
+      bool operator!=(iterator const& ci) const { return idx_ != ci.idx_; }
+      value_type const& operator*() const { return src_->objAt(idx_); }
+      value_type const* operator->() const { return &src_->objAt(idx_); }
+      iterator& operator+=(difference_type d) {
+        idx_ += d;
+        return *this;
+      }
+      iterator& operator-=(difference_type d) {
+        idx_ -= d;
+        return *this;
+      }
+      value_type const& operator[](difference_type d) const { return src_->objAt(idx_ + d); }
+      // interface to get EDM refs & related stuff
+      edm::Ref<T> ref() const { return src_->refAt(idx_); }
+      edm::ProductID id() const { return src_->id(); }
+      unsigned int idx() const { return idx_; }
+      unsigned int key() const { return idx_; }
+
+    private:
+      RegionalOutput<T>* src_;
+      unsigned int idx_;
+    };
+    typedef iterator const_iterator;
+
+    class Region {
+    public:
+      typedef typename T::value_type value_type;
+      typedef typename RegionalOutput<T>::iterator iterator;
+      typedef typename RegionalOutput<T>::const_iterator const_iterator;
+
+      const value_type& operator[](unsigned int idx) const { return src_->objAt(ibegin_ + idx); }
+      const value_type& front() const { return src_->objAt(ibegin_); }
+      const value_type& back() const { return src_->objAt(iend_ - 1); }
+      iterator begin() const { return iterator(src_, ibegin_); }
+      iterator end() const { return iterator(src_, iend_); }
+      unsigned int size() const { return iend_ - ibegin_; }
+      bool empty() const { return (iend_ == ibegin_); }
+      // interface to get EDM refs & related stuff
+      ref refAt(unsigned int idx) const { return src_->refAt(ibegin_ + idx); }
+      edm::ProductID id() const { return src_->id(); }
+
+    private:
+      RegionalOutput<T>* src_;
+      unsigned int ibegin_, iend_;
+      friend class RegionalOutput<T>;
+      Region(RegionalOutput<T>* src, unsigned int ibegin, unsigned int iend)
+          : src_(src), ibegin_(ibegin), iend_(iend) {}
+    };
+
+    RegionalOutput() : refprod_(), values_(), regions_() {}
+    RegionalOutput(const edm::RefProd<T>& prod) : refprod_(prod), values_(), regions_() {}
+
+    void addRegion(const std::vector<int>& indices) {
+      regions_.emplace_back((regions_.empty() ? 0 : regions_.back()) + indices.size());
+      values_.insert(values_.end(), indices.begin(), indices.end());
+    }
+
+    edm::ProductID id() const { return refprod_.id(); }
+    unsigned int size() const { return values_.size(); }
+    unsigned int nRegions() const { return regions_.size(); }
+    bool empty() const { return values_.empty(); }
+    void clear() {
+      values_.clear();
+      regions_.clear();
+    }
+    void shrink_to_fit() {
+      values_.shrink_to_fit();
+      regions_.shrink_to_fit();
+    }
+
+    const_iterator begin() const { return const_iterator(this, 0); }
+    const_iterator end() const { return const_iterator(this, values_.size()); }
+
+    Region region(unsigned int ireg) { return Region(this, ireg == 0 ? 0 : regions_[ireg - 1], regions_[ireg]); }
+
+    ref refAt(unsigned int idx) { return ref(refprod_, values_[idx]); }
+    const value_type& objAt(unsigned int idx) { return (*refprod_)[values_[idx]]; }
+
+    //Used by ROOT storage
+    CMS_CLASS_VERSION(10)
+
+  protected:
+    refprod refprod_;
+    std::vector<unsigned int> values_;   // list of indices to objects in each region, flattened.
+    std::vector<unsigned int> regions_;  // for each region, store the index of one-past the last object in values
+  };
+}  // namespace l1t
+#endif

--- a/DataFormats/L1TParticleFlow/src/PFCandidate.cc
+++ b/DataFormats/L1TParticleFlow/src/PFCandidate.cc
@@ -2,7 +2,14 @@
 
 l1t::PFCandidate::PFCandidate(
     ParticleType kind, int charge, const PolarLorentzVector& p, float puppiWeight, int hwpt, int hweta, int hwphi)
-    : L1Candidate(p, hwpt, hweta, hwphi, /*hwQuality=*/int(kind)), puppiWeight_(puppiWeight) {
+    : L1Candidate(p, hwpt, hweta, hwphi, /*hwQuality=*/int(kind)),
+      dxy_(0),
+      puppiWeight_(puppiWeight),
+      hwZ0_(0),
+      hwDxy_(0),
+      hwTkQuality_(0),
+      hwPuppiWeight_(0),
+      encodedPuppi64_(0) {
   setCharge(charge);
   setPdgIdFromParticleType(charge, kind);
 }

--- a/DataFormats/L1TParticleFlow/src/classes_def.xml
+++ b/DataFormats/L1TParticleFlow/src/classes_def.xml
@@ -18,13 +18,17 @@
   <class name="edm::RefVector<l1t::PFTrackCollection>" /> 
   <class name="std::vector<edm::Ref<l1t::PFTrackCollection> >" />
 
-  <class name="l1t::PFCandidate"  ClassVersion="3">
+  <class name="l1t::PFCandidate"  ClassVersion="4">
+        <version ClassVersion="4" checksum="3798885201"/>
         <version ClassVersion="3" checksum="4253860178"/>
   </class>
   <class name="l1t::PFCandidateCollection" />
   <class name="edm::Wrapper<l1t::PFCandidateCollection>" />
   <class name="edm::Ref<l1t::PFCandidateCollection>" />
   <class name="edm::RefVector<l1t::PFCandidateCollection>" />
+  <class name="edm::RefProd<l1t::PFCandidateCollection>" />
+  <class name="l1t::RegionalOutput<l1t::PFCandidateCollection>" />
+  <class name="edm::Wrapper<l1t::RegionalOutput<l1t::PFCandidateCollection>>" />
 
   <class name="l1t::PFJet"  ClassVersion="3">
         <version ClassVersion="3" checksum="133342988"/>

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc
@@ -151,7 +151,7 @@ L1TCorrelatorLayer1Producer::L1TCorrelatorLayer1Producer(const edm::ParameterSet
       debugR_(iConfig.getUntrackedParameter<double>("debugR", -1)) {
   produces<l1t::PFCandidateCollection>("PF");
   produces<l1t::PFCandidateCollection>("Puppi");
-  produces<l1t::PFCandidateRegionalOutput>("Puppi");
+  produces<l1t::PFCandidateRegionalOutput>("PuppiRegional");
 
   produces<l1t::PFCandidateCollection>("EmCalo");
   produces<l1t::PFCandidateCollection>("Calo");
@@ -753,7 +753,7 @@ void L1TCorrelatorLayer1Producer::putPuppi(edm::Event &iEvent) const {
     reg->addRegion(nobj);
   }
   iEvent.put(std::move(coll), "Puppi");
-  iEvent.put(std::move(reg), "Puppi");
+  iEvent.put(std::move(reg), "PuppiRegional");
 }
 
 void L1TCorrelatorLayer1Producer::putEgObjects(edm::Event &iEvent,

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TPFCandMultiMerger.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TPFCandMultiMerger.cc
@@ -16,34 +16,78 @@ public:
 private:
   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
-  std::vector<std::string> instances_;
-  std::vector<edm::EDGetTokenT<std::vector<l1t::PFCandidate>>> tokens_;
+  std::vector<std::string> instances_, regionalInstances_;
+  std::vector<bool> alsoRegional_;  // aligned with instances_
+  std::vector<edm::EDGetTokenT<l1t::PFCandidateCollection>> tokens_;
+  std::vector<edm::EDGetTokenT<l1t::PFCandidateRegionalOutput>> regionalTokens_;
 };
 
 L1TPFCandMultiMerger::L1TPFCandMultiMerger(const edm::ParameterSet& iConfig)
-    : instances_(iConfig.getParameter<std::vector<std::string>>("labelsToMerge")) {
+    : instances_(iConfig.getParameter<std::vector<std::string>>("labelsToMerge")),
+      regionalInstances_(iConfig.getParameter<std::vector<std::string>>("regionalLabelsToMerge")) {
   const std::vector<edm::InputTag>& pfProducers = iConfig.getParameter<std::vector<edm::InputTag>>("pfProducers");
   tokens_.reserve(instances_.size() * pfProducers.size());
-  for (unsigned int ii = 0, ni = instances_.size(); ii < ni; ++ii) {
+  for (const std::string& instance : instances_) {
     for (const edm::InputTag& tag : pfProducers) {
-      tokens_.push_back(
-          consumes<std::vector<l1t::PFCandidate>>(edm::InputTag(tag.label(), instances_[ii], tag.process())));
+      tokens_.push_back(consumes<l1t::PFCandidateCollection>(edm::InputTag(tag.label(), instance, tag.process())));
     }
-    produces<std::vector<l1t::PFCandidate>>(instances_[ii]);
+    produces<l1t::PFCandidateCollection>(instance);
+    // check if regional output is needed too
+    if (std::find(regionalInstances_.begin(), regionalInstances_.end(), instance) != regionalInstances_.end()) {
+      alsoRegional_.push_back(true);
+      for (const edm::InputTag& tag : pfProducers) {
+        regionalTokens_.push_back(
+            consumes<l1t::PFCandidateRegionalOutput>(edm::InputTag(tag.label(), instance + "Regional", tag.process())));
+      }
+      produces<l1t::PFCandidateRegionalOutput>(instance + "Regional");
+    } else {
+      alsoRegional_.push_back(false);
+    }
+  }
+  // check that regional output is not requested without the standard one
+  for (const std::string& instance : regionalInstances_) {
+    auto match = std::find(instances_.begin(), instances_.end(), instance);
+    if (match == instances_.end()) {
+      throw cms::Exception("Configuration", "The regional label '" + instance + "' is not in labelsToMerge\n");
+    }
   }
 }
 
 L1TPFCandMultiMerger::~L1TPFCandMultiMerger() {}
 
 void L1TPFCandMultiMerger::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup&) const {
-  edm::Handle<std::vector<l1t::PFCandidate>> handle;
-  for (unsigned int ii = 0, it = 0, ni = instances_.size(), np = tokens_.size() / ni; ii < ni; ++ii) {
-    auto out = std::make_unique<std::vector<l1t::PFCandidate>>();
-    for (unsigned int ip = 0; ip < np; ++ip, ++it) {
+  edm::Handle<l1t::PFCandidateCollection> handle;
+  edm::Handle<l1t::PFCandidateRegionalOutput> regionalHandle;
+  unsigned int ninstances = instances_.size(), nproducers = tokens_.size() / ninstances;
+  std::vector<int> keys;
+  for (unsigned int ii = 0, it = 0, irt = 0; ii < ninstances; ++ii) {
+    auto out = std::make_unique<l1t::PFCandidateCollection>();
+    std::unique_ptr<l1t::PFCandidateRegionalOutput> regout;
+    if (alsoRegional_[ii]) {
+      auto refprod = iEvent.getRefBeforePut<l1t::PFCandidateCollection>(instances_[ii]);
+      regout = std::make_unique<l1t::PFCandidateRegionalOutput>(edm::RefProd<l1t::PFCandidateCollection>(refprod));
+    }
+    for (unsigned int ip = 0; ip < nproducers; ++ip, ++it) {
       iEvent.getByToken(tokens_[it], handle);
+      unsigned int offset = out->size();
       out->insert(out->end(), handle->begin(), handle->end());
+      if (alsoRegional_[ii]) {
+        iEvent.getByToken(regionalTokens_[irt++], regionalHandle);
+        const auto& src = *regionalHandle;
+        for (unsigned int ireg = 0, nreg = src.nRegions(); ireg < nreg; ++ireg) {
+          auto region = src.region(ireg);
+          keys.clear();
+          for (auto iter = region.begin(), iend = region.end(); iter != iend; ++iter) {
+            keys.push_back(iter.idx() + offset);
+          }
+          regout->addRegion(keys);
+        }
+      }
     }
     iEvent.put(std::move(out), instances_[ii]);
+    if (alsoRegional_[ii]) {
+      iEvent.put(std::move(regout), instances_[ii] + "Regional");
+    }
   }
 }
 

--- a/L1Trigger/Phase2L1ParticleFlow/python/l1ParticleFlow_cff.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1ParticleFlow_cff.py
@@ -311,6 +311,7 @@ l1pfCandidates = cms.EDProducer("L1TPFCandMultiMerger",
         cms.InputTag("l1pfProducerHF")
     ),
     labelsToMerge = cms.vstring("Calo", "TK", "TKVtx", "PF", "Puppi"),
+    regionalLabelsToMerge = cms.vstring(),
 )
 
 l1tCorrelatorEG = cms.EDProducer(

--- a/L1Trigger/Phase2L1ParticleFlow/python/l1ctLayer1_cff.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1ctLayer1_cff.py
@@ -315,6 +315,7 @@ l1ctLayer1 = cms.EDProducer("L1TPFCandMultiMerger",
         cms.InputTag("l1ctLayer1HF")
     ),
     labelsToMerge = cms.vstring("PF", "Puppi"),
+    regionalLabelsToMerge = cms.vstring("Puppi"),
 )
 
 l1ctLayer1EG = cms.EDProducer(

--- a/L1Trigger/Phase2L1ParticleFlow/src/RegionMapper.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/RegionMapper.cc
@@ -212,8 +212,10 @@ std::unique_ptr<l1t::PFCandidateCollection> RegionMapper::fetch(bool puppi, floa
       if (p.floatPt() > ptMin) {
         reco::Particle::PolarLorentzVector p4(
             p.floatPt(), r.globalEta(p.floatVtxEta()), r.globalPhi(p.floatVtxPhi()), 0.13f);
-        ret->emplace_back(l1t::PFCandidate::ParticleType(p.hwId), p.intCharge(), p4, p.floatPuppiW());
-        ret->back().setVertex(reco::Particle::Point(0, 0, p.floatDZ()));
+        ret->emplace_back(
+            l1t::PFCandidate::ParticleType(p.hwId), p.intCharge(), p4, p.floatPuppiW(), p.hwPt, p.hwEta, p.hwPhi);
+        ret->back().setZ0(p.floatDZ());
+        ret->back().setHwZ0(p.track.hwZ0);
         ret->back().setStatus(p.hwStatus);
         if (p.cluster.src) {
           auto match = clusterRefMap_.find(p.cluster.src);
@@ -255,7 +257,7 @@ std::unique_ptr<l1t::PFCandidateCollection> RegionMapper::fetchCalo(float ptMin,
         reco::Particle::PolarLorentzVector p4(p.floatPt(), r.globalEta(p.floatEta()), r.globalPhi(p.floatPhi()), 0.13f);
         l1t::PFCandidate::ParticleType kind =
             (p.isEM || emcalo) ? l1t::PFCandidate::Photon : l1t::PFCandidate::NeutralHadron;
-        ret->emplace_back(kind, 0, p4);
+        ret->emplace_back(kind, /*charge=*/0, p4, /*puppiW=*/1, p.hwPt, p.hwEta, p.hwPhi);
         if (p.src) {
           auto match = clusterRefMap_.find(p.src);
           if (match == clusterRefMap_.end()) {
@@ -294,8 +296,9 @@ std::unique_ptr<l1t::PFCandidateCollection> RegionMapper::fetchTracks(float ptMi
         reco::Particle::PolarLorentzVector p4(
             p.floatVtxPt(), r.globalEta(p.floatVtxEta()), r.globalPhi(p.floatVtxPhi()), 0.13f);
         l1t::PFCandidate::ParticleType kind = p.muonLink ? l1t::PFCandidate::Muon : l1t::PFCandidate::ChargedHadron;
-        ret->emplace_back(kind, p.intCharge(), p4);
-        ret->back().setVertex(reco::Particle::Point(0, 0, p.floatDZ()));
+        ret->emplace_back(kind, p.intCharge(), p4, /*puppiW=*/float(p.fromPV), p.hwPt, p.hwEta, p.hwPhi);
+        ret->back().setZ0(p.floatDZ());
+        ret->back().setHwZ0(p.hwZ0);
         if (p.src) {
           auto match = trackRefMap_.find(p.src);
           if (match == trackRefMap_.end()) {


### PR DESCRIPTION
 * Discrete datamembers are added to PFCandidate to hold the additional discretized variables of Puppi candidates (z0, dxy, puppi weight) and to allow retrieving the puppi candidate encoded as 64-bit object (as in the hardware).
 * Puppi output is now also available in regional form, as from the output of layer 1: a list of regions, with a list of Puppi candidates in each region. The new collection is implemented using the `RegionalOutput` template class that internally just hold indices into the flattened Puppi collection and the associated EDM machinery to allow retrieving the objects. 
 
Example access to the regional output:
````
edm::Handle<l1t::PFCandidateRegionalOutput> src;

iEvent.getByToken(token_, src); //   token_ for an InputTag of "l1ctLayer1:PuppiRegional"

for (unsigned int ireg = 0, nReg = src->nRegions(); ireg < nreg; ++ireg) {
    auto region = src->region(ireg); // get the region (by value, since it's a lightweight object)
    for (int i = 0, n = region.size(); i < n; ++i) {
        const l1t::PFCandidate & cand = region[i]; // if you want the object, i.e. a C++ reference
        l1t::PFCandidateRef candref = region.refAt(i); // if you want and EDM reference
    }
}
````
Looping with the c++11 for loop should also work (not tested), and similarly with `begin()` and `end()` iterators. 
The iterators dereference to a `const l1t::PFCandidate &`, but you can get a  `l1t::PFCandidateRef` out using the `ref()` method of the iterator itself.

This can be used as input e.g. to the deregionizer emulator (@VourMa, @thesps) or the Phase-1-like jets (@EmyrClement)

@violatingcp @drankincms 
