### PR TITLE
Add a 'FakePuppi' option where the output puppi candidate has no selection applied but contains debug info

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/puppi/linpuppi_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/puppi/linpuppi_ref.cpp
@@ -62,7 +62,8 @@ l1ct::LinPuppiEmulator::LinPuppiEmulator(unsigned int nTrack,
       priorNe_(2),
       priorPh_(2),
       ptCut_(2),
-      debug_(false) {
+      debug_(false),
+      fakePuppi_(false) {
   ptSlopeNe_[0] = ptSlopeNe_0;
   ptSlopeNe_[1] = ptSlopeNe_1;
   ptSlopePh_[0] = ptSlopePh_0;
@@ -106,7 +107,10 @@ l1ct::LinPuppiEmulator::LinPuppiEmulator(const edm::ParameterSet &iConfig)
       priorNe_(iConfig.getParameter<std::vector<double>>("priors")),
       priorPh_(iConfig.getParameter<std::vector<double>>("priorsPhoton")),
       ptCut_(edm::vector_transform(iConfig.getParameter<std::vector<double>>("ptCut"), l1ct::Scales::makePtFromFloat)),
-      debug_(iConfig.getUntrackedParameter<bool>("debug", false)) {
+      debug_(iConfig.getUntrackedParameter<bool>("debug", false)),
+      fakePuppi_(iConfig.existsAs<bool>("fakePuppi") ? iConfig.getParameter<bool>("fakePuppi")
+                                                     : false)  // it's only for debug, but still better be tracked
+{
   if (absEtaBins_.size() + 1 != ptSlopeNe_.size())
     throw cms::Exception("Configuration", "size mismatch for ptSlopes parameter");
   if (absEtaBins_.size() + 1 != ptSlopePh_.size())
@@ -160,26 +164,36 @@ void l1ct::LinPuppiEmulator::linpuppi_chs_ref(const PFRegionEmu &region,
   outallch.resize(nTrack);
   for (unsigned int i = 0; i < nTrack; ++i) {
     int z0diff = pfch[i].hwZ0 - pv.hwZ0;
-    if (pfch[i].hwPt != 0 && region.isFiducial(pfch[i]) && (std::abs(z0diff) <= int(dzCut_) || pfch[i].hwId.isMuon())) {
+    bool accept = pfch[i].hwPt != 0;
+    if (!fakePuppi_)
+      accept = accept && region.isFiducial(pfch[i]) && (std::abs(z0diff) <= int(dzCut_) || pfch[i].hwId.isMuon());
+    if (accept) {
       outallch[i].fill(region, pfch[i]);
+      if (fakePuppi_) {  // overwrite Dxy & TkQuality with debug information
+        outallch[i].setHwDxy(dxy_t(pv.hwZ0));
+        outallch[i].setHwTkQuality(region.isFiducial(pfch[i]) ? 1 : 0);
+      }
       if (debug_ && pfch[i].hwPt > 0)
-        printf("ref candidate %02u pt %7.2f pid %1d   vz %+6d  dz %+6d (cut %5d) -> pass\n",
+        printf("ref candidate %02u pt %7.2f pid %1d   vz %+6d  dz %+6d (cut %5d), fid %1d -> pass, packed %s\n",
                i,
                pfch[i].floatPt(),
                pfch[i].intId(),
                int(pfch[i].hwZ0),
                z0diff,
-               dzCut_);
+               dzCut_,
+               region.isFiducial(pfch[i]),
+               outallch[i].pack().to_string(16).c_str());
     } else {
       outallch[i].clear();
       if (debug_ && pfch[i].hwPt > 0)
-        printf("ref candidate %02u pt %7.2f pid %1d   vz %+6d  dz %+6d (cut %5d) -> fail\n",
+        printf("ref candidate %02u pt %7.2f pid %1d   vz %+6d  dz %+6d (cut %5d), fid %1d -> fail\n",
                i,
                pfch[i].floatPt(),
                pfch[i].intId(),
                int(pfch[i].hwZ0),
                z0diff,
-               dzCut_);
+               dzCut_,
+               region.isFiducial(pfch[i]));
     }
   }
 }
@@ -400,8 +414,15 @@ void l1ct::LinPuppiEmulator::linpuppi_ref(const PFRegionEmu &region,
     unsigned int ieta = find_ieta(region, pfallne[in].hwEta);
     bool isEM = (pfallne[in].hwId.isPhoton());
     std::pair<pt_t, puppiWgt_t> ptAndW = sum2puppiPt_ref(sum, pfallne[in].hwPt, ieta, isEM, in);
-    outallne_nocut[in].fill(region, pfallne[in], ptAndW.first, ptAndW.second);
-    if (region.isFiducial(pfallne[in]) && outallne_nocut[in].hwPt >= ptCut_[ieta]) {
+    if (!fakePuppi_) {
+      outallne_nocut[in].fill(region, pfallne[in], ptAndW.first, ptAndW.second);
+      if (region.isFiducial(pfallne[in]) && outallne_nocut[in].hwPt >= ptCut_[ieta]) {
+        outallne[in] = outallne_nocut[in];
+      }
+    } else {  // fakePuppi: keep the full candidate, but set the Puppi weight and some debug info into it
+      outallne_nocut[in].fill(region, pfallne[in], pfallne[in].hwPt, ptAndW.second);
+      outallne_nocut[in].hwData[9] = region.isFiducial(pfallne[in]);
+      outallne_nocut[in].hwData(20, 10) = ptAndW.first(10, 0);
       outallne[in] = outallne_nocut[in];
     }
   }

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/puppi/linpuppi_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/puppi/linpuppi_ref.h
@@ -48,7 +48,8 @@ namespace l1ct {
           priorNe_(1, priorNe),
           priorPh_(1, priorPh),
           ptCut_(1, ptCut),
-          debug_(false) {}
+          debug_(false),
+          fakePuppi_(false) {}
 
     LinPuppiEmulator(unsigned int nTrack,
                      unsigned int nIn,
@@ -115,7 +116,8 @@ namespace l1ct {
           priorNe_(priorNe),
           priorPh_(priorPh),
           ptCut_(ptCut),
-          debug_(false) {}
+          debug_(false),
+          fakePuppi_(false) {}
 
     LinPuppiEmulator(const edm::ParameterSet &iConfig);
 
@@ -171,6 +173,9 @@ namespace l1ct {
 
     void setDebug(bool debug = true) { debug_ = debug; }
 
+    // instead of running Puppi, write Puppi debug information into the output Puppi candidates
+    void setFakePuppi(bool fakePuppi = true) { fakePuppi_ = fakePuppi; }
+
   protected:
     unsigned int nTrack_, nIn_,
         nOut_;  // nIn_, nOut refer to the calorimeter clusters or neutral PF candidates as input and as output (after sorting)
@@ -182,7 +187,7 @@ namespace l1ct {
     std::vector<pt_t> ptCut_;
 
     bool debug_;
-
+    bool fakePuppi_;
     // utility
     unsigned int find_ieta(const PFRegionEmu &region, eta_t eta) const;
     std::pair<pt_t, puppiWgt_t> sum2puppiPt_ref(uint64_t sum, pt_t pt, unsigned int ieta, bool isEM, int icand) const;


### PR DESCRIPTION
Compation PR of https://gitlab.cern.ch/cms-cactus/phase2/firmware/correlator-common/-/merge_requests/16
This emulator feature is useful when debugging the firmware or hardware, e.g. if the vertex and PF objects end up desinchronized.