### PR TITLE
Deregionizer Emulator In CMSSW

### DIFF
--- a/DataFormats/L1TParticleFlow/interface/RegionalOutput.h
+++ b/DataFormats/L1TParticleFlow/interface/RegionalOutput.h
@@ -137,8 +137,8 @@ namespace l1t {
     refprod refprod_;
     std::vector<unsigned int> values_;   // list of indices to objects in each region, flattened.
     std::vector<unsigned int> regions_;  // for each region, store the index of one-past the last object in values
-    std::vector<float> etas_;  // floatEtaCenter of each PFregion
-    std::vector<float> phis_;  // floatPhiCenter of each PFregion
+    std::vector<float> etas_;            // floatEtaCenter of each PFregion
+    std::vector<float> phis_;            // floatPhiCenter of each PFregion
   };
 }  // namespace l1t
 #endif

--- a/DataFormats/L1TParticleFlow/interface/RegionalOutput.h
+++ b/DataFormats/L1TParticleFlow/interface/RegionalOutput.h
@@ -93,12 +93,14 @@ namespace l1t {
           : src_(src), ibegin_(ibegin), iend_(iend) {}
     };
 
-    RegionalOutput() : refprod_(), values_(), regions_() {}
-    RegionalOutput(const edm::RefProd<T>& prod) : refprod_(prod), values_(), regions_() {}
+    RegionalOutput() : refprod_(), values_(), regions_(), etas_(), phis_() {}
+    RegionalOutput(const edm::RefProd<T>& prod) : refprod_(prod), values_(), regions_(), etas_(), phis_() {}
 
