### PR TITLE
adding barrel regionizer emulator

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc
@@ -22,6 +22,7 @@
 #include "L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/layer1_emulator.h"
 #include "L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/common/regionizer_base_ref.h"
 #include "L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/multififo/multififo_regionizer_ref.h"
+#include "L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/tdr/tdr_regionizer_ref.h"
 #include "L1Trigger/Phase2L1ParticleFlow/src/newfirmware/pf/pfalgo2hgc_ref.h"
 #include "L1Trigger/Phase2L1ParticleFlow/src/newfirmware/pf/pfalgo3_ref.h"
 #include "L1Trigger/Phase2L1ParticleFlow/src/newfirmware/pf/pfalgo_dummy_ref.h"
@@ -173,6 +174,9 @@ L1TCorrelatorLayer1Producer::L1TCorrelatorLayer1Producer(const edm::ParameterSet
         std::make_unique<l1ct::RegionizerEmulator>(iConfig.getParameter<edm::ParameterSet>("regionizerAlgoParameters"));
   } else if (regalgo == "Multififo") {
     regionizer_ = std::make_unique<l1ct::MultififoRegionizerEmulator>(
+        iConfig.getParameter<edm::ParameterSet>("regionizerAlgoParameters"));
+  } else if (regalgo == "TDR") {
+    regionizer_ = std::make_unique<l1ct::TDRRegionizerEmulator>(
         iConfig.getParameter<edm::ParameterSet>("regionizerAlgoParameters"));
   } else
     throw cms::Exception("Configuration", "Unsupported regionizerAlgo");

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/tdr/tdr_regionizer_elements_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/tdr/tdr_regionizer_elements_ref.h
@@ -1,0 +1,185 @@
+#ifndef tdr_regionizer_elements_ref_h
+#define tdr_regionizer_elements_ref_h
+
+#include "../../dataformats/layer1_emulator.h"
+
+#include <list>
+#include <vector>
+#include <cassert>
+#include <algorithm>
+
+namespace l1ct {
+  namespace tdr_regionizer {
+
+    inline int dphi_wrap(int local_phi) {
+      if (local_phi > l1ct::Scales::INTPHI_PI)
+        local_phi -= l1ct::Scales::INTPHI_TWOPI;
+      else if (local_phi <= -l1ct::Scales::INTPHI_PI)
+        local_phi += l1ct::Scales::INTPHI_TWOPI;
+      return local_phi;
+    }
+
+    struct RegionInfo {
+      RegionInfo(unsigned int idx, int regphi, int regeta) : index(idx), phi(regphi), eta(regeta) {}
+      unsigned int index;
+      int phi;
+      int eta;
+    };
+
+    bool sortRegionInfo(RegionInfo &a, RegionInfo &b)
+    { 
+      if (a.phi < b.phi) return true;
+      if (a.phi > b.phi) return false;
+      if (a.eta < b.eta) return true;
+      if (a.eta > b.eta) return false;
+      return false;
+    } 
+
+    template <typename T>
+    class PipeObject {
+    public:
+      PipeObject() {}
+      PipeObject(const T& obj, unsigned int phiindex, unsigned int etaindex, bool phioverlap, bool etaoverlap, int glbphi, int glbeta, unsigned int clk);
+
+      unsigned int getClock() { return linkobjclk_;}
+      void setClock(unsigned int clock) { linkobjclk_ = clock;}
+      unsigned int getPhi() { return phiindex_;}
+      unsigned int getEta() { return etaindex_;}
+      bool getPhiOverlap() { return phioverlap_;}
+      bool getEtaOverlap() { return etaoverlap_;}
+      unsigned int getCount() { return objcount_;}
+      unsigned int getCountAndInc() { return objcount_++;}
+      void incCount() { objcount_++;}
+      int getPt() { return obj_.hwPt.to_int();}
+      int getGlbPhi() { return glbphi_;}
+      int getGlbEta() { return glbeta_;}
+               
+      T getObj() { return obj_;}
+
+      private:
+        T obj_;
+        unsigned int phiindex_, etaindex_;
+        bool phioverlap_, etaoverlap_;
+        int glbphi_, glbeta_;
+        unsigned int linkobjclk_, objcount_;
+    };
+
+    template <typename T>
+    class Pipe {
+      public:
+        Pipe(unsigned int nphi = 9) : clkindex_(0), nphi_(nphi) {}
+
+        void addObj(T obj, unsigned int phiindex, unsigned int etaindex, bool phioverlap, bool etaoverlap, int glbphi, int glbeta);
+        PipeObject<T>& getObj(unsigned int index) { return data_[index];}
+        T getRawObj(unsigned int index) { return data_[index].getObj();}
+
+        unsigned int getClock(unsigned int index = 0) { return getObj(index).getClock();}
+        void setClock(unsigned int clock, unsigned int index = 0) { return getObj(index).setClock(clock);}
+        unsigned int getPhi(unsigned int index = 0) { return getObj(index).getPhi();}
+        unsigned int getEta(unsigned int index = 0) { return getObj(index).getEta();}
+        bool getPhiOverlap(unsigned int index = 0) { return getObj(index).getPhiOverlap();}
+        bool getEtaOverlap(unsigned int index = 0) { return getObj(index).getEtaOverlap();}
+        unsigned int getCount(unsigned int index = 0) { return getObj(index).getCount();}
+        unsigned int getCountAndInc(unsigned int index = 0) { return getObj(index).getCountAndInc();}
+        void incCount(unsigned int index = 0) { getObj(index).incCount();}
+        void erase(unsigned int index = 0) { data_.erase(data_.begin() + index);}
+        int getPt(unsigned int index = 0) { return getObj(index).getPt();}
+        int getGlbPhi(unsigned int index = 0) { return getObj(index).getGlbPhi();}
+        int getGlbEta(unsigned int index = 0) { return getObj(index).getGlbEta();}
+    
+        int getClosedIndexForObject(unsigned int index = 0);
+        int getPipeIndexForObject(unsigned int index = 0);
+
+        unsigned int getSize() { return data_.size();}
+
+        void reset() {
+          clkindex_ = 0;
+          data_.clear();
+        }
+
+      private:
+        unsigned int clkindex_, nphi_;
+        std::vector<PipeObject<T>> data_;
+    };
+        
+
+    template <typename T>
+    class Regionizer {
+    public:
+      Regionizer() {}
+      Regionizer(unsigned int neta,
+                 unsigned int nregions, 
+                 unsigned int maxobjects,
+                 int etaoffset, 
+                 int etawidth,
+                 int nclocks);
+      void initSectors(const std::vector<DetectorSector<T>>& sectors);
+      void initSectors(const DetectorSector<T>& sector);
+      void initRegions(const std::vector<PFInputRegion>& regions);
+
+      unsigned int getSize() { return pipes_.size();}
+      unsigned int getPipeSize(unsigned int index) { return getPipe(index).getSize();}
+
+      bool setIndicesOverlaps(const T& obj, unsigned int &phiindex, unsigned int &etaindex, bool &phioverlap, bool &etaoverlap, int &glbphi, int &glbeta, unsigned int index);
+
+      void addToPipe(const T& obj, unsigned int index);
+      void setPipe(const std::vector<T>& objvec, unsigned int index);
+      void setPipes(const std::vector<std::vector<T>>& objvecvec);
+      Pipe<T>& getPipe(unsigned int index) { return pipes_[index];}
+
+      int getPipeTime(int linkIndex, int linkTimeOfObject, int linkAlgoClockRunningTime);
+      int popLinkObject(int linkIndex, int currentTimeOfObject);
+      int timeNextFromIndex(unsigned int index, int time) { return getPipeTime(index,pipes_[index].getClock(),time);}
+
+      void initTimes();
+
+      int getClosedIndexForObject(unsigned int linknum, unsigned int index = 0) { return pipes_[linknum].getClosedIndexForObject(index);}
+      int getPipeIndexForObject(unsigned int linknum, unsigned int index = 0) { return pipes_[linknum].getPipeIndexForObject(index);}
+      void addToSmallRegion(unsigned int linkNum, unsigned int index = 0); 
+
+      void run(bool debug = false);
+
+      void reset();
+
+      std::vector<T> getSmallRegion(unsigned int index);
+
+      void printDebug(int count) {
+        std::cout<<count<<"\tindex\tpt\teta\tphi"<<std::endl;
+        std::cout<<"PIPES"<<std::endl;
+        for (unsigned int i = 0; i < getSize(); i++) {
+          for (unsigned int j = 0; j < getPipeSize(i); j++) {
+            std::cout<<"\t"<<i<<" "<<j<<"\t"<<getPipe(i).getPt(j)<<"\t"<<getPipe(i).getGlbEta(j)<<"\t"<<getPipe(i).getGlbPhi(j)<<std::endl;
+          }
+          std::cout<<"-------------------------------"<<std::endl;
+        }
+        std::cout<<"SMALL REGIONS"<<std::endl;
+        for (unsigned int i = 0; i < nregions_; i++) {
+          for (unsigned int j = 0; j < smallRegionObjects_[i].size(); j++) {
+            std::cout<<"\t"<<i<<" "<<j<<"\t"<<smallRegionObjects_[i][j].hwPt.to_int()<<"\t"<<smallRegionObjects_[i][j].hwEta.to_int()+regionmap_[i].eta<<"\t"<<smallRegionObjects_[i][j].hwPhi.to_int()+regionmap_[i].phi<<std::endl;
+          }
+          std::cout<<"-------------------------------"<<std::endl;
+        }
+        std::cout<<"TIMES"<<std::endl;
+        for (unsigned int i = 0; i < timeOfNextObject_.size(); i++) {
+          std::cout<<"  "<<timeOfNextObject_[i];
+        }
+        std::cout<<"\n-------------------------------"<<std::endl;
+      }
+
+    private:
+      unsigned int neta_, nregions_, maxobjects_, nsectors_;
+      int etaoffset_, etawidth_, nclocks_;
+      std::vector<l1ct::PFRegionEmu> sectors_;
+      std::vector<l1ct::PFRegionEmu> regions_;
+      std::vector<RegionInfo> regionmap_;
+
+      std::vector<Pipe<T>> pipes_;
+      std::vector<int> timeOfNextObject_;
+      std::vector<std::vector<T>> smallRegionObjects_; //keep count to see if small region is full
+
+    };
+
+  }  // namespace  tdr_regionizer
+}  // namespace l1ct
+
+#endif

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/tdr/tdr_regionizer_elements_ref.icc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/tdr/tdr_regionizer_elements_ref.icc
@@ -1,0 +1,283 @@
+template <typename T>
+l1ct::tdr_regionizer::PipeObject<T>::PipeObject(const T& obj, unsigned int phiindex, unsigned int etaindex, bool phioverlap, bool etaoverlap, int glbphi, int glbeta, unsigned int clk) : obj_(obj), phiindex_(phiindex), etaindex_(etaindex), phioverlap_(phioverlap), etaoverlap_(etaoverlap), glbphi_(glbphi), glbeta_(glbeta), linkobjclk_(clk) {
+  objcount_ = 0;
+}
+
+template <typename T>
+void l1ct::tdr_regionizer::Pipe<T>::addObj(T obj, unsigned int phiindex, unsigned int etaindex, bool phioverlap, bool etaoverlap, int glbphi, int glbeta) {
+  data_.emplace_back(PipeObject<T>(obj, phiindex, etaindex, phioverlap, etaoverlap, glbphi, glbeta, clkindex_++));
+}
+//explicit for tracker to handle clocking
+template<>
+void l1ct::tdr_regionizer::Pipe<l1ct::TkObjEmu>::addObj(l1ct::TkObjEmu obj, unsigned int phiindex, unsigned int etaindex, bool phioverlap, bool etaoverlap, int glbphi, int glbeta) {
+  data_.emplace_back(PipeObject<l1ct::TkObjEmu>(obj, phiindex, etaindex, phioverlap, etaoverlap, glbphi, glbeta, clkindex_++));
+  if (clkindex_%3==2) clkindex_++; //this is for tracker, could I get this generically maybe?
+}
+
+template <typename T>
+int l1ct::tdr_regionizer::Pipe<T>::getClosedIndexForObject(unsigned int index) {
+  switch(getCount(index)) {
+    case 0:
+      return getPhi(index)*2 + getEta(index);
+    case 1:
+      if(getPhiOverlap(index) && !getEtaOverlap(index))
+        return ((getPhi(index) + 1)%nphi_)*2 + getEta(index);
+      else  //eta overlap, or 4-small-region overlap
+        return getPhi(index)*2 + getEta(index) + 1;
+    case 2:
+      return ((getPhi(index) + 1)%nphi_)*2 + getEta(index);
+    case 3:
+      return ((getPhi(index) + 1)%nphi_)*2 + getEta(index) + 1;      
+    default:
+      std::cout << "Impossible object count!" << std::endl;
+      exit(0);
+  }
+}
+
+template <typename T>
+int l1ct::tdr_regionizer::Pipe<T>::getPipeIndexForObject(unsigned int index) {
+  switch(getCount(index)) {
+    case 0:
+      return getPhi(index);
+    case 1:
+      if(getPhiOverlap(index) && !getEtaOverlap(index))
+        return (getPhi(index) + 1)%nphi_;
+      else  
+        return getPhi(index);
+    case 2:
+    case 3:
+      return (getPhi(index) + 1)%nphi_;
+    default:
+      std::cout << "Impossible object count!" << std::endl;
+      exit(0);
+  }
+}
+
+template <typename T>
+l1ct::tdr_regionizer::Regionizer<T>::Regionizer(unsigned int neta, unsigned int nregions, unsigned int maxobjects, int etaoffset, int etawidth, int nclocks) : 
+    neta_(neta), 
+    nregions_(nregions), 
+    maxobjects_(maxobjects), 
+    nsectors_(0),
+    etaoffset_(etaoffset),
+    etawidth_(etawidth),
+    nclocks_(nclocks) {
+  smallRegionObjects_.resize(nregions);
+}
+
+template <typename T>
+void l1ct::tdr_regionizer::Regionizer<T>::initSectors(const std::vector<DetectorSector<T>>& sectors) {
+  assert(nsectors_ == 0);
+  nsectors_ = sectors.size();
+  sectors_.resize(nsectors_);
+  pipes_.resize(nsectors_);
+  for (unsigned int i = 0; i < nsectors_; ++i) {
+    sectors_[i] = sectors[i].region;
+  }
+}
+
+template <typename T>
+void l1ct::tdr_regionizer::Regionizer<T>::initSectors(const DetectorSector<T>& sector) {
+  assert(nsectors_ == 0);
+  nsectors_ = 1;
+  sectors_.resize(1, sector.region);
+  pipes_.resize(nsectors_);
+}
+
+template <typename T>
+void l1ct::tdr_regionizer::Regionizer<T>::initRegions(const std::vector<PFInputRegion>& regions) {
+  regions_.resize(regions.size());
+  regionmap_.clear();
+  for (unsigned int i = 0; i < regions.size(); ++i) {
+    regions_[i] = regions[i].region;
+    if (etaoffset_ - etawidth_ <= regions_[i].intEtaCenter() && regions_[i].intEtaCenter() < etaoffset_ + etawidth_) {
+      regionmap_.emplace_back(i, regions_[i].intPhiCenter(), regions_[i].intEtaCenter());
+    }
+  }
+  assert(regionmap_.size()==nregions_);
+  std::sort(regionmap_.begin(), regionmap_.end(), sortRegionInfo);
+}
+
+template <typename T>
+bool l1ct::tdr_regionizer::Regionizer<T>::setIndicesOverlaps(const T& obj, unsigned int &phiindex, unsigned int &etaindex, bool &phioverlap, bool &etaoverlap, int &glbphi, int &glbeta, unsigned int index) {
+  glbphi = sectors_[index].hwGlbPhiOf(obj).to_int();
+  glbeta = sectors_[index].hwGlbEtaOf(obj).to_int();
+  phiindex = nregions_;
+  etaindex = nregions_;
+  phioverlap = false;
+  etaoverlap = false;
+  bool isset = false;
+  for (unsigned int i = 0; i < nregions_; i++) {
+    int regphi = dphi_wrap(glbphi-regionmap_[i].phi);
+    int regeta = glbeta-regionmap_[i].eta;
+
+    if (regions_[regionmap_[i].index].isInside(regeta, regphi)) {
+      if (isset) {
+        if (i/neta_ != phiindex)
+          phioverlap = true;
+        if (i%neta_ != etaindex)
+          etaoverlap = true;
+      }
+      if (i/neta_ < phiindex || (i>(nregions_-neta_) && phiindex==0)) {
+        phiindex = i/neta_;
+      }
+      if (i%neta_ < etaindex) {
+        etaindex = i%neta_;
+        isset = true; //only need to check eta to set since there is full coverage in each board in phi
+      }
+    }
+  }
+  if (isset && etaindex==1 && etaoverlap) {
+    etaoverlap = false;
+  }
+  return isset;
+}
+
+template <typename T>
+void l1ct::tdr_regionizer::Regionizer<T>::addToPipe(const T& obj, unsigned int index) {
+  assert(index < getSize());
+  unsigned int phiindex, etaindex;
+  bool phioverlap, etaoverlap;
+  int glbphi, glbeta;
+  bool isset = setIndicesOverlaps(obj, phiindex, etaindex, phioverlap, etaoverlap, glbphi, glbeta, index);
+  if (isset) {
+    pipes_[index].addObj(obj, phiindex, etaindex, phioverlap, etaoverlap, glbphi, glbeta);
+  }
+}
+
+template <typename T>
+void l1ct::tdr_regionizer::Regionizer<T>::setPipe(const std::vector<T>& objvec, unsigned int index) {
+  assert(index < getSize());
+  pipes_[index].reset();
+  for (unsigned int i = 0; i < objvec.size(); i++) {
+    addToPipe(objvec[i],index);
+  }
+}
+
+template <typename T>
+void l1ct::tdr_regionizer::Regionizer<T>::setPipes(const std::vector<std::vector<T>>& objvecvec) {
+  assert(getSize() == objvecvec.size());
+  for (unsigned int i = 0; i < getSize(); i++) {
+    setPipe(objvecvec[i], i);
+  }
+}
+
+template <typename T>
+int l1ct::tdr_regionizer::Regionizer<T>::getPipeTime(int linkIndex, int linkTimeOfObject, int linkAlgoClockRunningTime) {
+  const int LINK_TO_ALGO_CLK_OFFSET = 2; //13; // in units of algo clock
+  int linkObjectArrival = (nsectors_ - 1 - linkIndex) + LINK_TO_ALGO_CLK_OFFSET + linkTimeOfObject;
+
+  return (linkAlgoClockRunningTime < 0 || linkObjectArrival > linkAlgoClockRunningTime + 4) ?
+    linkObjectArrival : (linkAlgoClockRunningTime + 4);
+}
+
+template <typename T>
+int l1ct::tdr_regionizer::Regionizer<T>::popLinkObject(int linkIndex, int currentTimeOfObject) {
+  pipes_[linkIndex].incCount();
+
+  //determine which object is next and at what time
+  unsigned int countToBeDone = 1;
+  if(pipes_[linkIndex].getPhiOverlap() && pipes_[linkIndex].getEtaOverlap())
+    countToBeDone = 4;
+  else if(pipes_[linkIndex].getPhiOverlap() || pipes_[linkIndex].getEtaOverlap())
+    countToBeDone = 2;
+
+  if(countToBeDone == pipes_[linkIndex].getCount()) {
+    //pop off leading object, done with it
+    pipes_[linkIndex].erase();
+
+    //get time of next object
+    if(pipes_[linkIndex].getSize())
+      return getPipeTime(linkIndex,pipes_[linkIndex].getClock(),currentTimeOfObject); 
+    else //no more objects on link
+      return -1;
+  } else {
+    //increment time for next overlapped object on this link
+    return currentTimeOfObject + 1;
+  }
+}
+
+template <typename T>
+void l1ct::tdr_regionizer::Regionizer<T>::initTimes() {
+  for(unsigned int l = 0; l < getSize(); ++l) {
+    if(getPipeSize(l)) {
+      timeOfNextObject_.push_back(timeNextFromIndex(l,-1));
+    } else {
+      timeOfNextObject_.push_back(-1);
+    }
+  }
+}
+
+template <typename T>
+void l1ct::tdr_regionizer::Regionizer<T>::addToSmallRegion(unsigned int linkNum, unsigned int index) {
+  T theobj = pipes_[linkNum].getRawObj(index);
+  unsigned int regind = getClosedIndexForObject(linkNum);
+  theobj.hwPhi = dphi_wrap(pipes_[linkNum].getGlbPhi(index) - regionmap_[regind].phi);
+  theobj.hwEta = pipes_[linkNum].getGlbEta(index) - regionmap_[regind].eta;
+  smallRegionObjects_[regind].push_back(theobj);
+}
+
+template <typename T>
+void l1ct::tdr_regionizer::Regionizer<T>::run(bool debug) {
+  unsigned int loopCount = 0;
+  if (debug) printDebug(loopCount);
+  while(loopCount < 972) {//this is the max allowable if nothing ever blocks
+    //init min time, pipe, and link index 
+    //      to find the target pipe currently with action
+    int minp = -1;
+    int minl = -1;
+    int minTime = 0;
+
+    //do pipe-full handling
+    for(unsigned int l = 0; l < getSize(); ++l) {
+      if(timeOfNextObject_[l] >= 0 && smallRegionObjects_[getClosedIndexForObject(l)].size() == maxobjects_) {
+
+        //pipe is full so proceed to next object
+        //'remove' the selected object from its link
+        timeOfNextObject_[l] = popLinkObject(l, timeOfNextObject_[l]);
+      } //end pipe-full handling loop
+    }
+
+    //do find object handling
+    for(unsigned int l = 0; l < getSize(); ++l) {
+      if(timeOfNextObject_[l] >= 0 && (minl == -1 || timeOfNextObject_[l] < minTime)) {
+        //found new 'selected' link object and pipe
+        minp = getPipeIndexForObject(l);
+        minTime = timeOfNextObject_[l];
+        minl = l;
+      } else if(getPipeSize(l) && minl >= 0 && minp == getPipeIndexForObject(l) && timeOfNextObject_[l] == minTime) {
+        //have pipe conflict, so need to wait a clock
+        ++timeOfNextObject_[l];
+      }
+    }
+
+    if(minl < 0)
+      break;  //exit case
+
+    //'put' object in small region
+    addToSmallRegion(minl);
+      
+    //'remove' the selected object from its link
+    int nextTime = popLinkObject(minl, timeOfNextObject_[minl]);
+    if (nextTime>nclocks_) break;
+    timeOfNextObject_[minl] = nextTime;
+    ++loopCount;            
+  } //end main loop
+
+  if (debug) printDebug(loopCount);
+}
+
+template <typename T>
+void l1ct::tdr_regionizer::Regionizer<T>::reset() {
+  for (unsigned int i = 0; i < getSize(); i++) {pipes_[i].reset();}
+  timeOfNextObject_.clear();
+  for (unsigned int i = 0; i < nregions_; i++) {smallRegionObjects_[i].clear();}
+}
+
+template <typename T>
+std::vector<T> l1ct::tdr_regionizer::Regionizer<T>::getSmallRegion(unsigned int index) {
+  for (unsigned int i = 0; i < nregions_; i++) {
+    if (regionmap_[i].index==index) return smallRegionObjects_[i];
+  }
+  return {};
+}

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/tdr/tdr_regionizer_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/tdr/tdr_regionizer_ref.cpp
@@ -1,0 +1,291 @@
+#include "tdr_regionizer_ref.h"
+
+#include <iostream>
+
+#include "tdr_regionizer_elements_ref.icc"
+
+#ifdef CMSSW_GIT_HASH
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+l1ct::TDRRegionizerEmulator::TDRRegionizerEmulator(const edm::ParameterSet& iConfig)
+    : TDRRegionizerEmulator(
+          /*netaslices=*/3,
+          iConfig.getParameter<uint32_t>("nTrack"),
+          iConfig.getParameter<uint32_t>("nCalo"),
+          iConfig.getParameter<uint32_t>("nEmCalo"),
+          iConfig.getParameter<uint32_t>("nMu"),
+          iConfig.getParameter<int32_t>("nClocks"),
+          iConfig.getParameter<bool>("doSort")) {
+  debug_ = iConfig.getUntrackedParameter<bool>("debug", false);
+}
+#endif
+
+l1ct::TDRRegionizerEmulator::TDRRegionizerEmulator(unsigned int netaslices,
+                                                   unsigned int ntk,
+                                                   unsigned int ncalo,
+                                                   unsigned int nem,
+                                                   unsigned int nmu,
+                                                   int nclocks,
+                                                   bool dosort)
+    : RegionizerEmulator(),
+      netaslices_(netaslices),
+      ntk_(ntk),
+      ncalo_(ncalo),
+      nem_(nem),
+      nmu_(nmu),
+      nclocks_(nclocks),
+      dosort_(dosort),
+      init_(false) {
+  assert(netaslices == 3);//the setup here only works for 3 barrel boards
+  int etaoffsets[3] = {-228, 0, 228};//this could be made generic perhaps, hardcoding for now
+  for (unsigned int i = 0; i < netaslices_; i++) {
+    tkRegionizers_.emplace_back((unsigned int)NETA_SMALL, (unsigned int)NUMBER_OF_SMALL_REGIONS, ntk, etaoffsets[i], 115, nclocks);
+    hadCaloRegionizers_.emplace_back((unsigned int)NETA_SMALL, (unsigned int)NUMBER_OF_SMALL_REGIONS, ncalo, etaoffsets[i], 115, nclocks);
+    emCaloRegionizers_.emplace_back((unsigned int)NETA_SMALL, (unsigned int)NUMBER_OF_SMALL_REGIONS, nem, etaoffsets[i], 115, nclocks);
+    muRegionizers_.emplace_back((unsigned int)NETA_SMALL, (unsigned int)NUMBER_OF_SMALL_REGIONS, nmu, etaoffsets[i], 115, nclocks);
+  }
+}
+
+l1ct::TDRRegionizerEmulator::~TDRRegionizerEmulator() {}
+
+void l1ct::TDRRegionizerEmulator::initSectorsAndRegions(const RegionizerDecodedInputs& in,
+                                                        const std::vector<PFInputRegion>& out) {
+  assert(!init_);
+  init_ = true;
+  nregions_ = out.size();
+  if (ntk_) {
+    for (unsigned int i = 0; i < netaslices_; i++) {
+      tkRegionizers_[i].initSectors(in.track);
+      tkRegionizers_[i].initRegions(out);
+    }
+  }
+  if (ncalo_) {
+    for (unsigned int i = 0; i < netaslices_; i++) {
+      hadCaloRegionizers_[i].initSectors(in.hadcalo);
+      hadCaloRegionizers_[i].initRegions(out);
+    }
+  }
+  if (nem_) {
+    for (unsigned int i = 0; i < netaslices_; i++) {
+      emCaloRegionizers_[i].initSectors(in.emcalo);
+      emCaloRegionizers_[i].initRegions(out);
+    }
+  }
+  if (nmu_) {
+    for (unsigned int i = 0; i < netaslices_; i++) {
+      muRegionizers_[i].initSectors(in.muon);
+      muRegionizers_[i].initRegions(out);
+    }
+  }
+}
+
+void l1ct::TDRRegionizerEmulator::fillLinks(const l1ct::RegionizerDecodedInputs& in,
+                                            std::vector<std::vector<l1ct::TkObjEmu>>& links) {
+  if (ntk_ == 0)
+    return;
+
+  links.clear();
+  links.resize(in.track.size());
+
+  //one link per sector
+  for (unsigned int il = 0; il < in.track.size(); il++) {
+    const l1ct::DetectorSector<l1ct::TkObjEmu>& sec = in.track[il];
+    for (unsigned int io = 0; io < sec.size(); io++) {
+      links[il].push_back(sec[io]);
+      if (links[il].size()==MAX_TK_EVT) {
+        break;
+      }
+    }
+  }
+}
+
+void l1ct::TDRRegionizerEmulator::fillLinks(const l1ct::RegionizerDecodedInputs& in,
+                                            std::vector<std::vector<l1ct::HadCaloObjEmu>>& links) {
+  if (ncalo_ == 0)
+    return;
+
+  links.clear();
+  links.resize(in.hadcalo.size());
+
+  //one link per sector
+  for (unsigned int il = 0; il < in.hadcalo.size(); il++) {
+    const l1ct::DetectorSector<l1ct::HadCaloObjEmu>& sec = in.hadcalo[il];
+    for (unsigned int io = 0; io < sec.size(); io++) {
+      links[il].push_back(sec[io]);
+      if (links[il].size()==MAX_CALO_EVT) {
+        break;
+      }
+    }
+  }
+}
+
+void l1ct::TDRRegionizerEmulator::fillLinks(const l1ct::RegionizerDecodedInputs& in,
+                                            std::vector<std::vector<l1ct::EmCaloObjEmu>>& links) {
+  if (nem_ == 0)
+    return;
+
+  links.clear();
+  links.resize(in.emcalo.size());
+
+  //one link per sector
+  for (unsigned int il = 0; il < in.emcalo.size(); il++) {
+    const l1ct::DetectorSector<l1ct::EmCaloObjEmu>& sec = in.emcalo[il];
+    for (unsigned int io = 0; io < sec.size(); io++) {
+      links[il].push_back(sec[io]);
+      if (links[il].size()==MAX_EMCALO_EVT) {
+        break;
+      }
+    }
+  }
+}
+
+void l1ct::TDRRegionizerEmulator::fillLinks(const l1ct::RegionizerDecodedInputs& in,
+                                            std::vector<std::vector<l1ct::MuObjEmu>>& links) {
+  if (nmu_ == 0)
+    return;
+
+  links.clear();
+  links.resize(1);//muons are global
+
+  const l1ct::DetectorSector<l1ct::MuObjEmu>& sec = in.muon;
+  for (unsigned int io = 0; io < sec.size(); io++) {
+    links[0].push_back(sec[io]);
+    if (links[0].size()==MAX_MU_EVT) {
+      break;
+    }
+  }
+}
+
+void l1ct::TDRRegionizerEmulator::toFirmware(const std::vector<l1ct::TkObjEmu>& emu,
+                                                   TkObj fw[NTK_SECTORS][NTK_LINKS]) {
+  if (ntk_ == 0)
+    return;
+  assert(emu.size() == NTK_SECTORS * NTK_LINKS * netaslices_);
+  for (unsigned int is = 0, idx = 0; is < NTK_SECTORS * netaslices_; ++is) {  // tf sectors
+    for (unsigned int il = 0; il < NTK_LINKS; ++il, ++idx) {
+      fw[is][il] = emu[idx];
+    }
+  }
+}
+void l1ct::TDRRegionizerEmulator::toFirmware(const std::vector<l1ct::HadCaloObjEmu>& emu,
+                                                   HadCaloObj fw[NCALO_SECTORS][NCALO_LINKS]) {
+  if (ncalo_ == 0)
+    return;
+  assert(emu.size() == NCALO_SECTORS * NCALO_LINKS * netaslices_);
+  for (unsigned int is = 0, idx = 0; is < NCALO_SECTORS * netaslices_; ++is) {  // tf sectors
+    for (unsigned int il = 0; il < NCALO_LINKS; ++il, ++idx) {
+      fw[is][il] = emu[idx];
+    }
+  }
+}
+
+void l1ct::TDRRegionizerEmulator::toFirmware(const std::vector<l1ct::EmCaloObjEmu>& emu,
+                                                   EmCaloObj fw[NCALO_SECTORS][NCALO_LINKS]) {
+  if (nem_ == 0)
+    return;
+  assert(emu.size() == NCALO_SECTORS * NCALO_LINKS * netaslices_);
+  for (unsigned int is = 0, idx = 0; is < NCALO_SECTORS * netaslices_; ++is) {  // tf sectors
+    for (unsigned int il = 0; il < NCALO_LINKS; ++il, ++idx) {
+      fw[is][il] = emu[idx];
+    }
+  }
+}
+
+void l1ct::TDRRegionizerEmulator::toFirmware(const std::vector<l1ct::MuObjEmu>& emu, MuObj fw[NMU_LINKS]) {
+  if (nmu_ == 0)
+    return;
+  assert(emu.size() == NMU_LINKS);
+  for (unsigned int il = 0, idx = 0; il < NMU_LINKS; ++il, ++idx) {
+    fw[il] = emu[idx];
+  }
+}
+
+void l1ct::TDRRegionizerEmulator::run(const RegionizerDecodedInputs& in, std::vector<PFInputRegion>& out) {
+  if (!init_)
+    initSectorsAndRegions(in, out);
+
+  std::vector<std::vector<l1ct::TkObjEmu>> tk_links_in;
+  std::vector<std::vector<l1ct::EmCaloObjEmu>> em_links_in;
+  std::vector<std::vector<l1ct::HadCaloObjEmu>> calo_links_in;
+  std::vector<std::vector<l1ct::MuObjEmu>> mu_links_in;
+  
+  // read the inputs
+  fillLinks(in, tk_links_in);
+  fillLinks(in, em_links_in);
+  fillLinks(in, calo_links_in);
+  fillLinks(in, mu_links_in);
+  //this is overkill and could be improved, for now its ok (the sectors outside each board just wont do anything)
+
+  for (unsigned int ie = 0; ie < netaslices_; ie++) {
+    //add objects from link
+    tkRegionizers_[ie].reset();
+    tkRegionizers_[ie].setPipes(tk_links_in);
+    tkRegionizers_[ie].initTimes();
+    if (debug_) {
+      std::cout<<ie<<"SECTORS/LINKS "<<ie<<std::endl;
+      for (unsigned int i = 0; i < tk_links_in.size(); i++) {
+        for (unsigned int j = 0; j < tk_links_in[i].size(); j++) {
+          std::cout<<"\t"<<i<<" "<<j<<"\t"<<tk_links_in[i][j].hwPt.to_int()<<"\t"<<tk_links_in[i][j].hwEta.to_int()<<"\t"<<tk_links_in[i][j].hwPhi.to_int()<<std::endl;
+        }
+        std::cout<<"-------------------------------"<<std::endl;
+      }
+    }
+    tkRegionizers_[ie].run(debug_);
+
+    emCaloRegionizers_[ie].reset();
+    emCaloRegionizers_[ie].setPipes(em_links_in);
+    emCaloRegionizers_[ie].initTimes();
+    emCaloRegionizers_[ie].run();
+
+    hadCaloRegionizers_[ie].reset();
+    hadCaloRegionizers_[ie].setPipes(calo_links_in);
+    hadCaloRegionizers_[ie].initTimes();
+    hadCaloRegionizers_[ie].run();
+
+    muRegionizers_[ie].reset();
+    muRegionizers_[ie].setPipes(mu_links_in);
+    muRegionizers_[ie].initTimes();
+    muRegionizers_[ie].run();
+  }
+  
+  for (unsigned int ie = 0; ie < netaslices_; ie++) {
+    for (unsigned int ireg = 0; ireg < nregions_; ireg++) {
+      std::vector<l1ct::TkObjEmu> out_tks = tkRegionizers_[ie].getSmallRegion(ireg);
+      if (out_tks.size()>0) {
+        if (dosort_) {
+          std::sort(out_tks.begin(), out_tks.end(), [](const l1ct::TkObjEmu a, const l1ct::TkObjEmu b) {
+            return a > b;
+          });
+        }
+        out[ireg].track = out_tks;
+      }
+      std::vector<l1ct::EmCaloObjEmu> out_emcalos = emCaloRegionizers_[ie].getSmallRegion(ireg);
+      if (out_emcalos.size()>0) {
+        if (dosort_) {
+          std::sort(out_emcalos.begin(), out_emcalos.end(), [](const l1ct::EmCaloObjEmu a, const l1ct::EmCaloObjEmu b) {
+            return a > b;
+          });
+        }
+        out[ireg].emcalo = out_emcalos;
+      }
+      std::vector<l1ct::HadCaloObjEmu> out_hadcalos = hadCaloRegionizers_[ie].getSmallRegion(ireg);
+      if (out_hadcalos.size()>0) {
+        if (dosort_) {
+          std::sort(out_hadcalos.begin(), out_hadcalos.end(), [](const l1ct::HadCaloObjEmu a, const l1ct::HadCaloObjEmu b) {
+            return a > b;
+          });
+        }
+        out[ireg].hadcalo = out_hadcalos;
+      }
+      std::vector<l1ct::MuObjEmu> out_mus = muRegionizers_[ie].getSmallRegion(ireg);
+      if (out_mus.size()>0) {
+        if (dosort_) {
+          std::sort(out_mus.begin(), out_mus.end(), [](const l1ct::MuObjEmu a, const l1ct::MuObjEmu b) {
+            return a > b;
+          });
+        }
+        out[ireg].muon = out_mus;
+      }
+    }
+  }
+}

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/tdr/tdr_regionizer_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/tdr/tdr_regionizer_ref.h
@@ -1,0 +1,67 @@
+#ifndef tdr_regionizer_ref_h
+#define tdr_regionizer_ref_h
+
+#include "../common/regionizer_base_ref.h"
+
+#include "tdr_regionizer_elements_ref.h"
+
+namespace edm {
+  class ParameterSet;
+}
+
+namespace l1ct {
+  class TDRRegionizerEmulator : public RegionizerEmulator {
+  public:
+    TDRRegionizerEmulator(unsigned int netaslices,
+                          unsigned int ntk,
+                          unsigned int ncalo,
+                          unsigned int nem,
+                          unsigned int nmu,
+                          int nclocks,
+                          bool dosort);
+
+    // note: this one will work only in CMSSW
+    TDRRegionizerEmulator(const edm::ParameterSet& iConfig);
+
+    ~TDRRegionizerEmulator() override;
+
+    static const int NTK_SECTORS = 9, NTK_LINKS = 2;  // max objects per sector per clock cycle
+    static const int NCALO_SECTORS = 4, NCALO_LINKS = 4;
+    static const int NEMCALO_SECTORS = 4, NEMCALO_LINKS = 4;
+    static const int NMU_LINKS = 2;
+    static const int MAX_TK_EVT = 108, MAX_EMCALO_EVT = 162, MAX_CALO_EVT = 162, MAX_MU_EVT = 162;//all at TMUX 6, per link
+    //assuming 96b for tracks, 64b for emcalo, calo, mu
+    static const int NUMBER_OF_SMALL_REGIONS = 18;
+    static const int NETA_SMALL = 2;
+
+    void initSectorsAndRegions(const RegionizerDecodedInputs& in, const std::vector<PFInputRegion>& out) override;
+
+    // TODO: implement
+    void run(const RegionizerDecodedInputs& in, std::vector<PFInputRegion>& out) override;
+
+    // link emulation from decoded inputs (for simulation)
+    void fillLinks(const RegionizerDecodedInputs& in, std::vector<std::vector<l1ct::TkObjEmu>>& links);
+    void fillLinks(const RegionizerDecodedInputs& in, std::vector<std::vector<l1ct::HadCaloObjEmu>>& links);
+    void fillLinks(const RegionizerDecodedInputs& in, std::vector<std::vector<l1ct::EmCaloObjEmu>>& links);
+    void fillLinks(const RegionizerDecodedInputs& in, std::vector<std::vector<l1ct::MuObjEmu>>& links);
+
+    // convert links to firmware
+    void toFirmware(const std::vector<l1ct::TkObjEmu>& emu, TkObj fw[NTK_SECTORS][NTK_LINKS]);
+    void toFirmware(const std::vector<l1ct::HadCaloObjEmu>& emu, HadCaloObj fw[NCALO_SECTORS][NCALO_LINKS]);
+    void toFirmware(const std::vector<l1ct::EmCaloObjEmu>& emu, EmCaloObj fw[NCALO_SECTORS][NCALO_LINKS]);
+    void toFirmware(const std::vector<l1ct::MuObjEmu>& emu, MuObj fw[NMU_LINKS]);
+
+  private:
+    unsigned int netaslices_, ntk_, ncalo_, nem_, nmu_, nregions_;
+    int nclocks_;
+    bool dosort_, init_;
+
+    std::vector<tdr_regionizer::Regionizer<l1ct::TkObjEmu>> tkRegionizers_;
+    std::vector<tdr_regionizer::Regionizer<l1ct::HadCaloObjEmu>> hadCaloRegionizers_;
+    std::vector<tdr_regionizer::Regionizer<l1ct::EmCaloObjEmu>> emCaloRegionizers_;
+    std::vector<tdr_regionizer::Regionizer<l1ct::MuObjEmu>> muRegionizers_;
+  };
+
+}  // namespace l1ct
+
+#endif


### PR DESCRIPTION
This adds the barrel regionizer emulator (TDR) to cmssw. It is designed to operate similarly to the endcap regionizer emulator, and can be enabled by setting `regionizerAlgo="TDR"` in the config. An equivalent PR will be made in correlator-common.
