### PR TITLE
Update EM ID information stored in emulator clusters

### DIFF
--- a/DataFormats/L1TParticleFlow/interface/PFCandidate.h
+++ b/DataFormats/L1TParticleFlow/interface/PFCandidate.h
@@ -56,12 +56,14 @@ namespace l1t {
     int16_t hwDxy() const { return hwDxy_; }
     uint16_t hwTkQuality() const { return hwTkQuality_; }
     uint16_t hwPuppiWeight() const { return hwPuppiWeight_; }
+    uint16_t hwEmID() const { return hwEmID_; }
     uint64_t encodedPuppi64() const { return encodedPuppi64_; }
 
     void setHwZ0(int16_t hwZ0) { hwZ0_ = hwZ0; }
     void setHwDxy(int16_t hwDxy) { hwDxy_ = hwDxy; }
     void setHwTkQuality(uint16_t hwTkQuality) { hwTkQuality_ = hwTkQuality; }
     void setHwPuppiWeight(uint16_t hwPuppiWeight) { hwPuppiWeight_ = hwPuppiWeight; }
+    void setHwEmID(uint16_t hwEmID) { hwEmID_ = hwEmID; }
     void setEncodedPuppi64(uint64_t encodedPuppi64) { encodedPuppi64_ = encodedPuppi64; }
 
   private:
@@ -71,7 +73,7 @@ namespace l1t {
     float dxy_, puppiWeight_;
 
     int16_t hwZ0_, hwDxy_;
-    uint16_t hwTkQuality_, hwPuppiWeight_;
+    uint16_t hwTkQuality_, hwPuppiWeight_, hwEmID_;
     uint64_t encodedPuppi64_;
 
     void setPdgIdFromParticleType(int charge, ParticleType kind);

--- a/DataFormats/L1TParticleFlow/interface/PFCluster.h
+++ b/DataFormats/L1TParticleFlow/interface/PFCluster.h
@@ -58,6 +58,7 @@ namespace l1t {
 
     bool isEM() const { return hwQual(); }
     void setIsEM(bool isEM) { setHwQual(isEM); }
+    unsigned int hwEmID() const { return hwQual(); }
 
     float egVsPionMVAOut() const { return egVsPionMVAOut_; }
     void setEgVsPionMVAOut(float egVsPionMVAOut) { egVsPionMVAOut_ = egVsPionMVAOut; }

--- a/DataFormats/L1TParticleFlow/src/PFCandidate.cc
+++ b/DataFormats/L1TParticleFlow/src/PFCandidate.cc
@@ -9,6 +9,7 @@ l1t::PFCandidate::PFCandidate(
       hwDxy_(0),
       hwTkQuality_(0),
       hwPuppiWeight_(0),
+      hwEmID_(0),
       encodedPuppi64_(0) {
   setCharge(charge);
   setPdgIdFromParticleType(charge, kind);

--- a/DataFormats/L1TParticleFlow/src/classes_def.xml
+++ b/DataFormats/L1TParticleFlow/src/classes_def.xml
@@ -18,7 +18,8 @@
   <class name="edm::RefVector<l1t::PFTrackCollection>" /> 
   <class name="std::vector<edm::Ref<l1t::PFTrackCollection> >" />
 
-  <class name="l1t::PFCandidate"  ClassVersion="4">
+  <class name="l1t::PFCandidate"  ClassVersion="5">
+        <version ClassVersion="5" checksum="3777180193"/>
         <version ClassVersion="4" checksum="3798885201"/>
         <version ClassVersion="3" checksum="4253860178"/>
   </class>

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc
@@ -514,8 +514,8 @@ void L1TCorrelatorLayer1Producer::addDecodedTrack(l1ct::DetectorSector<l1ct::TkO
 void L1TCorrelatorLayer1Producer::addDecodedMuon(l1ct::DetectorSector<l1ct::MuObjEmu> &sec, const l1t::Muon &t) {
   l1ct::MuObjEmu mu;
   mu.hwPt = l1ct::Scales::makePtFromFloat(t.pt());
-  mu.hwEta = l1ct::Scales::makeEta(t.eta());
-  mu.hwPhi = l1ct::Scales::makePhi(t.phi());
+  mu.hwEta = l1ct::Scales::makeGlbEta(t.eta());  // IMPORTANT: input is in global coordinates!
+  mu.hwPhi = l1ct::Scales::makeGlbPhi(t.phi());
   mu.hwCharge = t.charge() > 0;
   mu.hwQuality = t.hwQual();
   mu.hwDEta = 0;
@@ -751,6 +751,7 @@ void L1TCorrelatorLayer1Producer::putPuppi(edm::Event &iEvent) const {
         coll->back().setHwEmID(p.hwEmID());
       }
       coll->back().setEncodedPuppi64(p.pack().to_uint64());
+      setRefs_(coll->back(), p);
       nobj.push_back(coll->size() - 1);
     }
     reg->addRegion(nobj);

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc
@@ -435,8 +435,7 @@ void L1TCorrelatorLayer1Producer::initSectorsAndRegions(const edm::ParameterSet 
     }
   }
 
-  event_.decoded.muon.region = l1ct::PFRegionEmu(
-      -l1ct::Scales::maxAbsGlbEta(), l1ct::Scales::maxAbsGlbEta(), 0.f, 2 * l1ct::Scales::maxAbsGlbPhi(), 0.f, 0.f);
+  event_.decoded.muon.region = l1ct::PFRegionEmu(0., 0.);  // centered at (0,0)
 
   event_.pfinputs.clear();
   for (const edm::ParameterSet &preg : iConfig.getParameter<std::vector<edm::ParameterSet>>("regions")) {

--- a/L1Trigger/Phase2L1ParticleFlow/python/l1ctLayer1_cff.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1ctLayer1_cff.py
@@ -322,7 +322,7 @@ l1ctLayer1 = cms.EDProducer("L1TPFCandMultiMerger",
         cms.InputTag("l1ctLayer1HGCalNoTK"),
         cms.InputTag("l1ctLayer1HF")
     ),
-    labelsToMerge = cms.vstring("PF", "Puppi"),
+    labelsToMerge = cms.vstring("PF", "Puppi", "Calo", "TK"),
     regionalLabelsToMerge = cms.vstring("Puppi"),
 )
 
@@ -366,4 +366,13 @@ l1ctLayer1EG = cms.EDProducer(
             )
         )    
     )
+)
+
+l1ctLayer1Task = cms.Task(
+     l1ctLayer1Barrel,
+     l1ctLayer1HGCal,
+     l1ctLayer1HGCalNoTK,
+     l1ctLayer1HF,
+     l1ctLayer1,
+     l1ctLayer1EG
 )

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/datatypes.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/datatypes.h
@@ -33,6 +33,7 @@ namespace l1ct {
   typedef ap_int<8> dxy_t;         // tbd
   typedef ap_uint<3> tkquality_t;  // tbd
   typedef ap_uint<9> puppiWgt_t;   // 256 = 1.0
+  typedef ap_uint<6> emid_t;
   typedef ap_uint<14> tk2em_dr_t;
   typedef ap_uint<14> tk2calo_dr_t;
   typedef ap_uint<10> em2calo_dr_t;

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/layer1_emulator.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/layer1_emulator.cpp
@@ -91,6 +91,14 @@ bool l1ct::EGIsoEleObjEmu::read(std::fstream& from) {
 
 bool l1ct::EGIsoEleObjEmu::write(std::fstream& to) const { return writeObj<EGIsoEleObj>(*this, to); }
 
+l1ct::PFRegionEmu::PFRegionEmu(float etaCenter, float phicenter) {
+  hwEtaCenter = Scales::makeGlbEta(etaCenter);
+  hwPhiCenter = Scales::makeGlbPhi(phicenter);
+  hwEtaHalfWidth = 0;
+  hwPhiHalfWidth = 0;
+  hwEtaExtra = 0;
+  hwPhiExtra = 0;
+}
 l1ct::PFRegionEmu::PFRegionEmu(
     float etamin, float etamax, float phicenter, float phiwidth, float etaextra, float phiextra) {
   glbeta_t hwEtaMin = Scales::makeGlbEtaRoundEven(etamin);

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/layer1_emulator.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/layer1_emulator.h
@@ -293,7 +293,7 @@ namespace l1ct {
   };
 
   struct Event {
-    static const int VERSION = 6;
+    static const int VERSION = 7;
     uint32_t run, lumi;
     uint64_t event;
     RegionizerDecodedInputs decoded;

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/layer1_emulator.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/layer1_emulator.h
@@ -90,6 +90,7 @@ namespace l1ct {
 
   struct PFRegionEmu : public PFRegion {
     PFRegionEmu() : PFRegion() {}
+    PFRegionEmu(float etaCenter, float phicenter);
     PFRegionEmu(float etamin, float etamax, float phicenter, float phiwidth, float etaextra, float phiextra);
 
     // global coordinates

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/layer1_objs.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/layer1_objs.h
@@ -11,11 +11,11 @@ namespace l1ct {
     eta_t hwEta;  // relative to the region center, at calo
     phi_t hwPhi;  // relative to the region center, at calo
     pt_t hwEmPt;
-    bool hwIsEM;
+    emid_t hwEmID;
 
     inline bool operator==(const HadCaloObj &other) const {
       return hwPt == other.hwPt && hwEta == other.hwEta && hwPhi == other.hwPhi && hwEmPt == other.hwEmPt &&
-             hwIsEM == other.hwIsEM;
+             hwEmID == other.hwEmID;
     }
 
     inline bool operator>(const HadCaloObj &other) const { return hwPt > other.hwPt; }
@@ -26,7 +26,7 @@ namespace l1ct {
       hwEta = 0;
       hwPhi = 0;
       hwEmPt = 0;
-      hwIsEM = false;
+      hwEmID = 0;
     }
 
     int intPt() const { return Scales::intPt(hwPt); }
@@ -38,7 +38,9 @@ namespace l1ct {
     float floatEta() const { return Scales::floatEta(hwEta); }
     float floatPhi() const { return Scales::floatPhi(hwPhi); }
 
-    static const int BITWIDTH = pt_t::width + eta_t::width + phi_t::width + pt_t::width + 1;
+    bool hwIsEM() const { return hwEmID != 0; }
+
+    static const int BITWIDTH = pt_t::width + eta_t::width + phi_t::width + pt_t::width + emid_t::width;
     inline ap_uint<BITWIDTH> pack() const {
       ap_uint<BITWIDTH> ret;
       unsigned int start = 0;
@@ -46,7 +48,7 @@ namespace l1ct {
       _pack_into_bits(ret, start, hwEta);
       _pack_into_bits(ret, start, hwPhi);
       _pack_into_bits(ret, start, hwEmPt);
-      _pack_bool_into_bits(ret, start, hwIsEM);
+      _pack_into_bits(ret, start, hwEmID);
       return ret;
     }
     inline static HadCaloObj unpack(const ap_uint<BITWIDTH> &src) {
@@ -56,7 +58,7 @@ namespace l1ct {
       _unpack_from_bits(src, start, ret.hwEta);
       _unpack_from_bits(src, start, ret.hwPhi);
       _unpack_from_bits(src, start, ret.hwEmPt);
-      _unpack_bool_from_bits(src, start, ret.hwIsEM);
+      _unpack_from_bits(src, start, ret.hwEmID);
       return ret;
     }
   };
@@ -67,11 +69,11 @@ namespace l1ct {
     pt_t hwPt, hwPtErr;
     eta_t hwEta;  // relative to the region center, at calo
     phi_t hwPhi;  // relative to the region center, at calo
-    ap_uint<4> hwFlags;
+    emid_t hwEmID;
 
     inline bool operator==(const EmCaloObj &other) const {
       return hwPt == other.hwPt && hwEta == other.hwEta && hwPhi == other.hwPhi && hwPtErr == other.hwPtErr &&
-             hwFlags == other.hwFlags;
+             hwEmID == other.hwEmID;
     }
 
     inline bool operator>(const EmCaloObj &other) const { return hwPt > other.hwPt; }
@@ -82,7 +84,7 @@ namespace l1ct {
       hwPtErr = 0;
       hwEta = 0;
       hwPhi = 0;
-      hwFlags = 0;
+      hwEmID = 0;
     }
 
     int intPt() const { return Scales::intPt(hwPt); }
@@ -94,7 +96,7 @@ namespace l1ct {
     float floatEta() const { return Scales::floatEta(hwEta); }
     float floatPhi() const { return Scales::floatPhi(hwPhi); }
 
-    static const int BITWIDTH = pt_t::width + eta_t::width + phi_t::width + pt_t::width + 4;
+    static const int BITWIDTH = pt_t::width + eta_t::width + phi_t::width + pt_t::width + emid_t::width;
     inline ap_uint<BITWIDTH> pack() const {
       ap_uint<BITWIDTH> ret;
       unsigned int start = 0;
@@ -102,7 +104,7 @@ namespace l1ct {
       _pack_into_bits(ret, start, hwEta);
       _pack_into_bits(ret, start, hwPhi);
       _pack_into_bits(ret, start, hwPtErr);
-      _pack_into_bits(ret, start, hwFlags);
+      _pack_into_bits(ret, start, hwEmID);
       return ret;
     }
     inline static EmCaloObj unpack(const ap_uint<BITWIDTH> &src) {
@@ -112,7 +114,7 @@ namespace l1ct {
       _unpack_from_bits(src, start, ret.hwEta);
       _unpack_from_bits(src, start, ret.hwPhi);
       _unpack_from_bits(src, start, ret.hwPtErr);
-      _unpack_from_bits(src, start, ret.hwFlags);
+      _unpack_from_bits(src, start, ret.hwEmID);
       return ret;
     }
   };

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/pf.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/pf.h
@@ -109,7 +109,7 @@ namespace l1ct {
 
   struct PFNeutralObj : public PFCommonObj {
     pt_t hwEmPt;
-    ap_uint<6> hwEmID;
+    emid_t hwEmID;
     ap_uint<6> hwPUID;
 
     inline bool operator==(const PFNeutralObj &other) const {

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/egamma/pftkegalgo_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/egamma/pftkegalgo_ref.cpp
@@ -75,7 +75,7 @@ void PFTkEGAlgoEmulator::link_emCalo2emCalo(const std::vector<EmCaloObjEmu> &emc
   // NOTE: we assume the input to be sorted!!!
   for (int ic = 0, nc = emcalo.size(); ic < nc; ++ic) {
     auto &calo = emcalo[ic];
-    if (cfg.filterHwQuality && calo.hwFlags != cfg.caloHwQual)
+    if (cfg.filterHwQuality && calo.hwEmID != cfg.caloHwQual)
       continue;
 
     if (emCalo2emCalo[ic] != -1)
@@ -86,7 +86,7 @@ void PFTkEGAlgoEmulator::link_emCalo2emCalo(const std::vector<EmCaloObjEmu> &emc
         continue;
 
       auto &otherCalo = emcalo[jc];
-      if (cfg.filterHwQuality && otherCalo.hwFlags != cfg.caloHwQual)
+      if (cfg.filterHwQuality && otherCalo.hwEmID != cfg.caloHwQual)
         continue;
 
       if (fabs(otherCalo.floatEta() - calo.floatEta()) < cfg.dEtaMaxBrem &&
@@ -104,7 +104,7 @@ void PFTkEGAlgoEmulator::link_emCalo2tk(const PFRegionEmu &r,
   for (int ic = 0, nc = emcalo.size(); ic < nc; ++ic) {
     auto &calo = emcalo[ic];
 
-    if (cfg.filterHwQuality && calo.hwFlags != cfg.caloHwQual)
+    if (cfg.filterHwQuality && calo.hwEmID != cfg.caloHwQual)
       continue;
 
     float dPtMin = 999;
@@ -143,7 +143,7 @@ void PFTkEGAlgoEmulator::sel_emCalo(unsigned int nmax_sel,
 
   for (int ic = 0, nc = emcalo.size(); ic < nc; ++ic) {
     const auto &calo = emcalo[ic];
-    if ((cfg.filterHwQuality && calo.hwFlags != cfg.caloHwQual) || (calo.floatPt() < cfg.emClusterPtMin))
+    if ((cfg.filterHwQuality && calo.hwEmID != cfg.caloHwQual) || (calo.floatPt() < cfg.emClusterPtMin))
       continue;
     emcalo_tmp.push_back(calo);
   }
@@ -198,11 +198,11 @@ void PFTkEGAlgoEmulator::eg_algo(const std::vector<EmCaloObjEmu> &emcalo,
   for (int ic = 0, nc = emcalo.size(); ic < nc; ++ic) {
     auto &calo = emcalo[ic];
 
-    if (cfg.filterHwQuality && calo.hwFlags != cfg.caloHwQual)
+    if (cfg.filterHwQuality && calo.hwEmID != cfg.caloHwQual)
       continue;
 
     if (debug_ > 3)
-      std::cout << "[REF] SEL emcalo with pt: " << calo.hwPt << " qual: " << calo.hwFlags << " eta: " << calo.hwEta
+      std::cout << "[REF] SEL emcalo with pt: " << calo.hwPt << " qual: " << calo.hwEmID << " eta: " << calo.hwEta
                 << " phi " << calo.hwPhi << std::endl;
 
     int itk = emCalo2tk[ic];
@@ -210,7 +210,7 @@ void PFTkEGAlgoEmulator::eg_algo(const std::vector<EmCaloObjEmu> &emcalo,
     // check if brem recovery is on
     if (!cfg.doBremRecovery || cfg.writeBeforeBremRecovery) {
       // 1. create EG objects before brem recovery
-      addEgObjsToPF(egstas, egobjs, egeleobjs, emcalo, track, ic, calo.hwFlags, calo.hwPt, itk);
+      addEgObjsToPF(egstas, egobjs, egeleobjs, emcalo, track, ic, calo.hwEmID, calo.hwPt, itk);
     }
 
     if (!cfg.doBremRecovery)
@@ -233,7 +233,7 @@ void PFTkEGAlgoEmulator::eg_algo(const std::vector<EmCaloObjEmu> &emcalo,
 
     // 2. create EG objects with brem recovery
     // NOTE: duplicating the object is suboptimal but this is done for keeping things as in TDR code...
-    addEgObjsToPF(egstas, egobjs, egeleobjs, emcalo, track, ic, calo.hwFlags + 1, ptBremReco, itk, components);
+    addEgObjsToPF(egstas, egobjs, egeleobjs, emcalo, track, ic, calo.hwEmID + 1, ptBremReco, itk, components);
   }
 }
 

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/pf/pfalgo2hgc_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/pf/pfalgo2hgc_ref.cpp
@@ -50,9 +50,11 @@ void l1ct::PFAlgo2HGCEmulator::run(const PFInputRegion& in, OutputRegion& out) c
   unsigned int nMU = std::min<unsigned>(nMU_, in.muon.size());
 
   if (debug_) {
-    printf("FW\nFW  \t region eta [ %+5.2f , %+5.2f ], phi [ %+5.2f , %+5.2f ]   packed %s\n",
+    printf("FW\nFW  \t region eta %+5.2f [ %+5.2f , %+5.2f ], phi %+5.2f [ %+5.2f , %+5.2f ]   packed %s\n",
+           in.region.floatEtaCenter(),
            in.region.floatEtaMinExtra(),
            in.region.floatEtaMaxExtra(),
+           in.region.floatPhiCenter(),
            in.region.floatPhiCenter() - in.region.floatPhiHalfWidthExtra(),
            in.region.floatPhiCenter() + in.region.floatPhiHalfWidthExtra(),
            in.region.pack().to_string(16).c_str());
@@ -63,8 +65,8 @@ void l1ct::PFAlgo2HGCEmulator::run(const PFInputRegion& in, OutputRegion& out) c
       if (in.track[i].hwPt == 0)
         continue;
       printf(
-          "FW  \t track %3d: pt %8.2f [ %8d ]  calo eta %+5.2f [ %+5d ]  calo phi %+5.2f [ %+5d ]  vtx eta %+5.2f   "
-          "vtx phi %+5.2f   charge %+2d  quality %d  packed %s\n",
+          "FW  \t track %3d: pt %8.2f [ %8d ]  calo eta %+5.2f [ %+5d ]  calo phi %+5.2f [ %+5d ]  vtx eta %+5.2f  "
+          "vtx phi %+5.2f  charge %+2d  qual %d  fid %d  glb eta %+5.2f phi %+5.2f  packed %s\n",
           i,
           in.track[i].floatPt(),
           in.track[i].intPt(),
@@ -76,6 +78,9 @@ void l1ct::PFAlgo2HGCEmulator::run(const PFInputRegion& in, OutputRegion& out) c
           in.track[i].floatVtxPhi(),
           in.track[i].intCharge(),
           int(in.track[i].hwQuality),
+          int(in.region.isFiducial(in.track[i].hwEta, in.track[i].hwPhi)),
+          in.region.floatGlbEta(in.track[i].hwVtxEta()),
+          in.region.floatGlbPhi(in.track[i].hwVtxPhi()),
           in.track[i].pack().to_string(16).c_str());
     }
     for (unsigned int i = 0; i < nCALO; ++i) {
@@ -83,7 +88,7 @@ void l1ct::PFAlgo2HGCEmulator::run(const PFInputRegion& in, OutputRegion& out) c
         continue;
       printf(
           "FW  \t calo  %3d: pt %8.2f [ %8d ]  calo eta %+5.2f [ %+5d ]  calo phi %+5.2f [ %+5d ]  calo emPt %8.2f [ "
-          "%6d ]   emID %2d  packed %s \n",
+          "%6d ]   emID %2d  fid %d  glb eta %+5.2f phi %+5.2f  packed %s \n",
           i,
           in.hadcalo[i].floatPt(),
           in.hadcalo[i].intPt(),
@@ -94,14 +99,17 @@ void l1ct::PFAlgo2HGCEmulator::run(const PFInputRegion& in, OutputRegion& out) c
           in.hadcalo[i].floatEmPt(),
           in.hadcalo[i].intEmPt(),
           in.hadcalo[i].hwEmID.to_int(),
+          int(in.region.isFiducial(in.hadcalo[i].hwEta, in.hadcalo[i].hwPhi)),
+          in.region.floatGlbEtaOf(in.hadcalo[i]),
+          in.region.floatGlbPhiOf(in.hadcalo[i]),
           in.hadcalo[i].pack().to_string(16).c_str());
     }
     for (unsigned int i = 0; i < nMU; ++i) {
       if (in.muon[i].hwPt == 0)
         continue;
       printf(
-          "FW  \t muon  %3d: pt %8.2f [ %8d ]  calo eta %+5.2f [ %+5d ]  calo phi %+5.2f [ %+5d ]  charge %+2d   "
-          "packed %s \n",
+          "FW  \t muon  %3d: pt %8.2f [ %8d ]  calo eta %+5.2f [ %+5d ]  calo phi %+5.2f [ %+5d ]  "
+          "vtx eta %+5.2f  vtx phi %+5.2f  charge %+2d  qual %2d  glb eta %+5.2f phi %+5.2f  packed %s \n",
           i,
           in.muon[i].floatPt(),
           in.muon[i].intPt(),
@@ -109,7 +117,12 @@ void l1ct::PFAlgo2HGCEmulator::run(const PFInputRegion& in, OutputRegion& out) c
           in.muon[i].intEta(),
           in.muon[i].floatPhi(),
           in.muon[i].intPhi(),
+          in.muon[i].floatVtxEta(),
+          in.muon[i].floatVtxPhi(),
           in.muon[i].intCharge(),
+          int(in.muon[i].hwQuality),
+          in.region.floatGlbEta(in.muon[i].hwVtxEta()),
+          in.region.floatGlbPhi(in.muon[i].hwVtxPhi()),
           in.muon[i].pack().to_string(16).c_str());
     }
   }

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/pf/pfalgo2hgc_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/pf/pfalgo2hgc_ref.cpp
@@ -83,7 +83,7 @@ void l1ct::PFAlgo2HGCEmulator::run(const PFInputRegion& in, OutputRegion& out) c
         continue;
       printf(
           "FW  \t calo  %3d: pt %8.2f [ %8d ]  calo eta %+5.2f [ %+5d ]  calo phi %+5.2f [ %+5d ]  calo emPt %8.2f [ "
-          "%6d ]   isEM %d  packed %s \n",
+          "%6d ]   emID %2d  packed %s \n",
           i,
           in.hadcalo[i].floatPt(),
           in.hadcalo[i].intPt(),
@@ -93,7 +93,7 @@ void l1ct::PFAlgo2HGCEmulator::run(const PFInputRegion& in, OutputRegion& out) c
           in.hadcalo[i].intPhi(),
           in.hadcalo[i].floatEmPt(),
           in.hadcalo[i].intEmPt(),
-          int(in.hadcalo[i].hwIsEM),
+          in.hadcalo[i].hwEmID.to_int(),
           in.hadcalo[i].pack().to_string(16).c_str());
     }
     for (unsigned int i = 0; i < nMU; ++i) {
@@ -164,7 +164,7 @@ void l1ct::PFAlgo2HGCEmulator::run(const PFInputRegion& in, OutputRegion& out) c
                  ibest,
                  in.hadcalo[ibest].floatPt());
         track_good[it] = true;
-        isEle[it] = in.hadcalo[ibest].hwIsEM;
+        isEle[it] = in.hadcalo[ibest].hwIsEM();
         calo_sumtk[ibest] += in.track[it].hwPt;
         calo_sumtkErr2[ibest] += tkCaloPtErr * tkCaloPtErr;
       }
@@ -220,9 +220,9 @@ void l1ct::PFAlgo2HGCEmulator::run(const PFInputRegion& in, OutputRegion& out) c
     outne_all[ipf].clear();
   for (unsigned int ic = 0; ic < nCALO; ++ic) {
     if (calo_subpt[ic] > 0) {
-      fillPFCand(in.hadcalo[ic], outne_all[ic], in.hadcalo[ic].hwIsEM);
+      fillPFCand(in.hadcalo[ic], outne_all[ic], in.hadcalo[ic].hwIsEM());
       outne_all[ic].hwPt = calo_subpt[ic];
-      outne_all[ic].hwEmPt = in.hadcalo[ic].hwIsEM ? calo_subpt[ic] : pt_t(0);  // FIXME
+      outne_all[ic].hwEmPt = in.hadcalo[ic].hwIsEM() ? calo_subpt[ic] : pt_t(0);  // FIXME
     }
   }
 

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/pf/pfalgo3_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/pf/pfalgo3_ref.cpp
@@ -213,7 +213,7 @@ void l1ct::PFAlgo3Emulator::pfalgo3_em_ref(const PFInputRegion& in,
              em2calo[ic],
              (em2calo[ic] >= 0 ? in.hadcalo[em2calo[ic]].floatPt() : -1),
              (em2calo[ic] >= 0 ? in.hadcalo[em2calo[ic]].floatEmPt() : -1),
-             (em2calo[ic] >= 0 ? int(in.hadcalo[em2calo[ic]].hwIsEM) : 0));
+             (em2calo[ic] >= 0 ? int(in.hadcalo[em2calo[ic]].hwIsEM()) : 0));
     }
   }
 
@@ -239,7 +239,7 @@ void l1ct::PFAlgo3Emulator::pfalgo3_em_ref(const PFInputRegion& in,
              Scales::floatPt(alldiff),
              in.hadcalo[ih].floatEmPt(),
              Scales::floatPt(emdiff),
-             int(in.hadcalo[ih].hwIsEM),
+             int(in.hadcalo[ih].hwIsEM()),
              keep);
     }
     if (alldiff <= (in.hadcalo[ih].hwPt >> 4)) {
@@ -247,7 +247,7 @@ void l1ct::PFAlgo3Emulator::pfalgo3_em_ref(const PFInputRegion& in,
       hadcalo_out[ih].hwEmPt = 0;  // kill
       if (debug_ && (in.hadcalo[ih].hwPt > 0))
         printf("FW  \t calo   %3d pt %8.2f --> discarded (zero pt)\n", ih, in.hadcalo[ih].floatPt());
-    } else if ((in.hadcalo[ih].hwIsEM && emdiff <= (in.hadcalo[ih].hwEmPt >> 3)) && !keep) {
+    } else if ((in.hadcalo[ih].hwIsEM() && emdiff <= (in.hadcalo[ih].hwEmPt >> 3)) && !keep) {
       hadcalo_out[ih].hwPt = 0;    // kill
       hadcalo_out[ih].hwEmPt = 0;  // kill
       if (debug_ && (in.hadcalo[ih].hwPt > 0))
@@ -320,7 +320,7 @@ void l1ct::PFAlgo3Emulator::run(const PFInputRegion& in, OutputRegion& out) cons
         continue;
       printf(
           "FW  \t calo  %3d: pt %8.2f [ %8d ]  calo eta %+5.2f [ %+5d ]  calo phi %+5.2f [ %+5d ]  calo emPt  %8.2f [ "
-          "%6d ]   isEM %d \n",
+          "%6d ]   emID %2d \n",
           i,
           in.hadcalo[i].floatPt(),
           in.hadcalo[i].intPt(),
@@ -330,7 +330,7 @@ void l1ct::PFAlgo3Emulator::run(const PFInputRegion& in, OutputRegion& out) cons
           in.hadcalo[i].intPhi(),
           in.hadcalo[i].floatEmPt(),
           in.hadcalo[i].intEmPt(),
-          int(in.hadcalo[i].hwIsEM));
+          in.hadcalo[i].hwEmID.to_int());
     }
     for (unsigned int i = 0; i < nMU; ++i) {
       if (in.muon[i].hwPt == 0)
@@ -461,7 +461,7 @@ void l1ct::PFAlgo3Emulator::run(const PFInputRegion& in, OutputRegion& out) cons
     if (calo_subpt[ic] > 0) {
       fillPFCand(hadcalo_subem[ic], outne_all[ic]);
       outne_all[ic].hwPt = calo_subpt[ic];
-      outne_all[ic].hwEmPt = hadcalo_subem[ic].hwIsEM ? calo_subpt[ic] : pt_t(0);  // FIXME
+      outne_all[ic].hwEmPt = hadcalo_subem[ic].hwIsEM() ? calo_subpt[ic] : pt_t(0);  // FIXME
     }
   }
 

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/pf/pfalgo3_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/pf/pfalgo3_ref.cpp
@@ -269,11 +269,14 @@ void l1ct::PFAlgo3Emulator::run(const PFInputRegion& in, OutputRegion& out) cons
   unsigned int nMU = std::min<unsigned>(nMU_, in.muon.size());
 
   if (debug_) {
-    printf("FW\nFW  \t region eta [ %+5.2f , %+5.2f ], phi [ %+5.2f , %+5.2f ]\n",
+    printf("FW\nFW  \t region eta %+5.2f [ %+5.2f , %+5.2f ], phi %+5.2f [ %+5.2f , %+5.2f ]   packed %s\n",
+           in.region.floatEtaCenter(),
            in.region.floatEtaMinExtra(),
            in.region.floatEtaMaxExtra(),
+           in.region.floatPhiCenter(),
            in.region.floatPhiCenter() - in.region.floatPhiHalfWidthExtra(),
-           in.region.floatPhiCenter() + in.region.floatPhiHalfWidthExtra());
+           in.region.floatPhiCenter() + in.region.floatPhiHalfWidthExtra(),
+           in.region.pack().to_string(16).c_str());
 
     printf("FW  \t N(track) %3lu   N(em) %3lu   N(calo) %3lu   N(mu) %3lu\n",
            in.track.size(),
@@ -285,8 +288,8 @@ void l1ct::PFAlgo3Emulator::run(const PFInputRegion& in, OutputRegion& out) cons
       if (in.track[i].hwPt == 0)
         continue;
       printf(
-          "FW  \t track %3d: pt %8.2f [ %8d ]  calo eta %+5.2f [ %+5d ]  calo phi %+5.2f [ %+5d ]  vtx eta %+5.2f   "
-          "vtx phi %+5.2f   charge %+2d  quality %d\n",
+          "FW  \t track %3d: pt %8.2f [ %8d ]  calo eta %+5.2f [ %+5d ]  calo phi %+5.2f [ %+5d ]  vtx eta %+5.2f  "
+          "vtx phi %+5.2f   charge %+2d  qual %2d  fid %d  glb eta %+5.2f phi %+5.2f  packed %s\n",
           i,
           in.track[i].floatPt(),
           in.track[i].intPt(),
@@ -297,14 +300,18 @@ void l1ct::PFAlgo3Emulator::run(const PFInputRegion& in, OutputRegion& out) cons
           in.track[i].floatVtxEta(),
           in.track[i].floatVtxPhi(),
           in.track[i].intCharge(),
-          int(in.track[i].hwQuality));
+          int(in.track[i].hwQuality),
+          int(in.region.isFiducial(in.track[i].hwEta, in.track[i].hwPhi)),
+          in.region.floatGlbEta(in.track[i].hwVtxEta()),
+          in.region.floatGlbPhi(in.track[i].hwVtxPhi()),
+          in.track[i].pack().to_string(16).c_str());
     }
     for (unsigned int i = 0; i < nEMCALO; ++i) {
       if (in.emcalo[i].hwPt == 0)
         continue;
       printf(
           "FW  \t EM    %3d: pt %8.2f [ %8d ]  calo eta %+5.2f [ %+5d ]  calo phi %+5.2f [ %+5d ]  calo ptErr %8.2f [ "
-          "%6d ] \n",
+          "%6d ]  emID %2d  fid %d  glb eta %+5.2f phi %+5.2f  packed %s \n",
           i,
           in.emcalo[i].floatPt(),
           in.emcalo[i].intPt(),
@@ -313,14 +320,19 @@ void l1ct::PFAlgo3Emulator::run(const PFInputRegion& in, OutputRegion& out) cons
           in.emcalo[i].floatPhi(),
           in.emcalo[i].intPhi(),
           in.emcalo[i].floatPtErr(),
-          in.emcalo[i].intPtErr());
+          in.emcalo[i].intPtErr(),
+          in.emcalo[i].hwEmID.to_int(),
+          int(in.region.isFiducial(in.emcalo[i].hwEta, in.emcalo[i].hwPhi)),
+          in.region.floatGlbEtaOf(in.emcalo[i]),
+          in.region.floatGlbPhiOf(in.emcalo[i]),
+          in.emcalo[i].pack().to_string(16).c_str());
     }
     for (unsigned int i = 0; i < nCALO; ++i) {
       if (in.hadcalo[i].hwPt == 0)
         continue;
       printf(
           "FW  \t calo  %3d: pt %8.2f [ %8d ]  calo eta %+5.2f [ %+5d ]  calo phi %+5.2f [ %+5d ]  calo emPt  %8.2f [ "
-          "%6d ]   emID %2d \n",
+          "%6d ]   emID %2d  fid %d  glb eta %+5.2f phi %+5.2f  packed %s \n",
           i,
           in.hadcalo[i].floatPt(),
           in.hadcalo[i].intPt(),
@@ -330,20 +342,32 @@ void l1ct::PFAlgo3Emulator::run(const PFInputRegion& in, OutputRegion& out) cons
           in.hadcalo[i].intPhi(),
           in.hadcalo[i].floatEmPt(),
           in.hadcalo[i].intEmPt(),
-          in.hadcalo[i].hwEmID.to_int());
+          in.hadcalo[i].hwEmID.to_int(),
+          int(in.region.isFiducial(in.hadcalo[i].hwEta, in.hadcalo[i].hwPhi)),
+          in.region.floatGlbEtaOf(in.hadcalo[i]),
+          in.region.floatGlbPhiOf(in.hadcalo[i]),
+          in.hadcalo[i].pack().to_string(16).c_str());
     }
     for (unsigned int i = 0; i < nMU; ++i) {
       if (in.muon[i].hwPt == 0)
         continue;
-      printf("FW  \t muon  %3d: pt %8.2f [ %8d ]  calo eta %+5.2f [ %+5d ]  calo phi %+5.2f [ %+5d ]  charge %+2d  \n",
-             i,
-             in.muon[i].floatPt(),
-             in.muon[i].intPt(),
-             in.muon[i].floatEta(),
-             in.muon[i].intEta(),
-             in.muon[i].floatPhi(),
-             in.muon[i].intPhi(),
-             in.muon[i].intCharge());
+      printf(
+          "FW  \t muon  %3d: pt %8.2f [ %8d ]  calo eta %+5.2f [ %+5d ]  calo phi %+5.2f [ %+5d ]  "
+          "vtx eta %+5.2f  vtx phi %+5.2f  charge %+2d  qual %2d  glb eta %+5.2f phi %+5.2f  packed %s \n",
+          i,
+          in.muon[i].floatPt(),
+          in.muon[i].intPt(),
+          in.muon[i].floatEta(),
+          in.muon[i].intEta(),
+          in.muon[i].floatPhi(),
+          in.muon[i].intPhi(),
+          in.muon[i].floatVtxEta(),
+          in.muon[i].floatVtxPhi(),
+          in.muon[i].intCharge(),
+          int(in.muon[i].hwQuality),
+          in.region.floatGlbEta(in.muon[i].hwVtxEta()),
+          in.region.floatGlbPhi(in.muon[i].hwVtxPhi()),
+          in.muon[i].pack().to_string(16).c_str());
     }
     printf("FW\n");
   }

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/pf/pfalgo_common_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/pf/pfalgo_common_ref.cpp
@@ -137,7 +137,7 @@ void l1ct::PFAlgoEmulatorBase::fillPFCand(const HadCaloObjEmu &calo, PFNeutralOb
   pf.hwPhi = calo.hwPhi;
   pf.hwId = isPhoton ? ParticleID::PHOTON : ParticleID::HADZERO;
   pf.hwEmPt = calo.hwEmPt;  // FIXME
-  pf.hwEmID = calo.hwIsEM;
+  pf.hwEmID = calo.hwEmID;
   pf.hwPUID = 0;
   // extra emulator information
   pf.srcCluster = calo.src;
@@ -149,7 +149,7 @@ void l1ct::PFAlgoEmulatorBase::fillPFCand(const EmCaloObjEmu &calo, PFNeutralObj
   pf.hwPhi = calo.hwPhi;
   pf.hwId = isPhoton ? ParticleID::PHOTON : ParticleID::HADZERO;
   pf.hwEmPt = calo.hwPt;
-  pf.hwEmID = calo.hwFlags;
+  pf.hwEmID = calo.hwEmID;
   pf.hwPUID = 0;
   // more emulator info
   pf.srcCluster = calo.src;

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/pf/pfalgo_dummy_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/pf/pfalgo_dummy_ref.cpp
@@ -25,7 +25,7 @@ void l1ct::PFAlgoDummyEmulator::run(const PFInputRegion& in, OutputRegion& out) 
         continue;
       printf(
           "FW  \t calo  %3d: pt %8.2f [ %8d ]  calo eta %+5.2f [ %+7d ]  calo phi %+5.2f [ %+7d ]  calo emPt %8.2f [ "
-          "%6d ]   isEM %d \n",
+          "%6d ]   emID %2d \n",
           i,
           in.hadcalo[i].floatPt(),
           in.hadcalo[i].intPt(),
@@ -35,7 +35,7 @@ void l1ct::PFAlgoDummyEmulator::run(const PFInputRegion& in, OutputRegion& out) 
           in.hadcalo[i].intPhi(),
           in.hadcalo[i].floatEmPt(),
           in.hadcalo[i].intEmPt(),
-          int(in.hadcalo[i].hwIsEM));
+          in.hadcalo[i].hwEmID.to_int());
     }
     for (unsigned int i = 0; i < nMU; ++i) {
       if (in.muon[i].hwPt == 0)
@@ -54,7 +54,7 @@ void l1ct::PFAlgoDummyEmulator::run(const PFInputRegion& in, OutputRegion& out) 
   out.pfneutral.resize(nCALO);
   for (unsigned int ic = 0; ic < nCALO; ++ic) {
     if (in.hadcalo[ic].hwPt > 0) {
-      fillPFCand(in.hadcalo[ic], out.pfneutral[ic], in.hadcalo[ic].hwIsEM);
+      fillPFCand(in.hadcalo[ic], out.pfneutral[ic], in.hadcalo[ic].hwIsEM());
     } else {
       out.pfneutral[ic].clear();
     }

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/puppi/linpuppi_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/puppi/linpuppi_ref.cpp
@@ -381,7 +381,7 @@ void l1ct::LinPuppiEmulator::fwdlinpuppi_ref(const PFRegionEmu &region,
       }
     }
     unsigned int ieta = find_ieta(region, caloin[in].hwEta);
-    std::pair<pt_t, puppiWgt_t> ptAndW = sum2puppiPt_ref(sum, caloin[in].hwPt, ieta, caloin[in].hwIsEM, in);
+    std::pair<pt_t, puppiWgt_t> ptAndW = sum2puppiPt_ref(sum, caloin[in].hwPt, ieta, caloin[in].hwIsEM(), in);
 
     outallne_nocut[in].fill(region, caloin[in], ptAndW.first, ptAndW.second);
     if (region.isFiducial(caloin[in]) && outallne_nocut[in].hwPt >= ptCut_[ieta]) {
@@ -527,7 +527,7 @@ void l1ct::LinPuppiEmulator::fwdlinpuppi_flt(const PFRegionEmu &region,
     }
 
     unsigned int ieta = find_ieta(region, caloin[in].hwEta);
-    std::pair<float, float> ptAndW = sum2puppiPt_flt(sum, caloin[in].floatPt(), ieta, caloin[in].hwIsEM, in);
+    std::pair<float, float> ptAndW = sum2puppiPt_flt(sum, caloin[in].floatPt(), ieta, caloin[in].hwIsEM(), in);
     outallne_nocut[in].fill(region, caloin[in], Scales::makePtFromFloat(ptAndW.first), int(ptAndW.second * 256));
     if (region.isFiducial(caloin[in]) && outallne_nocut[in].hwPt >= ptCut_[ieta]) {
       outallne[in] = outallne_nocut[in];


### PR DESCRIPTION
 * EmCaloObj and HadCaloObj objects now consistently store the EM ID as a 6-bit unsigned integer.  This info is then correctly propagated to PFNeutralObj and PuppiObj.
   * At the moment, in the endcaps the lowest order bit is filled with the PF e/g ID from Manos, and the higher bits with the e/&gamma; ID, as per #54 

@cerminar