### PR TITLE
Integration of egsorter emulator into the CMSSW Layer 1 producer

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/python/l1TkEgAlgoEmulator_cfi.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1TkEgAlgoEmulator_cfi.py
@@ -18,6 +18,7 @@ tkEgAlgoParameters = cms.PSet(
     caloEtMin=cms.double(0.0),
     trkQualityPtMin=cms.double(10.0),
     writeEGSta=cms.bool(False),
+    applyFinalSorting=cms.bool(True),
     tkIsoParametersTkEm=cms.PSet(
         tkQualityPtMin=cms.double(2.),
         dZ=cms.double(0.6),

--- a/L1Trigger/Phase2L1ParticleFlow/python/l1TkEgSorterEmulator_cfi.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1TkEgSorterEmulator_cfi.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+
+tkEgSorterParameters = cms.PSet(
+    splitEGObjectsToBoards = cms.untracked.bool(False),
+    nObjToSort = cms.uint32(6),
+    nObjSorted = cms.uint32(54),
+    nBoards = cms.uint32(5)
+)

--- a/L1Trigger/Phase2L1ParticleFlow/python/l1ctLayer1_cff.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1ctLayer1_cff.py
@@ -6,6 +6,7 @@ from L1Trigger.Phase2L1ParticleFlow.pfClustersFromCombinedCalo_cff import pfClus
 from L1Trigger.Phase2L1ParticleFlow.pfClustersFromHGC3DClusters_cfi import pfClustersFromHGC3DClusters
 
 from l1TkEgAlgoEmulator_cfi import tkEgAlgoParameters
+from l1TkEgSorterEmulator_cfi import tkEgSorterParameters
 
 muonInputConversionParameters = cms.PSet(
     z0Scale = cms.double(1.875),
@@ -81,6 +82,7 @@ l1ctLayer1Barrel = cms.EDProducer("L1TCorrelatorLayer1Producer",
         nEMCALO_EGIN = 10,
         nEM_EGOUT = 10,
     ),
+    tkEgSorterParameters=tkEgSorterParameters.clone(),
     caloSectors = cms.VPSet(
         cms.PSet( 
             etaBoundaries = cms.vdouble(-1.5, -1.0, -0.5, 0.0, 0.5, 1.0, 1.5),
@@ -212,6 +214,7 @@ l1ctLayer1HGCal = cms.EDProducer("L1TCorrelatorLayer1Producer",
         nEM_EGOUT = 5,
         doBremRecovery=True,
         writeEGSta=True),
+    tkEgSorterParameters=tkEgSorterParameters.clone(),
     caloSectors = _hgcalSectors,
     regions = cms.VPSet(
         cms.PSet( 
@@ -285,6 +288,7 @@ l1ctLayer1HGCalNoTK = cms.EDProducer("L1TCorrelatorLayer1Producer",
         nEM_EGOUT = 5,
         doBremRecovery=True,
         writeEGSta=True),
+    tkEgSorterParameters=tkEgSorterParameters.clone(),
     caloSectors = _hgcalSectors,
     regions = cms.VPSet(
         cms.PSet( 
@@ -359,6 +363,7 @@ l1ctLayer1HF = cms.EDProducer("L1TCorrelatorLayer1Producer",
         nEM_EGOUT = 5,        # to be defined
         doBremRecovery=True,
         writeEGSta=True),
+    tkEgSorterParameters=tkEgSorterParameters.clone(),
     caloSectors = cms.VPSet(
         cms.PSet( 
             etaBoundaries = cms.vdouble(-5.5, -3.0),

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/egamma/pftkegalgo_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/egamma/pftkegalgo_ref.cpp
@@ -34,6 +34,7 @@ l1ct::PFTkEGAlgoEmuConfig::PFTkEGAlgoEmuConfig(const edm::ParameterSet &pset)
       dPhiValues(pset.getParameter<std::vector<double>>("dPhiValues")),
       trkQualityPtMin(pset.getParameter<double>("trkQualityPtMin")),
       writeEgSta(pset.getParameter<bool>("writeEGSta")),
+      applyFinalSorting(pset.getParameter<bool>("applyFinalSorting")),
       tkIsoParams_tkEle(pset.getParameter<edm::ParameterSet>("tkIsoParametersTkEle")),
       tkIsoParams_tkEm(pset.getParameter<edm::ParameterSet>("tkIsoParametersTkEm")),
       pfIsoParams_tkEle(pset.getParameter<edm::ParameterSet>("pfIsoParametersTkEle")),

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/egamma/pftkegalgo_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/egamma/pftkegalgo_ref.h
@@ -35,7 +35,7 @@ namespace l1ct {
     std::vector<double> dEtaValues;
     std::vector<double> dPhiValues;
     float trkQualityPtMin;  // GeV
-    bool writeEgSta;
+    bool writeEgSta, applyFinalSorting;
 
     struct IsoParameters {
       IsoParameters(const edm::ParameterSet &);
@@ -77,6 +77,7 @@ namespace l1ct {
                         const std::vector<double> &dPhiValues = {0.07, 0.07},
                         float trkQualityPtMin = 10.,
                         bool writeEgSta = false,
+                        bool applyFinalSorting = false,
                         const IsoParameters &tkIsoParams_tkEle = {2., 0.6, 0.03, 0.2},
                         const IsoParameters &tkIsoParams_tkEm = {2., 0.6, 0.07, 0.3},
                         const IsoParameters &pfIsoParams_tkEle = {1., 0.6, 0.03, 0.2},
@@ -102,6 +103,7 @@ namespace l1ct {
           dPhiValues(std::move(dPhiValues)),
           trkQualityPtMin(trkQualityPtMin),
           writeEgSta(writeEgSta),
+          applyFinalSorting(applyFinalSorting),
           tkIsoParams_tkEle(tkIsoParams_tkEle),
           tkIsoParams_tkEm(tkIsoParams_tkEm),
           pfIsoParams_tkEle(pfIsoParams_tkEle),
@@ -132,6 +134,7 @@ namespace l1ct {
     void setDebug(int verbose) { debug_ = verbose; }
 
     bool writeEgSta() const { return cfg.writeEgSta; }
+    bool applyFinalSorting() const { return cfg.applyFinalSorting; }
 
   private:
     void link_emCalo2emCalo(const std::vector<EmCaloObjEmu> &emcalo, std::vector<int> &emCalo2emCalo) const;

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/egamma/pftkegsorter_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/egamma/pftkegsorter_ref.h
@@ -1,0 +1,126 @@
+#ifndef FIRMWARE_PFTKEGSORTER_REF_H
+#define FIRMWARE_PFTKEGSORTER_REF_H
+
+#include <cstdio>
+#include <vector>
+
+#ifdef CMSSW_GIT_HASH
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "../dataformats/layer1_emulator.h"
+#include "L1Trigger/Phase2L1ParticleFlow/src/dbgPrintf.h"
+#else
+#include "../../../dataformats/layer1_emulator.h"
+#include "../../utils/dbgPrintf.h"
+#endif
+
+namespace edm {
+  class ParameterSet;
+}
+
+namespace l1ct {
+  class PFTkEGSorterEmulator {
+    public:
+      PFTkEGSorterEmulator(bool splitEGObjectsToBoards=false,
+                           const unsigned int nObjToSort=6,
+                           const unsigned int nObjSorted=54,
+                           const unsigned int nBoards=5) //FIXME: Numbers to be revised
+        : splitEGObjectsToBoards_(splitEGObjectsToBoards),
+          nObjToSort_(nObjToSort),
+          nObjSorted_(nObjSorted),
+          nBoards_(nBoards),
+          debug_(false) {}
+
+      ~PFTkEGSorterEmulator() {};
+      
+      void setDebug(bool debug = true) { debug_ = debug; };
+      
+#ifdef CMSSW_GIT_HASH
+      PFTkEGSorterEmulator(const edm::ParameterSet &iConfig)
+        : PFTkEGSorterEmulator(
+          iConfig.getUntrackedParameter<bool>("splitEGObjectsToBoards"),
+          iConfig.getParameter<uint32_t>("nObjToSort"),
+          iConfig.getParameter<uint32_t>("nObjSorted"),
+          iConfig.getParameter<uint32_t>("nBoards")) {
+        setDebug(iConfig.getUntrackedParameter<bool>("debug", false));
+      }
+#endif
+
+      template <typename T>
+      void run(const std::vector<l1ct::PFInputRegion> & pfregions, 
+               const std::vector<l1ct::OutputRegion> & outregions, 
+               std::vector<std::vector<T> > & eg_sorted_inBoard){
+
+        std::vector<std::vector<T> >  eg_unsorted_inBoard = eg_sorted_inBoard;
+        mergeEGObjFromRegions<T>(pfregions, outregions, eg_unsorted_inBoard);
+
+        if(debug_) {
+          dbgCout() << "\nUNSORTED\n";
+          for (int i=0, ni=eg_unsorted_inBoard.size(); i<ni; i++) {
+            dbgCout() << "\nBoard "<<i<<"\n";
+            for (int j=0, nj=eg_unsorted_inBoard[i].size(); j<nj; j++) dbgCout() << "EG["<<j<<"]: pt = " << eg_unsorted_inBoard[i][j].hwPt << ",\t eta = " << eg_unsorted_inBoard[i][j].hwEta << ",\t phi = " << eg_unsorted_inBoard[i][j].hwPhi << "\n";
+          }
+        }
+
+        if(debug_) dbgCout() << "\nSORTED\n";
+
+        for (int i=0, ni=eg_unsorted_inBoard.size(); i<ni; i++) {
+          eg_sorted_inBoard[i] = eg_unsorted_inBoard[i];
+          std::reverse(eg_sorted_inBoard[i].begin(), eg_sorted_inBoard[i].end());
+          std::stable_sort(eg_sorted_inBoard[i].begin(), eg_sorted_inBoard[i].end(), comparePt<T>);
+          eg_sorted_inBoard[i].resize(nObjSorted_);
+          while (!eg_sorted_inBoard[i].empty() && eg_sorted_inBoard[i].back().hwPt == 0) eg_sorted_inBoard[i].pop_back(); // Zero suppression
+
+        
+          if(debug_) {
+            dbgCout() << "\nBoard "<<i<<"\n";
+            for (int j=0, nj=eg_sorted_inBoard[i].size(); j<nj; j++) dbgCout() << "EG["<<j<<"]: pt = " << eg_sorted_inBoard[i][j].hwPt << ",\t eta = " << eg_sorted_inBoard[i][j].hwEta << ",\t phi = " << eg_sorted_inBoard[i][j].hwPhi << "\n";
+          }
+        }
+      }
+
+
+    private:
+      bool splitEGObjectsToBoards_;
+      unsigned int nObjToSort_, nObjSorted_, nBoards_;
+      bool debug_;
+
+      void extractEGObjEmu(const l1ct::OutputRegion outregion, std::vector<l1ct::EGIsoObjEmu> & eg) { eg = outregion.egphoton; }
+      void extractEGObjEmu(const l1ct::OutputRegion outregion, std::vector<l1ct::EGIsoEleObjEmu> & eg) { eg = outregion.egelectron; }
+
+      template <typename T>
+      static bool comparePt(T obj1, T obj2) { return (obj1.hwPt > obj2.hwPt); }
+
+      template <typename T>
+      void mergeEGObjFromRegions(const std::vector<l1ct::PFInputRegion> & pfregions,
+                                 const std::vector<l1ct::OutputRegion> & outregions,
+                                 std::vector<std::vector<T> > & eg_unsorted_inBoard){
+        
+        for (int i=0, ni=outregions.size(); i<ni; i++) {
+          unsigned int x;
+          if(splitEGObjectsToBoards_) {
+            l1ct::glbeta_t eta = pfregions[i].region.hwEtaCenter;
+
+            if ( abs(eta) < l1ct::Scales::makeGlbEta(0.5) ) x = 0;
+            else if ( abs(eta) < l1ct::Scales::makeGlbEta(1.5) ) x = (eta < 0 ? 1 : 2);
+            else if ( abs(eta) < l1ct::Scales::makeGlbEta(2.5) ) x = (eta < 0 ? 3 : 4);
+            //else /*if ( fabs(eta) < 3.0 )*/x = 5;
+            /*else x = 6;*/ // HF
+          }
+          else x=0;
+
+          if(debug_) dbgCout() << "\nOutput Region "<<i<<": eta = "<<pfregions[i].region.floatEtaCenter()<<" and phi = "<<pfregions[i].region.floatPhiCenter()<<" \n";
+          
+          std::vector<T> eg_tmp;
+          extractEGObjEmu(outregions[i], eg_tmp);
+          for (int j=0, nj=( eg_tmp.size()>nObjToSort_ ? nObjToSort_ : eg_tmp.size() ); j<nj; j++) {
+            if(debug_) dbgCout() << "EG["<<j<<"] pt = " << eg_tmp[j].hwPt << ",\t eta = " << eg_tmp[j].hwEta << ",\t phi = " << eg_tmp[j].hwPhi << "\n";
+            eg_unsorted_inBoard[x].push_back(eg_tmp[j]);
+          }
+          if(debug_) dbgCout() << "\n";
+        }
+      }
+  };
+}
+
+#endif
+


### PR DESCRIPTION
#### PR description:

This PR includes the egsorter emulator into CMSSW and modifies the egalgo and Layer 1 producer to run it.

There is the option of simplifying the egsorter emulator a bit, so we may want to discuss that.