### PR TITLE
WIP: equip to write decoded tracks to the event

### DIFF
--- a/DataFormats/L1TParticleFlow/interface/PFCandidate.h
+++ b/DataFormats/L1TParticleFlow/interface/PFCandidate.h
@@ -48,9 +48,14 @@ namespace l1t {
 
     void setZ0(float z0) { setVertex(reco::Particle::Point(0, 0, z0)); }
     void setDxy(float dxy) { dxy_ = dxy; }
+    void setCaloEta(float caloeta) { caloEta_ = caloeta; }
+    void setCaloPhi(float calophi) { caloPhi_ = calophi; }
+
 
     float z0() const { return vz(); }
     float dxy() const { return dxy_; }
+    float caloEta() const { return caloEta_; }
+    float caloPhi() const { return caloPhi_; }
 
     int16_t hwZ0() const { return hwZ0_; }
     int16_t hwDxy() const { return hwDxy_; }
@@ -70,7 +75,7 @@ namespace l1t {
     PFClusterRef clusterRef_;
     PFTrackRef trackRef_;
     MuonRef muonRef_;
-    float dxy_, puppiWeight_;
+    float dxy_, puppiWeight_, caloEta_, caloPhi_;
 
     int16_t hwZ0_, hwDxy_;
     uint16_t hwTkQuality_, hwPuppiWeight_, hwEmID_;

--- a/DataFormats/L1TParticleFlow/src/PFCandidate.cc
+++ b/DataFormats/L1TParticleFlow/src/PFCandidate.cc
@@ -5,6 +5,8 @@ l1t::PFCandidate::PFCandidate(
     : L1Candidate(p, hwpt, hweta, hwphi, /*hwQuality=*/int(kind)),
       dxy_(0),
       puppiWeight_(puppiWeight),
+      caloEta_(0),
+      caloPhi_(0),
       hwZ0_(0),
       hwDxy_(0),
       hwTkQuality_(0),

--- a/DataFormats/L1TParticleFlow/src/classes_def.xml
+++ b/DataFormats/L1TParticleFlow/src/classes_def.xml
@@ -19,7 +19,8 @@
   <class name="edm::RefVector<l1t::PFTrackCollection>" /> 
   <class name="std::vector<edm::Ref<l1t::PFTrackCollection> >" />
 
-  <class name="l1t::PFCandidate"  ClassVersion="5">
+  <class name="l1t::PFCandidate"  ClassVersion="6">
+        <version ClassVersion="6" checksum="2213464616"/>
         <version ClassVersion="5" checksum="3777180193"/>
         <version ClassVersion="4" checksum="3798885201"/>
         <version ClassVersion="3" checksum="4253860178"/>
@@ -60,4 +61,3 @@
   <class name="edm::RefVector<l1t::HPSPFTauCollection>" />
   <class name="std::vector<edm::Ref<l1t::HPSPFTauCollection> >" />
 </lcgdict>
-

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc
@@ -799,6 +799,9 @@ std::unique_ptr<l1t::PFCandidateCollection> L1TCorrelatorLayer1Producer::fetchPF
       ret->back().setHwZ0(p.hwZ0);
       ret->back().setHwDxy(p.hwDxy);
       ret->back().setHwTkQuality(p.hwTkQuality);
+      ret->back().setCaloEta(reg.floatGlbEtaOf(p));
+      ret->back().setCaloPhi(reg.floatGlbPhiOf(p));
+      
       setRefs_(ret->back(), p);
     }
     for (const auto &p : event_.out[ir].pfneutral) {
@@ -809,6 +812,8 @@ std::unique_ptr<l1t::PFCandidateCollection> L1TCorrelatorLayer1Producer::fetchPF
           p.hwId.isPhoton() ? l1t::PFCandidate::Photon : l1t::PFCandidate::NeutralHadron;
       ret->emplace_back(type, 0, p4, 1, p.intPt(), p.intEta(), p.intPhi());
       ret->back().setHwEmID(p.hwEmID);
+      ret->back().setCaloEta(reg.floatGlbEtaOf(p));
+      ret->back().setCaloPhi(reg.floatGlbPhiOf(p));
       setRefs_(ret->back(), p);
     }
   }


### PR DESCRIPTION
#### PR description:

Equip the `L1TCorrelatorProducer` to write the decoded tracks to the event.
This turned to be quite useful for offline debugging of the extrapolation.

Need to decide how to configure the option, shall we use a `define` statement?

