### PR TITLE
PFAlgo3 optimization and emulator bugfix

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/pf/pfalgo3_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/pf/pfalgo3_ref.cpp
@@ -62,7 +62,7 @@ int l1ct::PFAlgo3Emulator::tk_best_match_ref(unsigned int dR2MAX,
                                              const std::vector<l1ct::EmCaloObjEmu>& calo,
                                              const l1ct::TkObjEmu& track) const {
   int drmin = dR2MAX, ibest = -1;
-  for (unsigned int ic = 0, nCAL = calo.size(); ic < nCAL; ++ic) {
+  for (unsigned int ic = 0, nCAL = std::min<unsigned>(nEMCALO_,calo.size()); ic < nCAL; ++ic) {
     if (calo[ic].hwPt <= 0)
       continue;
     int dr = dr2_int(track.hwEta, track.hwPhi, calo[ic].hwEta, calo[ic].hwPhi);
@@ -496,7 +496,11 @@ void l1ct::PFAlgo3Emulator::run(const PFInputRegion& in, OutputRegion& out) cons
     }
   }
 
-  ptsort_ref(nCALO, nSELCALO, outne_all, out.pfneutral);
+  if (nCALO_ == nSELCALO_) {
+    std::swap(outne_all, out.pfneutral);
+  } else {
+    ptsort_ref(nCALO, nSELCALO, outne_all, out.pfneutral);
+  }
 
   if (debug_) {
     dbgPrintf("FW\n");


### PR DESCRIPTION
* skip unecessary sort of neutrals in pfalgo3 if configured with NSELCALO == NCALO (both in firmware and in emulator)
* fix bug in emulator that could cause crash or memory errors if the number of input ecal clusters is more than the configured nEMCalo

https://gitlab.cern.ch/cms-cactus/phase2/firmware/correlator-common/-/merge_requests/56
