### PR TITLE
Add raw muon inputs (64 bit words) to dump file format

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/emulator_io.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/emulator_io.h
@@ -76,6 +76,26 @@ namespace l1ct {
     return from.good();
   }
 
+  template <int NB>
+  bool writeManyAP(const std::vector<ap_uint<NB>> &objs, std::fstream &to) {
+    uint32_t number = objs.size();
+    writeVar(number, to);
+    for (uint32_t i = 0; i < number; ++i) {
+      writeAP(objs[i], to);
+    }
+    return to.good();
+  }
+
+  template <int NB>
+  bool readManyAP(std::fstream &from, std::vector<ap_uint<NB>> &objs) {
+    uint32_t number = 0;
+    readVar(from, number);
+    objs.resize(number);
+    for (uint32_t i = 0; i < number; ++i)
+      readAP(from, objs[i]);
+    return from.good();
+  }
+
 }  // namespace l1ct
 
 #endif

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/layer1_emulator.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/layer1_emulator.h
@@ -237,6 +237,14 @@ namespace l1ct {
     inline void clear() { obj.clear(); }
   };
 
+  struct RawInputs {
+    DetectorSector<ap_uint<64>> muon;  // muons are global
+
+    bool read(std::fstream &from);
+    bool write(std::fstream &to) const;
+    void clear();
+  };
+
   struct RegionizerDecodedInputs {
     std::vector<DetectorSector<HadCaloObjEmu>> hadcalo;
     std::vector<DetectorSector<EmCaloObjEmu>> emcalo;
@@ -298,9 +306,10 @@ namespace l1ct {
   };
 
   struct Event {
-    static const int VERSION = 7;
+    static const int VERSION = 8;
     uint32_t run, lumi;
     uint64_t event;
+    RawInputs raw;
     RegionizerDecodedInputs decoded;
     std::vector<PFInputRegion> pfinputs;
     std::vector<PVObjEmu> pvs;


### PR DESCRIPTION
Add raw muons in the format specified by the interface document: https://www.overleaf.com/read/ptkfbjyyxcvv
Currently the conversion is done in the correlator code, eventually to be migrated to somewhere in GMT code.