-    void addRegion(const std::vector<int>& indices) {
+    void addRegion(const std::vector<int>& indices, const float eta, const float phi) {
       regions_.emplace_back((regions_.empty() ? 0 : regions_.back()) + indices.size());
       values_.insert(values_.end(), indices.begin(), indices.end());
+      etas_.push_back(eta);
+      phis_.push_back(phi);
     }
 
     edm::ProductID id() const { return refprod_.id(); }
@@ -108,16 +110,22 @@ namespace l1t {
     void clear() {
       values_.clear();
       regions_.clear();
+      etas_.clear();
+      phis_.clear();
     }
     void shrink_to_fit() {
       values_.shrink_to_fit();
       regions_.shrink_to_fit();
+      etas_.shrink_to_fit();
+      phis_.shrink_to_fit();
     }
 
     const_iterator begin() const { return const_iterator(this, 0); }
     const_iterator end() const { return const_iterator(this, values_.size()); }
 
     Region region(unsigned int ireg) const { return Region(this, ireg == 0 ? 0 : regions_[ireg - 1], regions_[ireg]); }
+    const float eta(unsigned int ireg) const { return etas_[ireg]; }
+    const float phi(unsigned int ireg) const { return phis_[ireg]; }
 
     ref refAt(unsigned int idx) const { return ref(refprod_, values_[idx]); }
     const value_type& objAt(unsigned int idx) const { return (*refprod_)[values_[idx]]; }
@@ -129,6 +137,8 @@ namespace l1t {
     refprod refprod_;
     std::vector<unsigned int> values_;   // list of indices to objects in each region, flattened.
     std::vector<unsigned int> regions_;  // for each region, store the index of one-past the last object in values
+    std::vector<float> etas_;  // floatEtaCenter of each PFregion
+    std::vector<float> phis_;  // floatPhiCenter of each PFregion
   };
 }  // namespace l1t
 #endif

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/DeregionizerProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/DeregionizerProducer.cc
@@ -65,8 +65,10 @@ void DeregionizerProducer::produce(edm::Event &iEvent, const edm::EventSetup &iS
   for (unsigned int iReg = 0, nReg = src->nRegions(); iReg < nReg; ++iReg) {
     l1ct::OutputRegion tempOutputRegion;
 
-    if (debug_) std::cout<<"\nRegion "<<iReg<<"\n"<<"###########"<<"\n";
     auto region = src->region(iReg);
+    float eta = src->eta(iReg);
+    float phi = src->phi(iReg);
+    if (debug_) std::cout<<"\nRegion "<<iReg<<"\n"<<"Eta = "<<eta<<" and Phi = "<<phi<<"\n"<<"###########"<<"\n";
     for (int i = 0, n = region.size(); i < n; ++i) {
       l1ct::PuppiObjEmu tempPuppi;
       const l1t::PFCandidate &cand = region[i];
@@ -80,8 +82,8 @@ void DeregionizerProducer::produce(edm::Event &iEvent, const edm::EventSetup &iS
       if (debug_) std::cout <<"pt["<<i<<"] = "<<tempOutputRegion.puppi.back().hwPt<<", eta["<<i<<"] = "<<tempOutputRegion.puppi.back().floatEta()<<", phi["<<i<<"] = "<<tempOutputRegion.puppi.back().floatPhi()<<"\n";
     }
     if(tempOutputRegion.puppi.size() > 0) {
-      regionEtas.push_back(tempOutputRegion.puppi[0].floatEta());
-      regionPhis.push_back(tempOutputRegion.puppi[0].floatPhi());
+      regionEtas.push_back(eta);
+      regionPhis.push_back(phi);
       outputRegions.push_back(tempOutputRegion);
     }
   }

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/DeregionizerProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/DeregionizerProducer.cc
@@ -1,0 +1,166 @@
+#include <unordered_map>
+
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/L1TParticleFlow/interface/PFCandidate.h"
+
+#include "L1Trigger/Phase2L1ParticleFlow/src/newfirmware/deregionizer/deregionizer_input.h"
+#include "L1Trigger/Phase2L1ParticleFlow/src/newfirmware/deregionizer/deregionizer_ref.h"
+
+
+class DeregionizerProducer : public edm::stream::EDProducer<> {
+  public:
+    explicit DeregionizerProducer(const edm::ParameterSet &);
+    ~DeregionizerProducer() override;
+
+  private:
+    edm::ParameterSet config_;
+    edm::EDGetTokenT<l1t::PFCandidateRegionalOutput> token_;
+    l1ct::DeregionizerEmulator emulator_;
+    bool debug_;
+
+    std::unordered_map<const l1t::PFCandidate *, l1t::PFClusterRef> clusterRefMap_;
+    std::unordered_map<const l1t::PFCandidate *, l1t::PFTrackRef> trackRefMap_;
+    std::unordered_map<const l1t::PFCandidate *, l1t::PFCandidate::MuonRef> muonRefMap_;
+
+    void produce(edm::Event &, const edm::EventSetup &) override;
+    void hwToEdm_(const std::vector<l1ct::PuppiObjEmu> &hwOut, std::vector<l1t::PFCandidate> &edmOut) const;
+    void setRefs_(l1t::PFCandidate &pf, const l1ct::PuppiObjEmu &p) const;
+};
+
+DeregionizerProducer::DeregionizerProducer(const edm::ParameterSet &iConfig)
+  : config_(iConfig),
+    token_(consumes<l1t::PFCandidateRegionalOutput>(iConfig.getParameter<edm::InputTag>("RegionalPuppiCands"))),
+    emulator_(iConfig),
+    debug_(iConfig.getUntrackedParameter<bool>("debug", 0)) {
+  produces<l1t::PFCandidateCollection>("Puppi");
+  produces<l1t::PFCandidateCollection>("TruncatedPuppi");
+}
+
+DeregionizerProducer::~DeregionizerProducer() {}
+
+void DeregionizerProducer::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
+  clusterRefMap_.clear();
+  trackRefMap_.clear();
+  muonRefMap_.clear();
+
+  auto deregColl = std::make_unique<l1t::PFCandidateCollection>();
+  auto truncColl = std::make_unique<l1t::PFCandidateCollection>();
+
+  edm::Handle<l1t::PFCandidateRegionalOutput> src;
+
+  iEvent.getByToken(token_, src);
+
+  std::vector<float> regionEtas, regionPhis;
+  std::vector<l1ct::OutputRegion> outputRegions;
+  std::vector<l1ct::PuppiObjEmu> hwOut;
+  std::vector<l1t::PFCandidate> edmOut;
+  std::vector<l1ct::PuppiObjEmu> hwTruncOut;
+  std::vector<l1t::PFCandidate> edmTruncOut;
+
+  if (debug_) std::cout << "\nRegional Puppi Candidates" << "\n";
+  for (unsigned int iReg = 0, nReg = src->nRegions(); iReg < nReg; ++iReg) {
+    l1ct::OutputRegion tempOutputRegion;
+
+    if (debug_) std::cout<<"\nRegion "<<iReg<<"\n"<<"###########"<<"\n";
+    auto region = src->region(iReg);
+    for (int i = 0, n = region.size(); i < n; ++i) {
+      l1ct::PuppiObjEmu tempPuppi;
+      const l1t::PFCandidate &cand = region[i];
+      clusterRefMap_[&cand] = cand.pfCluster();
+      trackRefMap_[&cand] = cand.pfTrack();
+      muonRefMap_[&cand] = cand.muon();
+
+      tempPuppi.initFromBits(cand.encodedPuppi64());
+      tempPuppi.srcCand = &cand;
+      tempOutputRegion.puppi.push_back(tempPuppi);
+      if (debug_) std::cout <<"pt["<<i<<"] = "<<tempOutputRegion.puppi.back().hwPt<<", eta["<<i<<"] = "<<tempOutputRegion.puppi.back().floatEta()<<", phi["<<i<<"] = "<<tempOutputRegion.puppi.back().floatPhi()<<"\n";
+    }
+    if(tempOutputRegion.puppi.size() > 0) {
+      regionEtas.push_back(tempOutputRegion.puppi[0].floatEta());
+      regionPhis.push_back(tempOutputRegion.puppi[0].floatPhi());
+      outputRegions.push_back(tempOutputRegion);
+    }
+  }
+
+  l1ct::DeregionizerInput in = l1ct::DeregionizerInput(regionEtas, regionPhis, outputRegions);
+  in.setDebug(debug_);
+
+  emulator_.run(in,hwOut,hwTruncOut);
+
+  DeregionizerProducer::hwToEdm_(hwOut,edmOut);
+  DeregionizerProducer::hwToEdm_(hwTruncOut,edmTruncOut);
+
+  deregColl->swap(edmOut);
+  truncColl->swap(edmTruncOut);
+
+  iEvent.put(std::move(deregColl), "Puppi");
+  iEvent.put(std::move(truncColl), "TruncatedPuppi");
+}
+
+void DeregionizerProducer::hwToEdm_(const std::vector<l1ct::PuppiObjEmu> &hwOut, std::vector<l1t::PFCandidate> &edmOut) const {
+  for (const auto &hwPuppi : hwOut) {
+    l1t::PFCandidate::ParticleType type;
+    float mass = 0.13f;
+    if (hwPuppi.hwId.charged()) {
+      if (hwPuppi.hwId.isMuon()) {
+        type = l1t::PFCandidate::Muon;
+        mass = 0.105;
+      } else if (hwPuppi.hwId.isElectron()) {
+        type = l1t::PFCandidate::Electron;
+        mass = 0.005;
+      } else
+        type = l1t::PFCandidate::ChargedHadron;
+    } else {
+      type = hwPuppi.hwId.isPhoton() ? l1t::PFCandidate::Photon : l1t::PFCandidate::NeutralHadron;
+      mass = hwPuppi.hwId.isPhoton() ? 0.0 : 0.5;
+    }
+    reco::Particle::PolarLorentzVector p4(hwPuppi.floatPt(), hwPuppi.floatEta(), hwPuppi.floatPhi(), mass);
+    edmOut.emplace_back(type, hwPuppi.intCharge(), p4, hwPuppi.floatPuppiW(), hwPuppi.intPt(), hwPuppi.intEta(), hwPuppi.intPhi());
+    if (hwPuppi.hwId.charged()) {
+      edmOut.back().setZ0(hwPuppi.floatZ0());
+      edmOut.back().setDxy(hwPuppi.floatDxy());
+      edmOut.back().setHwZ0(hwPuppi.hwZ0());
+      edmOut.back().setHwDxy(hwPuppi.hwDxy());
+      edmOut.back().setHwTkQuality(hwPuppi.hwTkQuality());
+    } else {
+      edmOut.back().setHwPuppiWeight(hwPuppi.hwPuppiW());
+      edmOut.back().setHwEmID(hwPuppi.hwEmID());
+    }
+    edmOut.back().setEncodedPuppi64(hwPuppi.pack().to_uint64());
+    setRefs_(edmOut.back(), hwPuppi);
+  }
+}
+
+void DeregionizerProducer::setRefs_(l1t::PFCandidate &pf, const l1ct::PuppiObjEmu &p) const {
+  if (p.srcCluster) {
+    auto match = clusterRefMap_.find(p.srcCand);
+    if (match == clusterRefMap_.end()) {
+      throw cms::Exception("CorruptData") << "Invalid cluster pointer in PF candidate id " << p.intId() << " pt "
+                                          << p.floatPt() << " eta " << p.floatEta() << " phi " << p.floatPhi();
+    }
+    pf.setPFCluster(match->second);
+  }
+  if (p.srcTrack) {
+    auto match = trackRefMap_.find(p.srcCand);
+    if (match == trackRefMap_.end()) {
+      throw cms::Exception("CorruptData") << "Invalid track pointer in PF candidate id " << p.intId() << " pt "
+                                          << p.floatPt() << " eta " << p.floatEta() << " phi " << p.floatPhi();
+    }
+    pf.setPFTrack(match->second);
+  }
+  if (p.srcMu) {
+    auto match = muonRefMap_.find(p.srcCand);
+    if (match == muonRefMap_.end()) {
+      throw cms::Exception("CorruptData") << "Invalid muon pointer in PF candidate id " << p.intId() << " pt "
+                                          << p.floatPt() << " eta " << p.floatEta() << " phi " << p.floatPhi();
+    }
+    pf.setMuon(match->second);
+  }
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(DeregionizerProducer);

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/DeregionizerProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/DeregionizerProducer.cc
@@ -10,32 +10,31 @@
 #include "L1Trigger/Phase2L1ParticleFlow/src/newfirmware/deregionizer/deregionizer_input.h"
 #include "L1Trigger/Phase2L1ParticleFlow/src/newfirmware/deregionizer/deregionizer_ref.h"
 
-
 class DeregionizerProducer : public edm::stream::EDProducer<> {
-  public:
-    explicit DeregionizerProducer(const edm::ParameterSet &);
-    ~DeregionizerProducer() override;
+public:
+  explicit DeregionizerProducer(const edm::ParameterSet &);
+  ~DeregionizerProducer() override;
 
-  private:
-    edm::ParameterSet config_;
-    edm::EDGetTokenT<l1t::PFCandidateRegionalOutput> token_;
-    l1ct::DeregionizerEmulator emulator_;
-    bool debug_;
+private:
+  edm::ParameterSet config_;
+  edm::EDGetTokenT<l1t::PFCandidateRegionalOutput> token_;
+  l1ct::DeregionizerEmulator emulator_;
+  bool debug_;
 
-    std::unordered_map<const l1t::PFCandidate *, l1t::PFClusterRef> clusterRefMap_;
-    std::unordered_map<const l1t::PFCandidate *, l1t::PFTrackRef> trackRefMap_;
-    std::unordered_map<const l1t::PFCandidate *, l1t::PFCandidate::MuonRef> muonRefMap_;
+  std::unordered_map<const l1t::PFCandidate *, l1t::PFClusterRef> clusterRefMap_;
+  std::unordered_map<const l1t::PFCandidate *, l1t::PFTrackRef> trackRefMap_;
+  std::unordered_map<const l1t::PFCandidate *, l1t::PFCandidate::MuonRef> muonRefMap_;
 
-    void produce(edm::Event &, const edm::EventSetup &) override;
-    void hwToEdm_(const std::vector<l1ct::PuppiObjEmu> &hwOut, std::vector<l1t::PFCandidate> &edmOut) const;
-    void setRefs_(l1t::PFCandidate &pf, const l1ct::PuppiObjEmu &p) const;
+  void produce(edm::Event &, const edm::EventSetup &) override;
+  void hwToEdm_(const std::vector<l1ct::PuppiObjEmu> &hwOut, std::vector<l1t::PFCandidate> &edmOut) const;
+  void setRefs_(l1t::PFCandidate &pf, const l1ct::PuppiObjEmu &p) const;
 };
 
 DeregionizerProducer::DeregionizerProducer(const edm::ParameterSet &iConfig)
-  : config_(iConfig),
-    token_(consumes<l1t::PFCandidateRegionalOutput>(iConfig.getParameter<edm::InputTag>("RegionalPuppiCands"))),
-    emulator_(iConfig),
-    debug_(iConfig.getUntrackedParameter<bool>("debug", 0)) {
+    : config_(iConfig),
+      token_(consumes<l1t::PFCandidateRegionalOutput>(iConfig.getParameter<edm::InputTag>("RegionalPuppiCands"))),
+      emulator_(iConfig),
+      debug_(iConfig.getUntrackedParameter<bool>("debug", 0)) {
   produces<l1t::PFCandidateCollection>("Puppi");
   produces<l1t::PFCandidateCollection>("TruncatedPuppi");
 }
@@ -61,14 +60,18 @@ void DeregionizerProducer::produce(edm::Event &iEvent, const edm::EventSetup &iS
   std::vector<l1ct::PuppiObjEmu> hwTruncOut;
   std::vector<l1t::PFCandidate> edmTruncOut;
 
-  if (debug_) edm::LogPrint("DeregionizerProducer") << "\nRegional Puppi Candidates";
+  if (debug_)
+    edm::LogPrint("DeregionizerProducer") << "\nRegional Puppi Candidates";
   for (unsigned int iReg = 0, nReg = src->nRegions(); iReg < nReg; ++iReg) {
     l1ct::OutputRegion tempOutputRegion;
 
     auto region = src->region(iReg);
     float eta = src->eta(iReg);
     float phi = src->phi(iReg);
-    if (debug_) edm::LogPrint("DeregionizerProducer") <<"\nRegion "<<iReg<<"\n"<<"Eta = "<<eta<<" and Phi = "<<phi<<"\n"<<"###########";
+    if (debug_)
+      edm::LogPrint("DeregionizerProducer") << "\nRegion " << iReg << "\n"
+                                            << "Eta = " << eta << " and Phi = " << phi << "\n"
+                                            << "###########";
     for (int i = 0, n = region.size(); i < n; ++i) {
       l1ct::PuppiObjEmu tempPuppi;
       const l1t::PFCandidate &cand = region[i];
@@ -79,9 +82,12 @@ void DeregionizerProducer::produce(edm::Event &iEvent, const edm::EventSetup &iS
       tempPuppi.initFromBits(cand.encodedPuppi64());
       tempPuppi.srcCand = &cand;
       tempOutputRegion.puppi.push_back(tempPuppi);
-      if (debug_) edm::LogPrint("DeregionizerProducer") <<"pt["<<i<<"] = "<<tempOutputRegion.puppi.back().hwPt<<", eta["<<i<<"] = "<<tempOutputRegion.puppi.back().floatEta()<<", phi["<<i<<"] = "<<tempOutputRegion.puppi.back().floatPhi();
+      if (debug_)
+        edm::LogPrint("DeregionizerProducer") << "pt[" << i << "] = " << tempOutputRegion.puppi.back().hwPt << ", eta["
+                                              << i << "] = " << tempOutputRegion.puppi.back().floatEta() << ", phi["
+                                              << i << "] = " << tempOutputRegion.puppi.back().floatPhi();
     }
-    if(tempOutputRegion.puppi.size() > 0) {
+    if (tempOutputRegion.puppi.size() > 0) {
       regionEtas.push_back(eta);
       regionPhis.push_back(phi);
       outputRegions.push_back(tempOutputRegion);
@@ -91,10 +97,10 @@ void DeregionizerProducer::produce(edm::Event &iEvent, const edm::EventSetup &iS
   l1ct::DeregionizerInput in = l1ct::DeregionizerInput(regionEtas, regionPhis, outputRegions);
   in.setDebug(debug_);
 
-  emulator_.run(in,hwOut,hwTruncOut);
+  emulator_.run(in, hwOut, hwTruncOut);
 
-  DeregionizerProducer::hwToEdm_(hwOut,edmOut);
-  DeregionizerProducer::hwToEdm_(hwTruncOut,edmTruncOut);
+  DeregionizerProducer::hwToEdm_(hwOut, edmOut);
+  DeregionizerProducer::hwToEdm_(hwTruncOut, edmTruncOut);
 
   deregColl->swap(edmOut);
   truncColl->swap(edmTruncOut);
@@ -103,7 +109,8 @@ void DeregionizerProducer::produce(edm::Event &iEvent, const edm::EventSetup &iS
   iEvent.put(std::move(truncColl), "TruncatedPuppi");
 }
 
-void DeregionizerProducer::hwToEdm_(const std::vector<l1ct::PuppiObjEmu> &hwOut, std::vector<l1t::PFCandidate> &edmOut) const {
+void DeregionizerProducer::hwToEdm_(const std::vector<l1ct::PuppiObjEmu> &hwOut,
+                                    std::vector<l1t::PFCandidate> &edmOut) const {
   for (const auto &hwPuppi : hwOut) {
     l1t::PFCandidate::ParticleType type;
     float mass = 0.13f;
@@ -121,7 +128,8 @@ void DeregionizerProducer::hwToEdm_(const std::vector<l1ct::PuppiObjEmu> &hwOut,
       mass = hwPuppi.hwId.isPhoton() ? 0.0 : 0.5;
     }
     reco::Particle::PolarLorentzVector p4(hwPuppi.floatPt(), hwPuppi.floatEta(), hwPuppi.floatPhi(), mass);
-    edmOut.emplace_back(type, hwPuppi.intCharge(), p4, hwPuppi.floatPuppiW(), hwPuppi.intPt(), hwPuppi.intEta(), hwPuppi.intPhi());
+    edmOut.emplace_back(
+        type, hwPuppi.intCharge(), p4, hwPuppi.floatPuppiW(), hwPuppi.intPt(), hwPuppi.intEta(), hwPuppi.intPhi());
     if (hwPuppi.hwId.charged()) {
       edmOut.back().setZ0(hwPuppi.floatZ0());
       edmOut.back().setDxy(hwPuppi.floatDxy());

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/DeregionizerProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/DeregionizerProducer.cc
@@ -61,14 +61,14 @@ void DeregionizerProducer::produce(edm::Event &iEvent, const edm::EventSetup &iS
   std::vector<l1ct::PuppiObjEmu> hwTruncOut;
   std::vector<l1t::PFCandidate> edmTruncOut;
 
-  if (debug_) std::cout << "\nRegional Puppi Candidates" << "\n";
+  if (debug_) edm::LogPrint("DeregionizerProducer") << "\nRegional Puppi Candidates";
   for (unsigned int iReg = 0, nReg = src->nRegions(); iReg < nReg; ++iReg) {
     l1ct::OutputRegion tempOutputRegion;
 
     auto region = src->region(iReg);
     float eta = src->eta(iReg);
     float phi = src->phi(iReg);
-    if (debug_) std::cout<<"\nRegion "<<iReg<<"\n"<<"Eta = "<<eta<<" and Phi = "<<phi<<"\n"<<"###########"<<"\n";
+    if (debug_) edm::LogPrint("DeregionizerProducer") <<"\nRegion "<<iReg<<"\n"<<"Eta = "<<eta<<" and Phi = "<<phi<<"\n"<<"###########";
     for (int i = 0, n = region.size(); i < n; ++i) {
       l1ct::PuppiObjEmu tempPuppi;
       const l1t::PFCandidate &cand = region[i];
@@ -79,7 +79,7 @@ void DeregionizerProducer::produce(edm::Event &iEvent, const edm::EventSetup &iS
       tempPuppi.initFromBits(cand.encodedPuppi64());
       tempPuppi.srcCand = &cand;
       tempOutputRegion.puppi.push_back(tempPuppi);
-      if (debug_) std::cout <<"pt["<<i<<"] = "<<tempOutputRegion.puppi.back().hwPt<<", eta["<<i<<"] = "<<tempOutputRegion.puppi.back().floatEta()<<", phi["<<i<<"] = "<<tempOutputRegion.puppi.back().floatPhi()<<"\n";
+      if (debug_) edm::LogPrint("DeregionizerProducer") <<"pt["<<i<<"] = "<<tempOutputRegion.puppi.back().hwPt<<", eta["<<i<<"] = "<<tempOutputRegion.puppi.back().floatEta()<<", phi["<<i<<"] = "<<tempOutputRegion.puppi.back().floatPhi();
     }
     if(tempOutputRegion.puppi.size() > 0) {
       regionEtas.push_back(eta);
@@ -138,7 +138,7 @@ void DeregionizerProducer::hwToEdm_(const std::vector<l1ct::PuppiObjEmu> &hwOut,
 }
 
 void DeregionizerProducer::setRefs_(l1t::PFCandidate &pf, const l1ct::PuppiObjEmu &p) const {
-  if (p.srcCluster) {
+  if (p.srcCand) {
     auto match = clusterRefMap_.find(p.srcCand);
     if (match == clusterRefMap_.end()) {
       throw cms::Exception("CorruptData") << "Invalid cluster pointer in PF candidate id " << p.intId() << " pt "
@@ -146,7 +146,7 @@ void DeregionizerProducer::setRefs_(l1t::PFCandidate &pf, const l1ct::PuppiObjEm
     }
     pf.setPFCluster(match->second);
   }
-  if (p.srcTrack) {
+  if (p.srcCand) {
     auto match = trackRefMap_.find(p.srcCand);
     if (match == trackRefMap_.end()) {
       throw cms::Exception("CorruptData") << "Invalid track pointer in PF candidate id " << p.intId() << " pt "
@@ -154,7 +154,7 @@ void DeregionizerProducer::setRefs_(l1t::PFCandidate &pf, const l1ct::PuppiObjEm
     }
     pf.setPFTrack(match->second);
   }
-  if (p.srcMu) {
+  if (p.srcCand) {
     auto match = muonRefMap_.find(p.srcCand);
     if (match == muonRefMap_.end()) {
       throw cms::Exception("CorruptData") << "Invalid muon pointer in PF candidate id " << p.intId() << " pt "

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1SeedConePFJetProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1SeedConePFJetProducer.cc
@@ -123,7 +123,7 @@ l1t::PFJet L1SeedConePFJetProducer::makeJet_SW(const std::vector<edm::Ptr<l1t::P
 
 std::vector<l1t::PFJet> L1SeedConePFJetProducer::processEvent_SW(std::vector<edm::Ptr<l1t::PFCandidate>>& work) const {
   // The floating point algorithm simulation
-  std::sort(work.begin(), work.end(), [](edm::Ptr<l1t::PFCandidate> i, edm::Ptr<l1t::PFCandidate> j) {
+  std::stable_sort(work.begin(), work.end(), [](edm::Ptr<l1t::PFCandidate> i, edm::Ptr<l1t::PFCandidate> j) {
     return (i->pt() > j->pt());
   });
   std::vector<l1t::PFJet> jets;

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc
@@ -780,7 +780,7 @@ void L1TCorrelatorLayer1Producer::putPuppi(edm::Event &iEvent) const {
       setRefs_(coll->back(), p);
       nobj.push_back(coll->size() - 1);
     }
-    reg->addRegion(nobj,event_.pfinputs[ir].region.floatEtaCenter(),event_.pfinputs[ir].region.floatPhiCenter());
+    reg->addRegion(nobj, event_.pfinputs[ir].region.floatEtaCenter(), event_.pfinputs[ir].region.floatPhiCenter());
   }
   iEvent.put(std::move(coll), "Puppi");
   iEvent.put(std::move(reg), "PuppiRegional");

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc
@@ -780,7 +780,7 @@ void L1TCorrelatorLayer1Producer::putPuppi(edm::Event &iEvent) const {
       setRefs_(coll->back(), p);
       nobj.push_back(coll->size() - 1);
     }
-    reg->addRegion(nobj);
+    reg->addRegion(nobj,event_.pfinputs[ir].region.floatEtaCenter(),event_.pfinputs[ir].region.floatPhiCenter());
   }
   iEvent.put(std::move(coll), "Puppi");
   iEvent.put(std::move(reg), "PuppiRegional");

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TPFCandMultiMerger.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TPFCandMultiMerger.cc
@@ -80,7 +80,7 @@ void L1TPFCandMultiMerger::produce(edm::StreamID, edm::Event& iEvent, const edm:
           for (auto iter = region.begin(), iend = region.end(); iter != iend; ++iter) {
             keys.push_back(iter.idx() + offset);
           }
-          regout->addRegion(keys);
+          regout->addRegion(keys,src.eta(ireg),src.phi(ireg));
         }
       }
     }

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TPFCandMultiMerger.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TPFCandMultiMerger.cc
@@ -80,7 +80,7 @@ void L1TPFCandMultiMerger::produce(edm::StreamID, edm::Event& iEvent, const edm:
           for (auto iter = region.begin(), iend = region.end(); iter != iend; ++iter) {
             keys.push_back(iter.idx() + offset);
           }
-          regout->addRegion(keys,src.eta(ireg),src.phi(ireg));
+          regout->addRegion(keys, src.eta(ireg), src.phi(ireg));
         }
       }
     }

--- a/L1Trigger/Phase2L1ParticleFlow/python/DeregionizerProducer_cfi.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/DeregionizerProducer_cfi.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+DeregionizerProducer = cms.EDProducer("DeregionizerProducer",
+                           RegionalPuppiCands  = cms.InputTag("l1ctLayer1","PuppiRegional"),
+                           nPuppiFinalBuffer   = cms.uint32(128),
+                           nPuppiPerClk        = cms.uint32(6),
+                           nPuppiFirstBuffers  = cms.uint32(12),
+                           nPuppiSecondBuffers = cms.uint32(32),
+                           nPuppiThirdBuffers  = cms.uint32(64),
+                           debug               = cms.untracked.bool(False)
+                         )

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/deregionizer/deregionizer_input.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/deregionizer/deregionizer_input.cpp
@@ -9,74 +9,84 @@
 #include "../../utils/dbgPrintf.h"
 #endif
 
-l1ct::DeregionizerInput::DeregionizerInput(std::vector<float> &regionEtaCenter, std::vector<float> &regionPhiCenter, const std::vector<l1ct::OutputRegion> &inputRegions)
-  : regionEtaCenter_(regionEtaCenter),
-    regionPhiCenter_(regionPhiCenter) {
-      orderedInRegionsPuppis_ = std::vector<std::vector<std::vector<l1ct::PuppiObjEmu> > >(nEtaRegions);
-      for (int i=0, n=nEtaRegions; i<n; i++) orderedInRegionsPuppis_[i].resize(nPhiRegions);
-      initRegions(inputRegions);
-    }
+l1ct::DeregionizerInput::DeregionizerInput(std::vector<float> &regionEtaCenter,
+                                           std::vector<float> &regionPhiCenter,
+                                           const std::vector<l1ct::OutputRegion> &inputRegions)
+    : regionEtaCenter_(regionEtaCenter), regionPhiCenter_(regionPhiCenter) {
+  orderedInRegionsPuppis_ = std::vector<std::vector<std::vector<l1ct::PuppiObjEmu> > >(nEtaRegions);
+  for (int i = 0, n = nEtaRegions; i < n; i++)
+    orderedInRegionsPuppis_[i].resize(nPhiRegions);
+  initRegions(inputRegions);
+}
 
 // +pi read first & account for 2 small eta regions per phi slice
 unsigned int l1ct::DeregionizerInput::orderRegionsInPhi(const float eta, const float phi, const float etaComp) const {
   unsigned int y;
-  if      ( fabs(phi) < 0.35 ) y =             ( eta < etaComp ? 0 : 1);
-  else if ( fabs(phi) < 1.05 ) y = ( phi > 0 ? ( eta < etaComp ? 2 : 3) : ( eta < etaComp ? 16 : 17) );
-  else if ( fabs(phi) < 1.75 ) y = ( phi > 0 ? ( eta < etaComp ? 4 : 5) : ( eta < etaComp ? 14 : 15) );
-  else if ( fabs(phi) < 2.45 ) y = ( phi > 0 ? ( eta < etaComp ? 6 : 7) : ( eta < etaComp ? 12 : 13) );
-  else                         y = ( phi > 0 ? ( eta < etaComp ? 8 : 9) : ( eta < etaComp ? 10 : 11) );
+  if (fabs(phi) < 0.35)
+    y = (eta < etaComp ? 0 : 1);
+  else if (fabs(phi) < 1.05)
+    y = (phi > 0 ? (eta < etaComp ? 2 : 3) : (eta < etaComp ? 16 : 17));
+  else if (fabs(phi) < 1.75)
+    y = (phi > 0 ? (eta < etaComp ? 4 : 5) : (eta < etaComp ? 14 : 15));
+  else if (fabs(phi) < 2.45)
+    y = (phi > 0 ? (eta < etaComp ? 6 : 7) : (eta < etaComp ? 12 : 13));
+  else
+    y = (phi > 0 ? (eta < etaComp ? 8 : 9) : (eta < etaComp ? 10 : 11));
   return y;
 }
 
 void l1ct::DeregionizerInput::initRegions(const std::vector<l1ct::OutputRegion> &inputRegions) {
-  for (int i=0, n=inputRegions.size(); i<n; i++) {
-    unsigned int x,y;
+  for (int i = 0, n = inputRegions.size(); i < n; i++) {
+    unsigned int x, y;
     float eta = regionEtaCenter_[i];
     float phi = regionPhiCenter_[i];
 
-    if ( fabs(eta) < 0.5 ) {
+    if (fabs(eta) < 0.5) {
       x = 0;
       y = orderRegionsInPhi(eta, phi, 0.0);
-    }
-    else if ( fabs(eta) < 1.5 ) {
+    } else if (fabs(eta) < 1.5) {
       x = (eta < 0.0 ? 1 : 2);
       y = (eta < 0.0 ? orderRegionsInPhi(eta, phi, -1.0) : orderRegionsInPhi(eta, phi, 1.0));
-    }
-    else if ( fabs(eta) < 2.5 ) {
+    } else if (fabs(eta) < 2.5) {
       x = (eta < 0.0 ? 3 : 4);
-      y = orderRegionsInPhi(eta, phi, 999.0); // Send all candidates in 3 clks, then wait 3 clks for the barrel
-    }
-    else /*if ( fabs(eta) < 3.0 )*/{
+      y = orderRegionsInPhi(eta, phi, 999.0);  // Send all candidates in 3 clks, then wait 3 clks for the barrel
+    } else /*if ( fabs(eta) < 3.0 )*/ {
       x = 5;
-      y = orderRegionsInPhi(eta, phi, 0.0); // Send eta<0 in 3 clks, eta>0 in the next 3 clks
+      y = orderRegionsInPhi(eta, phi, 0.0);  // Send eta<0 in 3 clks, eta>0 in the next 3 clks
     }
-    /*else x = 6;*/ // HF
-    
-    orderedInRegionsPuppis_[x][y].insert(orderedInRegionsPuppis_[x][y].end(), inputRegions[i].puppi.begin(), inputRegions[i].puppi.end()); // For now, merging HF with forward HGCal
+    /*else x = 6;*/  // HF
 
-    while (!orderedInRegionsPuppis_[x][y].empty() && orderedInRegionsPuppis_[x][y].back().hwPt == 0) orderedInRegionsPuppis_[x][y].pop_back(); // Zero suppression
+    orderedInRegionsPuppis_[x][y].insert(orderedInRegionsPuppis_[x][y].end(),
+                                         inputRegions[i].puppi.begin(),
+                                         inputRegions[i].puppi.end());  // For now, merging HF with forward HGCal
+
+    while (!orderedInRegionsPuppis_[x][y].empty() && orderedInRegionsPuppis_[x][y].back().hwPt == 0)
+      orderedInRegionsPuppis_[x][y].pop_back();  // Zero suppression
   }
 }
 
 void l1ct::DeregionizerInput::orderRegions(int order[nEtaRegions]) {
   std::vector<std::vector<std::vector<l1ct::PuppiObjEmu> > > tmpOrderedInRegionsPuppis;
-  for (int i=0, n=nEtaRegions; i<n; i++) tmpOrderedInRegionsPuppis.push_back(orderedInRegionsPuppis_[order[i]]);
+  for (int i = 0, n = nEtaRegions; i < n; i++)
+    tmpOrderedInRegionsPuppis.push_back(orderedInRegionsPuppis_[order[i]]);
   orderedInRegionsPuppis_ = tmpOrderedInRegionsPuppis;
 
   if (debug_) {
-    for (int i=0, nx=orderedInRegionsPuppis_.size(); i<nx; i++) {
+    for (int i = 0, nx = orderedInRegionsPuppis_.size(); i < nx; i++) {
       dbgCout() << "\n";
       dbgCout() << "Eta region index : " << i << "\n";
-      for (int j=0, ny=orderedInRegionsPuppis_[i].size(); j<ny; j++) {
+      for (int j = 0, ny = orderedInRegionsPuppis_[i].size(); j < ny; j++) {
         dbgCout() << " ---> Phi region index : " << j << "\n";
-        for (int iPup=0, nPup=orderedInRegionsPuppis_[i][j].size(); iPup<nPup; iPup++) {
-          dbgCout() << "      > puppi[" << iPup << "]" << " pt = " << orderedInRegionsPuppis_[i][j][iPup].hwPt << "\n";
+        for (int iPup = 0, nPup = orderedInRegionsPuppis_[i][j].size(); iPup < nPup; iPup++) {
+          dbgCout() << "      > puppi[" << iPup << "]"
+                    << " pt = " << orderedInRegionsPuppis_[i][j][iPup].hwPt << "\n";
         }
       }
-      dbgCout() << " ----------------- " << "\n";
+      dbgCout() << " ----------------- "
+                << "\n";
     }
-    dbgCout() << "Regions ordered!" << "\n";
+    dbgCout() << "Regions ordered!"
+              << "\n";
     dbgCout() << "\n";
   }
 }
-

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/deregionizer/deregionizer_input.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/deregionizer/deregionizer_input.cpp
@@ -1,0 +1,76 @@
+#include <fstream>
+#include <cmath>
+#include <vector>
+#include "deregionizer_input.h"
+
+l1ct::DeregionizerInput::DeregionizerInput(std::vector<float> &regionEtaCenter, std::vector<float> &regionPhiCenter, const std::vector<l1ct::OutputRegion> &inputRegions)
+  : regionEtaCenter_(regionEtaCenter),
+    regionPhiCenter_(regionPhiCenter) {
+      orderedInRegionsPuppis_ = std::vector<std::vector<std::vector<l1ct::PuppiObjEmu> > >(nEtaRegions);
+      for (int i=0, n=nEtaRegions; i<n; i++) orderedInRegionsPuppis_[i].resize(nPhiRegions);
+      initRegions(inputRegions);
+    }
+
+// +pi read first & account for 2 small eta regions per phi slice
+unsigned int l1ct::DeregionizerInput::orderRegionsInPhi(const float eta, const float phi, const float etaComp) const {
+  unsigned int y;
+  if      ( fabs(phi) < 0.35 ) y =             ( eta < etaComp ? 0 : 1);
+  else if ( fabs(phi) < 1.05 ) y = ( phi > 0 ? ( eta < etaComp ? 2 : 3) : ( eta < etaComp ? 16 : 17) );
+  else if ( fabs(phi) < 1.75 ) y = ( phi > 0 ? ( eta < etaComp ? 4 : 5) : ( eta < etaComp ? 14 : 15) );
+  else if ( fabs(phi) < 2.45 ) y = ( phi > 0 ? ( eta < etaComp ? 6 : 7) : ( eta < etaComp ? 12 : 13) );
+  else                         y = ( phi > 0 ? ( eta < etaComp ? 8 : 9) : ( eta < etaComp ? 10 : 11) );
+  return y;
+}
+
+void l1ct::DeregionizerInput::initRegions(const std::vector<l1ct::OutputRegion> &inputRegions) {
+  for (int i=0, n=inputRegions.size(); i<n; i++) {
+    unsigned int x,y;
+    float eta = regionEtaCenter_[i];
+    float phi = regionPhiCenter_[i];
+
+    if ( fabs(eta) < 0.5 ) {
+      x = 0;
+      y = orderRegionsInPhi(eta, phi, 0.0);
+    }
+    else if ( fabs(eta) < 1.5 ) {
+      x = (eta < 0.0 ? 1 : 2);
+      y = (eta < 0.0 ? orderRegionsInPhi(eta, phi, -1.0) : orderRegionsInPhi(eta, phi, 1.0));
+    }
+    else if ( fabs(eta) < 2.5 ) {
+      x = (eta < 0.0 ? 3 : 4);
+      y = orderRegionsInPhi(eta, phi, 999.0); // Send all candidates in 3 clks, then wait 3 clks for the barrel
+    }
+    else /*if ( fabs(eta) < 3.0 )*/{
+      x = 5;
+      y = orderRegionsInPhi(eta, phi, 0.0); // Send eta<0 in 3 clks, eta>0 in the next 3 clks
+    }
+    /*else x = 6;*/ // HF
+    
+    orderedInRegionsPuppis_[x][y].insert(orderedInRegionsPuppis_[x][y].end(), inputRegions[i].puppi.begin(), inputRegions[i].puppi.end()); // For now, merging HF with forward HGCal
+
+    while (!orderedInRegionsPuppis_[x][y].empty() && orderedInRegionsPuppis_[x][y].back().hwPt == 0) orderedInRegionsPuppis_[x][y].pop_back(); // Zero suppression
+  }
+}
+
+void l1ct::DeregionizerInput::orderRegions(int order[nEtaRegions]) {
+  std::vector<std::vector<std::vector<l1ct::PuppiObjEmu> > > tmpOrderedInRegionsPuppis;
+  for (int i=0, n=nEtaRegions; i<n; i++) tmpOrderedInRegionsPuppis.push_back(orderedInRegionsPuppis_[order[i]]);
+  orderedInRegionsPuppis_ = tmpOrderedInRegionsPuppis;
+
+  if (debug_) {
+    for (int i=0, nx=orderedInRegionsPuppis_.size(); i<nx; i++) {
+      std::cout << std::endl;
+      std::cout << "Eta region index : " << i << std::endl;
+      for (int j=0, ny=orderedInRegionsPuppis_[i].size(); j<ny; j++) {
+        std::cout << " ---> Phi region index : " << j << std::endl;
+        for (int iPup=0, nPup=orderedInRegionsPuppis_[i][j].size(); iPup<nPup; iPup++) {
+          std::cout << "      > puppi[" << iPup << "]" << " pt = " << orderedInRegionsPuppis_[i][j][iPup].hwPt << std::endl;
+        }
+      }
+      std::cout << " ----------------- " << std::endl;
+    }
+    std::cout << "Regions ordered!" << std::endl;
+    std::cout << std::endl;
+  }
+}
+

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/deregionizer/deregionizer_input.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/deregionizer/deregionizer_input.cpp
@@ -3,6 +3,12 @@
 #include <vector>
 #include "deregionizer_input.h"
 
+#ifdef CMSSW_GIT_HASH
+#include "L1Trigger/Phase2L1ParticleFlow/src/dbgPrintf.h"
+#else
+#include "../../utils/dbgPrintf.h"
+#endif
+
 l1ct::DeregionizerInput::DeregionizerInput(std::vector<float> &regionEtaCenter, std::vector<float> &regionPhiCenter, const std::vector<l1ct::OutputRegion> &inputRegions)
   : regionEtaCenter_(regionEtaCenter),
     regionPhiCenter_(regionPhiCenter) {
@@ -59,18 +65,18 @@ void l1ct::DeregionizerInput::orderRegions(int order[nEtaRegions]) {
 
   if (debug_) {
     for (int i=0, nx=orderedInRegionsPuppis_.size(); i<nx; i++) {
-      std::cout << std::endl;
-      std::cout << "Eta region index : " << i << std::endl;
+      dbgCout() << "\n";
+      dbgCout() << "Eta region index : " << i << "\n";
       for (int j=0, ny=orderedInRegionsPuppis_[i].size(); j<ny; j++) {
-        std::cout << " ---> Phi region index : " << j << std::endl;
+        dbgCout() << " ---> Phi region index : " << j << "\n";
         for (int iPup=0, nPup=orderedInRegionsPuppis_[i][j].size(); iPup<nPup; iPup++) {
-          std::cout << "      > puppi[" << iPup << "]" << " pt = " << orderedInRegionsPuppis_[i][j][iPup].hwPt << std::endl;
+          dbgCout() << "      > puppi[" << iPup << "]" << " pt = " << orderedInRegionsPuppis_[i][j][iPup].hwPt << "\n";
         }
       }
-      std::cout << " ----------------- " << std::endl;
+      dbgCout() << " ----------------- " << "\n";
     }
-    std::cout << "Regions ordered!" << std::endl;
-    std::cout << std::endl;
+    dbgCout() << "Regions ordered!" << "\n";
+    dbgCout() << "\n";
   }
 }
 

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/deregionizer/deregionizer_input.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/deregionizer/deregionizer_input.h
@@ -8,31 +8,43 @@
 namespace l1ct {
 
   class DeregionizerInput {
-    public:
-      static const unsigned int nEtaRegions = 6 /*7 with HF*/; // Fold ([-0.5,0.0] and [0.0,+0.5]) and ([+-0.5,+-1.0] and [+-1.0,+-1.5]) eta slices into phi
-      static const unsigned int nPhiRegions = 18; // 9 phi slices * 2 to account for the barrel having x2 PF regions per eta slice in the barrel
+  public:
+    static const unsigned int nEtaRegions =
+        6 /*7 with HF*/;  // Fold ([-0.5,0.0] and [0.0,+0.5]) and ([+-0.5,+-1.0] and [+-1.0,+-1.5]) eta slices into phi
+    static const unsigned int nPhiRegions =
+        18;  // 9 phi slices * 2 to account for the barrel having x2 PF regions per eta slice in the barrel
 
-      DeregionizerInput(std::vector<float> &regionEtaCenter, std::vector<float> &regionPhiCenter, const std::vector<l1ct::OutputRegion> &inputRegions);
+    DeregionizerInput(std::vector<float> &regionEtaCenter,
+                      std::vector<float> &regionPhiCenter,
+                      const std::vector<l1ct::OutputRegion> &inputRegions);
 
-      void setDebug(bool debug = true) { debug_ = debug; }
-      
-      enum regionIndex { centralBarl = 0, negBarl = 1, posBarl = 2, negHGCal = 3, posHGCal = 4, forwardHGCal = 5/*, HF = 6*/ };
-      void orderRegions(int order[nEtaRegions]);
+    void setDebug(bool debug = true) { debug_ = debug; }
 
-      const std::vector<std::vector<std::vector<l1ct::PuppiObjEmu> > > &orderedInRegionsPuppis() const { return orderedInRegionsPuppis_; };
+    enum regionIndex {
+      centralBarl = 0,
+      negBarl = 1,
+      posBarl = 2,
+      negHGCal = 3,
+      posHGCal = 4,
+      forwardHGCal = 5 /*, HF = 6*/
+    };
+    void orderRegions(int order[nEtaRegions]);
 
-    private:
-      std::vector<float> regionEtaCenter_;
-      std::vector<float> regionPhiCenter_;
-      std::vector<std::vector<std::vector<l1ct::PuppiObjEmu> > > orderedInRegionsPuppis_;
+    const std::vector<std::vector<std::vector<l1ct::PuppiObjEmu> > > &orderedInRegionsPuppis() const {
+      return orderedInRegionsPuppis_;
+    };
 
-      bool debug_=false;
+  private:
+    std::vector<float> regionEtaCenter_;
+    std::vector<float> regionPhiCenter_;
+    std::vector<std::vector<std::vector<l1ct::PuppiObjEmu> > > orderedInRegionsPuppis_;
 
-      unsigned int orderRegionsInPhi(const float eta, const float phi, const float etaComp) const;
-      void initRegions(const std::vector<l1ct::OutputRegion> &inputRegions);
- };
+    bool debug_ = false;
+
+    unsigned int orderRegionsInPhi(const float eta, const float phi, const float etaComp) const;
+    void initRegions(const std::vector<l1ct::OutputRegion> &inputRegions);
+  };
 
 }  // namespace l1ct
 
 #endif
-

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/deregionizer/deregionizer_input.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/deregionizer/deregionizer_input.h
@@ -1,0 +1,38 @@
+#ifndef deregionizer_input_h
+#define deregionizer_input_h
+
+#include <fstream>
+#include <vector>
+#include "../dataformats/layer1_emulator.h"
+
+namespace l1ct {
+
+  class DeregionizerInput {
+    public:
+      static const unsigned int nEtaRegions = 6 /*7 with HF*/; // Fold ([-0.5,0.0] and [0.0,+0.5]) and ([+-0.5,+-1.0] and [+-1.0,+-1.5]) eta slices into phi
+      static const unsigned int nPhiRegions = 18; // 9 phi slices * 2 to account for the barrel having x2 PF regions per eta slice in the barrel
+
+      DeregionizerInput(std::vector<float> &regionEtaCenter, std::vector<float> &regionPhiCenter, const std::vector<l1ct::OutputRegion> &inputRegions);
+
+      void setDebug(bool debug = true) { debug_ = debug; }
+      
+      enum regionIndex { centralBarl = 0, negBarl = 1, posBarl = 2, negHGCal = 3, posHGCal = 4, forwardHGCal = 5/*, HF = 6*/ };
+      void orderRegions(int order[nEtaRegions]);
+
+      const std::vector<std::vector<std::vector<l1ct::PuppiObjEmu> > > &orderedInRegionsPuppis() const { return orderedInRegionsPuppis_; };
+
+    private:
+      std::vector<float> regionEtaCenter_;
+      std::vector<float> regionPhiCenter_;
+      std::vector<std::vector<std::vector<l1ct::PuppiObjEmu> > > orderedInRegionsPuppis_;
+
+      bool debug_=false;
+
+      unsigned int orderRegionsInPhi(const float eta, const float phi, const float etaComp) const;
+      void initRegions(const std::vector<l1ct::OutputRegion> &inputRegions);
+ };
+
+}  // namespace l1ct
+
+#endif
+

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/deregionizer/deregionizer_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/deregionizer/deregionizer_ref.cpp
@@ -5,6 +5,7 @@
 
 #ifdef CMSSW_GIT_HASH
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "L1Trigger/Phase2L1ParticleFlow/src/dbgPrintf.h"
 
 l1ct::DeregionizerEmulator::DeregionizerEmulator(const edm::ParameterSet &iConfig)
   : DeregionizerEmulator(
@@ -15,6 +16,8 @@ l1ct::DeregionizerEmulator::DeregionizerEmulator(const edm::ParameterSet &iConfi
     iConfig.getParameter<uint32_t>("nPuppiThirdBuffers")) {
   debug_ = iConfig.getUntrackedParameter<bool>("debug", false);
 }
+#else
+#include "../../utils/dbgPrintf.h"
 #endif
 
 l1ct::DeregionizerEmulator::DeregionizerEmulator(const unsigned int nPuppiFinalBuffer/*=128*/, const unsigned int nPuppiPerClk/*=6*/, const unsigned int nPuppiFirstBuffers/*=12*/, const unsigned int nPuppiSecondBuffers/*=32*/, const unsigned int nPuppiThirdBuffers/*=64*/)
@@ -60,8 +63,8 @@ void l1ct::DeregionizerEmulator::accumulateToY(const unsigned int Y, const std::
 }
 
 static void debugPrint(const std::string &header, const std::vector<l1ct::PuppiObjEmu> &pup) {
-  std::cout << " --> " << header << std::endl;
-  for (unsigned int iPup=0, nPup=pup.size(); iPup<nPup; ++iPup) std::cout << "      > puppi[" << iPup << "] pT = " << pup[iPup].hwPt << std::endl;
+  dbgCout() << " --> " << header << "\n";
+  for (unsigned int iPup=0, nPup=pup.size(); iPup<nPup; ++iPup) dbgCout() << "      > puppi[" << iPup << "] pT = " << pup[iPup].hwPt << "\n";
 }
 
 void l1ct::DeregionizerEmulator::run(const l1ct::DeregionizerInput in, std::vector<l1ct::PuppiObjEmu> &out, std::vector<l1ct::PuppiObjEmu> &truncated) {
@@ -88,29 +91,29 @@ void l1ct::DeregionizerEmulator::run(const l1ct::DeregionizerInput in, std::vect
       accumulateToY(nPuppiFinalBuffer_, buffer012345, out, truncated);
 
       if(debug_) {
-        std::cout << std::endl;
-        std::cout << "Phi region index : " << i <<"," << j << std::endl;
+        dbgCout() << "\n";
+        dbgCout() << "Phi region index : " << i <<"," << j << "\n";
 
         debugPrint("Eta region : 0", subregionPuppis[0]);
         debugPrint("Eta region : 1", subregionPuppis[1]);
         debugPrint("Eta region : 0+1", buffer01);
-        std::cout << "------------------ " << std::endl;
+        dbgCout() << "------------------ " << "\n";
 
         debugPrint("Eta region : 2", subregionPuppis[2]);
         debugPrint("Eta region : 3", subregionPuppis[3]);
         debugPrint("Eta region : 2+3", buffer23);
-        std::cout << "------------------ " << std::endl;
+        dbgCout() << "------------------ " << "\n";
 
         debugPrint("Eta region : 4", subregionPuppis[4]);
         debugPrint("Eta region : 5", subregionPuppis[5]);
         debugPrint("Eta region : 4+5", buffer45);
-        std::cout << "------------------ " << std::endl;
+        dbgCout() << "------------------ " << "\n";
 
         debugPrint("Eta region : 0+1+2+3", buffer0123);
-        std::cout << "------------------ " << std::endl;
+        dbgCout() << "------------------ " << "\n";
 
         debugPrint("Eta region : 0+1+2+3+4+5", buffer012345);
-        std::cout << "------------------ " << std::endl;
+        dbgCout() << "------------------ " << "\n";
 
         debugPrint("Inclusive", out);
       }
@@ -118,10 +121,10 @@ void l1ct::DeregionizerEmulator::run(const l1ct::DeregionizerInput in, std::vect
   }
 
   if(debug_) {
-    std::cout << std::endl;
+    dbgCout() << "\n";
     debugPrint("FINAL ARRAY", out);
-    std::cout << std::endl;
-    std::cout << "Ran successfully!" << std::endl;
+    dbgCout() << "\n";
+    dbgCout() << "Ran successfully!" << "\n";
   }
 }
 

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/deregionizer/deregionizer_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/deregionizer/deregionizer_ref.cpp
@@ -8,123 +8,149 @@
 #include "L1Trigger/Phase2L1ParticleFlow/src/dbgPrintf.h"
 
 l1ct::DeregionizerEmulator::DeregionizerEmulator(const edm::ParameterSet &iConfig)
-  : DeregionizerEmulator(
-    iConfig.getParameter<uint32_t>("nPuppiFinalBuffer"),
-    iConfig.getParameter<uint32_t>("nPuppiPerClk"),
-    iConfig.getParameter<uint32_t>("nPuppiFirstBuffers"),
-    iConfig.getParameter<uint32_t>("nPuppiSecondBuffers"),
-    iConfig.getParameter<uint32_t>("nPuppiThirdBuffers")) {
+    : DeregionizerEmulator(iConfig.getParameter<uint32_t>("nPuppiFinalBuffer"),
+                           iConfig.getParameter<uint32_t>("nPuppiPerClk"),
+                           iConfig.getParameter<uint32_t>("nPuppiFirstBuffers"),
+                           iConfig.getParameter<uint32_t>("nPuppiSecondBuffers"),
+                           iConfig.getParameter<uint32_t>("nPuppiThirdBuffers")) {
   debug_ = iConfig.getUntrackedParameter<bool>("debug", false);
 }
 #else
 #include "../../utils/dbgPrintf.h"
 #endif
 
-l1ct::DeregionizerEmulator::DeregionizerEmulator(const unsigned int nPuppiFinalBuffer/*=128*/, const unsigned int nPuppiPerClk/*=6*/, const unsigned int nPuppiFirstBuffers/*=12*/, const unsigned int nPuppiSecondBuffers/*=32*/, const unsigned int nPuppiThirdBuffers/*=64*/)
-  : nPuppiFinalBuffer_(nPuppiFinalBuffer),
-    nPuppiPerClk_(nPuppiPerClk),
-    nPuppiFirstBuffers_(nPuppiFirstBuffers),
-    nPuppiSecondBuffers_(nPuppiSecondBuffers),
-    nPuppiThirdBuffers_(nPuppiThirdBuffers),
-    debug_(false) {
-  assert(nPuppiPerClk < nPuppiFirstBuffers && nPuppiFirstBuffers < nPuppiSecondBuffers && nPuppiSecondBuffers < nPuppiThirdBuffers && nPuppiThirdBuffers <= nPuppiFinalBuffer);
+l1ct::DeregionizerEmulator::DeregionizerEmulator(const unsigned int nPuppiFinalBuffer /*=128*/,
+                                                 const unsigned int nPuppiPerClk /*=6*/,
+                                                 const unsigned int nPuppiFirstBuffers /*=12*/,
+                                                 const unsigned int nPuppiSecondBuffers /*=32*/,
+                                                 const unsigned int nPuppiThirdBuffers /*=64*/)
+    : nPuppiFinalBuffer_(nPuppiFinalBuffer),
+      nPuppiPerClk_(nPuppiPerClk),
+      nPuppiFirstBuffers_(nPuppiFirstBuffers),
+      nPuppiSecondBuffers_(nPuppiSecondBuffers),
+      nPuppiThirdBuffers_(nPuppiThirdBuffers),
+      debug_(false) {
+  assert(nPuppiPerClk < nPuppiFirstBuffers && nPuppiFirstBuffers < nPuppiSecondBuffers &&
+         nPuppiSecondBuffers < nPuppiThirdBuffers && nPuppiThirdBuffers <= nPuppiFinalBuffer);
 }
 
-std::vector<std::vector<l1ct::PuppiObjEmu> > l1ct::DeregionizerEmulator::splitPFregions(const std::vector<std::vector<std::vector<l1ct::PuppiObjEmu> > > &regionPuppis, const int i, const int j) {
-  int k=nPuppiPerClk_*j;
+std::vector<std::vector<l1ct::PuppiObjEmu> > l1ct::DeregionizerEmulator::splitPFregions(
+    const std::vector<std::vector<std::vector<l1ct::PuppiObjEmu> > > &regionPuppis, const int i, const int j) {
+  int k = nPuppiPerClk_ * j;
   std::vector<std::vector<l1ct::PuppiObjEmu> > subregionPuppis;
-  for (int l=0, n=regionPuppis.size(); l<n; l++) {
+  for (int l = 0, n = regionPuppis.size(); l < n; l++) {
     const auto &puppis = regionPuppis[l][i];
-    std::vector<l1ct::PuppiObjEmu> tmp(std::min(puppis.begin()+k, puppis.end()),std::min(puppis.begin()+k+nPuppiPerClk_, puppis.end()));
+    std::vector<l1ct::PuppiObjEmu> tmp(std::min(puppis.begin() + k, puppis.end()),
+                                       std::min(puppis.begin() + k + nPuppiPerClk_, puppis.end()));
     subregionPuppis.push_back(tmp);
   }
   return subregionPuppis;
 }
 
-std::vector<l1ct::PuppiObjEmu> l1ct::DeregionizerEmulator::mergeXtoY(const unsigned int X, const unsigned int Y, const std::vector<l1ct::PuppiObjEmu> &inLeft, const std::vector<l1ct::PuppiObjEmu> &inRight) {
+std::vector<l1ct::PuppiObjEmu> l1ct::DeregionizerEmulator::mergeXtoY(const unsigned int X,
+                                                                     const unsigned int Y,
+                                                                     const std::vector<l1ct::PuppiObjEmu> &inLeft,
+                                                                     const std::vector<l1ct::PuppiObjEmu> &inRight) {
   std::vector<l1ct::PuppiObjEmu> out;
-    
-  out.insert(out.end(), inLeft.begin(), std::min(inLeft.end(), inLeft.begin()+X));
-  out.insert(out.end(), inRight.begin(), std::min(inRight.end(), inRight.begin()+Y-X));
+
+  out.insert(out.end(), inLeft.begin(), std::min(inLeft.end(), inLeft.begin() + X));
+  out.insert(out.end(), inRight.begin(), std::min(inRight.end(), inRight.begin() + Y - X));
 
   return out;
 }
 
-void l1ct::DeregionizerEmulator::accumulateToY(const unsigned int Y, const std::vector<l1ct::PuppiObjEmu> &in, std::vector<l1ct::PuppiObjEmu> &out, std::vector<l1ct::PuppiObjEmu> &truncated) {
+void l1ct::DeregionizerEmulator::accumulateToY(const unsigned int Y,
+                                               const std::vector<l1ct::PuppiObjEmu> &in,
+                                               std::vector<l1ct::PuppiObjEmu> &out,
+                                               std::vector<l1ct::PuppiObjEmu> &truncated) {
   unsigned int initialOutSize = out.size();
   assert(initialOutSize <= Y);
   if (initialOutSize == Y) {
     truncated.insert(truncated.end(), in.begin(), in.end());
     return;
   }
-  out.insert(out.end(), in.begin(), std::min(in.end(), in.begin()+Y-initialOutSize));
-  if (out.size() == Y) truncated.insert(truncated.end(), in.begin()+Y-initialOutSize, in.end());
+  out.insert(out.end(), in.begin(), std::min(in.end(), in.begin() + Y - initialOutSize));
+  if (out.size() == Y)
+    truncated.insert(truncated.end(), in.begin() + Y - initialOutSize, in.end());
   return;
 }
 
 static void debugPrint(const std::string &header, const std::vector<l1ct::PuppiObjEmu> &pup) {
   dbgCout() << " --> " << header << "\n";
-  for (unsigned int iPup=0, nPup=pup.size(); iPup<nPup; ++iPup) dbgCout() << "      > puppi[" << iPup << "] pT = " << pup[iPup].hwPt << "\n";
+  for (unsigned int iPup = 0, nPup = pup.size(); iPup < nPup; ++iPup)
+    dbgCout() << "      > puppi[" << iPup << "] pT = " << pup[iPup].hwPt << "\n";
 }
 
-void l1ct::DeregionizerEmulator::run(const l1ct::DeregionizerInput in, std::vector<l1ct::PuppiObjEmu> &out, std::vector<l1ct::PuppiObjEmu> &truncated) {
+void l1ct::DeregionizerEmulator::run(const l1ct::DeregionizerInput in,
+                                     std::vector<l1ct::PuppiObjEmu> &out,
+                                     std::vector<l1ct::PuppiObjEmu> &truncated) {
   const auto &regionPuppis = in.orderedInRegionsPuppis();
   std::vector<l1ct::PuppiObjEmu> intermediateTruncated;
 
-  for (int i=0, n=in.nPhiRegions; i<n; i++) {
+  for (int i = 0, n = in.nPhiRegions; i < n; i++) {
     // Each PF region (containing at most 18 puppi candidates) is split in 3(*nPuppiPerClk=18)
-    for (int j=0; j<3; j++) {
-      std::vector<std::vector<l1ct::PuppiObjEmu> > subregionPuppis = splitPFregions(regionPuppis,i,j);
+    for (int j = 0; j < 3; j++) {
+      std::vector<std::vector<l1ct::PuppiObjEmu> > subregionPuppis = splitPFregions(regionPuppis, i, j);
 
       // Merge PF regions in pairs
-      std::vector<l1ct::PuppiObjEmu> buffer01 = mergeXtoY(nPuppiPerClk_, nPuppiFirstBuffers_, subregionPuppis[0], subregionPuppis[1]);
-      std::vector<l1ct::PuppiObjEmu> buffer23 = mergeXtoY(nPuppiPerClk_, nPuppiFirstBuffers_, subregionPuppis[2], subregionPuppis[3]);
-      std::vector<l1ct::PuppiObjEmu> buffer45 = mergeXtoY(nPuppiPerClk_, nPuppiFirstBuffers_, subregionPuppis[4], subregionPuppis[5]);
+      std::vector<l1ct::PuppiObjEmu> buffer01 =
+          mergeXtoY(nPuppiPerClk_, nPuppiFirstBuffers_, subregionPuppis[0], subregionPuppis[1]);
+      std::vector<l1ct::PuppiObjEmu> buffer23 =
+          mergeXtoY(nPuppiPerClk_, nPuppiFirstBuffers_, subregionPuppis[2], subregionPuppis[3]);
+      std::vector<l1ct::PuppiObjEmu> buffer45 =
+          mergeXtoY(nPuppiPerClk_, nPuppiFirstBuffers_, subregionPuppis[4], subregionPuppis[5]);
 
       // Merge 4 first regions together, forward the last 2
-      std::vector<l1ct::PuppiObjEmu> buffer0123 = mergeXtoY(nPuppiFirstBuffers_, nPuppiSecondBuffers_, buffer01, buffer23);
+      std::vector<l1ct::PuppiObjEmu> buffer0123 =
+          mergeXtoY(nPuppiFirstBuffers_, nPuppiSecondBuffers_, buffer01, buffer23);
       std::vector<l1ct::PuppiObjEmu> buffer45ext;
       accumulateToY(nPuppiSecondBuffers_, buffer45, buffer45ext, intermediateTruncated);
 
       // Merge all regions together and forward them to the final buffer
-      std::vector<l1ct::PuppiObjEmu> buffer012345 = mergeXtoY(nPuppiSecondBuffers_, nPuppiThirdBuffers_, buffer0123, buffer45ext);
+      std::vector<l1ct::PuppiObjEmu> buffer012345 =
+          mergeXtoY(nPuppiSecondBuffers_, nPuppiThirdBuffers_, buffer0123, buffer45ext);
       accumulateToY(nPuppiFinalBuffer_, buffer012345, out, truncated);
 
-      if(debug_) {
+      if (debug_) {
         dbgCout() << "\n";
-        dbgCout() << "Phi region index : " << i <<"," << j << "\n";
+        dbgCout() << "Phi region index : " << i << "," << j << "\n";
 
         debugPrint("Eta region : 0", subregionPuppis[0]);
         debugPrint("Eta region : 1", subregionPuppis[1]);
         debugPrint("Eta region : 0+1", buffer01);
-        dbgCout() << "------------------ " << "\n";
+        dbgCout() << "------------------ "
+                  << "\n";
 
         debugPrint("Eta region : 2", subregionPuppis[2]);
         debugPrint("Eta region : 3", subregionPuppis[3]);
         debugPrint("Eta region : 2+3", buffer23);
-        dbgCout() << "------------------ " << "\n";
+        dbgCout() << "------------------ "
+                  << "\n";
 
         debugPrint("Eta region : 4", subregionPuppis[4]);
         debugPrint("Eta region : 5", subregionPuppis[5]);
         debugPrint("Eta region : 4+5", buffer45);
-        dbgCout() << "------------------ " << "\n";
+        dbgCout() << "------------------ "
+                  << "\n";
 
         debugPrint("Eta region : 0+1+2+3", buffer0123);
-        dbgCout() << "------------------ " << "\n";
+        dbgCout() << "------------------ "
+                  << "\n";
 
         debugPrint("Eta region : 0+1+2+3+4+5", buffer012345);
-        dbgCout() << "------------------ " << "\n";
+        dbgCout() << "------------------ "
+                  << "\n";
 
         debugPrint("Inclusive", out);
       }
     }
   }
 
-  if(debug_) {
+  if (debug_) {
     dbgCout() << "\n";
     debugPrint("FINAL ARRAY", out);
     dbgCout() << "\n";
-    dbgCout() << "Ran successfully!" << "\n";
+    dbgCout() << "Ran successfully!"
+              << "\n";
   }
 }
-

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/deregionizer/deregionizer_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/deregionizer/deregionizer_ref.cpp
@@ -1,0 +1,127 @@
+#include "deregionizer_ref.h"
+
+#include <cstdio>
+#include <vector>
+
+#ifdef CMSSW_GIT_HASH
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+l1ct::DeregionizerEmulator::DeregionizerEmulator(const edm::ParameterSet &iConfig)
+  : DeregionizerEmulator(
+    iConfig.getParameter<uint32_t>("nPuppiFinalBuffer"),
+    iConfig.getParameter<uint32_t>("nPuppiPerClk"),
+    iConfig.getParameter<uint32_t>("nPuppiFirstBuffers"),
+    iConfig.getParameter<uint32_t>("nPuppiSecondBuffers"),
+    iConfig.getParameter<uint32_t>("nPuppiThirdBuffers")) {
+  debug_ = iConfig.getUntrackedParameter<bool>("debug", false);
+}
+#endif
+
+l1ct::DeregionizerEmulator::DeregionizerEmulator(const unsigned int nPuppiFinalBuffer/*=128*/, const unsigned int nPuppiPerClk/*=6*/, const unsigned int nPuppiFirstBuffers/*=12*/, const unsigned int nPuppiSecondBuffers/*=32*/, const unsigned int nPuppiThirdBuffers/*=64*/)
+  : nPuppiFinalBuffer_(nPuppiFinalBuffer),
+    nPuppiPerClk_(nPuppiPerClk),
+    nPuppiFirstBuffers_(nPuppiFirstBuffers),
+    nPuppiSecondBuffers_(nPuppiSecondBuffers),
+    nPuppiThirdBuffers_(nPuppiThirdBuffers),
+    debug_(false) {
+  assert(nPuppiPerClk < nPuppiFirstBuffers && nPuppiFirstBuffers < nPuppiSecondBuffers && nPuppiSecondBuffers < nPuppiThirdBuffers && nPuppiThirdBuffers <= nPuppiFinalBuffer);
+}
+
+std::vector<std::vector<l1ct::PuppiObjEmu> > l1ct::DeregionizerEmulator::splitPFregions(const std::vector<std::vector<std::vector<l1ct::PuppiObjEmu> > > &regionPuppis, const int i, const int j) {
+  int k=nPuppiPerClk_*j;
+  std::vector<std::vector<l1ct::PuppiObjEmu> > subregionPuppis;
+  for (int l=0, n=regionPuppis.size(); l<n; l++) {
+    const auto &puppis = regionPuppis[l][i];
+    std::vector<l1ct::PuppiObjEmu> tmp(std::min(puppis.begin()+k, puppis.end()),std::min(puppis.begin()+k+nPuppiPerClk_, puppis.end()));
+    subregionPuppis.push_back(tmp);
+  }
+  return subregionPuppis;
+}
+
+std::vector<l1ct::PuppiObjEmu> l1ct::DeregionizerEmulator::mergeXtoY(const unsigned int X, const unsigned int Y, const std::vector<l1ct::PuppiObjEmu> &inLeft, const std::vector<l1ct::PuppiObjEmu> &inRight) {
+  std::vector<l1ct::PuppiObjEmu> out;
+    
+  out.insert(out.end(), inLeft.begin(), std::min(inLeft.end(), inLeft.begin()+X));
+  out.insert(out.end(), inRight.begin(), std::min(inRight.end(), inRight.begin()+Y-X));
+
+  return out;
+}
+
+void l1ct::DeregionizerEmulator::accumulateToY(const unsigned int Y, const std::vector<l1ct::PuppiObjEmu> &in, std::vector<l1ct::PuppiObjEmu> &out, std::vector<l1ct::PuppiObjEmu> &truncated) {
+  unsigned int initialOutSize = out.size();
+  assert(initialOutSize <= Y);
+  if (initialOutSize == Y) {
+    truncated.insert(truncated.end(), in.begin(), in.end());
+    return;
+  }
+  out.insert(out.end(), in.begin(), std::min(in.end(), in.begin()+Y-initialOutSize));
+  if (out.size() == Y) truncated.insert(truncated.end(), in.begin()+Y-initialOutSize, in.end());
+  return;
+}
+
+static void debugPrint(const std::string &header, const std::vector<l1ct::PuppiObjEmu> &pup) {
+  std::cout << " --> " << header << std::endl;
+  for (unsigned int iPup=0, nPup=pup.size(); iPup<nPup; ++iPup) std::cout << "      > puppi[" << iPup << "] pT = " << pup[iPup].hwPt << std::endl;
+}
+
+void l1ct::DeregionizerEmulator::run(const l1ct::DeregionizerInput in, std::vector<l1ct::PuppiObjEmu> &out, std::vector<l1ct::PuppiObjEmu> &truncated) {
+  const auto &regionPuppis = in.orderedInRegionsPuppis();
+  std::vector<l1ct::PuppiObjEmu> intermediateTruncated;
+
+  for (int i=0, n=in.nPhiRegions; i<n; i++) {
+    // Each PF region (containing at most 18 puppi candidates) is split in 3(*nPuppiPerClk=18)
+    for (int j=0; j<3; j++) {
+      std::vector<std::vector<l1ct::PuppiObjEmu> > subregionPuppis = splitPFregions(regionPuppis,i,j);
+
+      // Merge PF regions in pairs
+      std::vector<l1ct::PuppiObjEmu> buffer01 = mergeXtoY(nPuppiPerClk_, nPuppiFirstBuffers_, subregionPuppis[0], subregionPuppis[1]);
+      std::vector<l1ct::PuppiObjEmu> buffer23 = mergeXtoY(nPuppiPerClk_, nPuppiFirstBuffers_, subregionPuppis[2], subregionPuppis[3]);
+      std::vector<l1ct::PuppiObjEmu> buffer45 = mergeXtoY(nPuppiPerClk_, nPuppiFirstBuffers_, subregionPuppis[4], subregionPuppis[5]);
+
+      // Merge 4 first regions together, forward the last 2
+      std::vector<l1ct::PuppiObjEmu> buffer0123 = mergeXtoY(nPuppiFirstBuffers_, nPuppiSecondBuffers_, buffer01, buffer23);
+      std::vector<l1ct::PuppiObjEmu> buffer45ext;
+      accumulateToY(nPuppiSecondBuffers_, buffer45, buffer45ext, intermediateTruncated);
+
+      // Merge all regions together and forward them to the final buffer
+      std::vector<l1ct::PuppiObjEmu> buffer012345 = mergeXtoY(nPuppiSecondBuffers_, nPuppiThirdBuffers_, buffer0123, buffer45ext);
+      accumulateToY(nPuppiFinalBuffer_, buffer012345, out, truncated);
+
+      if(debug_) {
+        std::cout << std::endl;
+        std::cout << "Phi region index : " << i <<"," << j << std::endl;
+
+        debugPrint("Eta region : 0", subregionPuppis[0]);
+        debugPrint("Eta region : 1", subregionPuppis[1]);
+        debugPrint("Eta region : 0+1", buffer01);
+        std::cout << "------------------ " << std::endl;
+
+        debugPrint("Eta region : 2", subregionPuppis[2]);
+        debugPrint("Eta region : 3", subregionPuppis[3]);
+        debugPrint("Eta region : 2+3", buffer23);
+        std::cout << "------------------ " << std::endl;
+
+        debugPrint("Eta region : 4", subregionPuppis[4]);
+        debugPrint("Eta region : 5", subregionPuppis[5]);
+        debugPrint("Eta region : 4+5", buffer45);
+        std::cout << "------------------ " << std::endl;
+
+        debugPrint("Eta region : 0+1+2+3", buffer0123);
+        std::cout << "------------------ " << std::endl;
+
+        debugPrint("Eta region : 0+1+2+3+4+5", buffer012345);
+        std::cout << "------------------ " << std::endl;
+
+        debugPrint("Inclusive", out);
+      }
+    }
+  }
+
+  if(debug_) {
+    std::cout << std::endl;
+    debugPrint("FINAL ARRAY", out);
+    std::cout << std::endl;
+    std::cout << "Ran successfully!" << std::endl;
+  }
+}
+

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/deregionizer/deregionizer_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/deregionizer/deregionizer_ref.h
@@ -1,0 +1,41 @@
+#ifndef deregionizer_ref_h
+#define deregionizer_ref_h
+
+#include <vector>
+#include "deregionizer_input.h"
+
+namespace edm {
+  class ParameterSet;
+}
+
+namespace l1ct {
+
+  class DeregionizerEmulator {
+    public:
+      DeregionizerEmulator(const unsigned int nPuppiFinalBuffer=128, const unsigned int nPuppiPerClk=6, const unsigned int nPuppiFirstBuffers=12, const unsigned int nPuppiSecondBuffers=32, const unsigned int nPuppiThirdBuffers=64);
+
+      // note: this one will work only in CMSSW
+      DeregionizerEmulator(const edm::ParameterSet &iConfig);
+
+      ~DeregionizerEmulator() {};
+
+      void setDebug(bool debug = true) { debug_ = debug; }
+
+      void run(const DeregionizerInput in, std::vector<l1ct::PuppiObjEmu> &out, std::vector<l1ct::PuppiObjEmu> &truncated);
+
+    private:
+      unsigned int nPuppiFinalBuffer_, nPuppiPerClk_, nPuppiFirstBuffers_, nPuppiSecondBuffers_, nPuppiThirdBuffers_;
+      bool debug_;
+
+      std::vector<std::vector<l1ct::PuppiObjEmu> > splitPFregions(const std::vector<std::vector<std::vector<l1ct::PuppiObjEmu> > > &regionPuppis, const int i, const int j);
+
+      static std::vector<l1ct::PuppiObjEmu> mergeXtoY(const unsigned int X, const unsigned int Y, const std::vector<l1ct::PuppiObjEmu> &inLeft, const std::vector<l1ct::PuppiObjEmu> &inRight);
+
+      static void accumulateToY(const unsigned int Y, const std::vector<l1ct::PuppiObjEmu> &in, std::vector<l1ct::PuppiObjEmu> &out, std::vector<l1ct::PuppiObjEmu> &truncated);
+
+  };
+
+}  // namespace l1ct
+
+#endif
+

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/deregionizer/deregionizer_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/deregionizer/deregionizer_ref.h
@@ -11,31 +11,42 @@ namespace edm {
 namespace l1ct {
 
   class DeregionizerEmulator {
-    public:
-      DeregionizerEmulator(const unsigned int nPuppiFinalBuffer=128, const unsigned int nPuppiPerClk=6, const unsigned int nPuppiFirstBuffers=12, const unsigned int nPuppiSecondBuffers=32, const unsigned int nPuppiThirdBuffers=64);
+  public:
+    DeregionizerEmulator(const unsigned int nPuppiFinalBuffer = 128,
+                         const unsigned int nPuppiPerClk = 6,
+                         const unsigned int nPuppiFirstBuffers = 12,
+                         const unsigned int nPuppiSecondBuffers = 32,
+                         const unsigned int nPuppiThirdBuffers = 64);
 
-      // note: this one will work only in CMSSW
-      DeregionizerEmulator(const edm::ParameterSet &iConfig);
+    // note: this one will work only in CMSSW
+    DeregionizerEmulator(const edm::ParameterSet &iConfig);
 
-      ~DeregionizerEmulator() {};
+    ~DeregionizerEmulator(){};
 
-      void setDebug(bool debug = true) { debug_ = debug; }
+    void setDebug(bool debug = true) { debug_ = debug; }
 
-      void run(const DeregionizerInput in, std::vector<l1ct::PuppiObjEmu> &out, std::vector<l1ct::PuppiObjEmu> &truncated);
+    void run(const DeregionizerInput in,
+             std::vector<l1ct::PuppiObjEmu> &out,
+             std::vector<l1ct::PuppiObjEmu> &truncated);
 
-    private:
-      unsigned int nPuppiFinalBuffer_, nPuppiPerClk_, nPuppiFirstBuffers_, nPuppiSecondBuffers_, nPuppiThirdBuffers_;
-      bool debug_;
+  private:
+    unsigned int nPuppiFinalBuffer_, nPuppiPerClk_, nPuppiFirstBuffers_, nPuppiSecondBuffers_, nPuppiThirdBuffers_;
+    bool debug_;
 
-      std::vector<std::vector<l1ct::PuppiObjEmu> > splitPFregions(const std::vector<std::vector<std::vector<l1ct::PuppiObjEmu> > > &regionPuppis, const int i, const int j);
+    std::vector<std::vector<l1ct::PuppiObjEmu> > splitPFregions(
+        const std::vector<std::vector<std::vector<l1ct::PuppiObjEmu> > > &regionPuppis, const int i, const int j);
 
-      static std::vector<l1ct::PuppiObjEmu> mergeXtoY(const unsigned int X, const unsigned int Y, const std::vector<l1ct::PuppiObjEmu> &inLeft, const std::vector<l1ct::PuppiObjEmu> &inRight);
+    static std::vector<l1ct::PuppiObjEmu> mergeXtoY(const unsigned int X,
+                                                    const unsigned int Y,
+                                                    const std::vector<l1ct::PuppiObjEmu> &inLeft,
+                                                    const std::vector<l1ct::PuppiObjEmu> &inRight);
 
-      static void accumulateToY(const unsigned int Y, const std::vector<l1ct::PuppiObjEmu> &in, std::vector<l1ct::PuppiObjEmu> &out, std::vector<l1ct::PuppiObjEmu> &truncated);
-
+    static void accumulateToY(const unsigned int Y,
+                              const std::vector<l1ct::PuppiObjEmu> &in,
+                              std::vector<l1ct::PuppiObjEmu> &out,
+                              std::vector<l1ct::PuppiObjEmu> &truncated);
   };
 
 }  // namespace l1ct
 
 #endif
-


### PR DESCRIPTION
This PR integrates the correlator layer-2 deregionizer emulator into CMSSW.

Once we are happy with this PR, I plan to transfer the updates that apply to the standalone emulator also to the `correlator-common` repo as well.

