### PR TITLE
Add emulation of HT & MHT 

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1MHtPFProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1MHtPFProducer.cc
@@ -1,0 +1,101 @@
+#include <vector>
+#include <numeric>
+
+////////////////////
+//// FRAMEWORK HEADERS
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/L1TParticleFlow/interface/PFCandidate.h"
+#include "DataFormats/L1TParticleFlow/interface/PFJet.h"
+
+#include "DataFormats/L1Trigger/interface/EtSum.h"
+#include "DataFormats/Math/interface/LorentzVector.h"
+
+// bitwise emulation headers
+#include "L1Trigger/Phase2L1ParticleFlow/src/newfirmware/jetmet/L1PFHtEmulator.h"
+
+class L1MhtPfProducer : public edm::global::EDProducer<> {
+public:
+    explicit L1MhtPfProducer(const edm::ParameterSet&);
+    ~L1MhtPfProducer() override;
+
+private:
+    void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
+    edm::EDGetTokenT<std::vector<l1t::PFJet>> _jetsToken;
+    float _minJetPt;
+    float _maxJetEta;
+
+    std::vector<l1ct::Jet> convertEDMToHW(std::vector<l1t::PFJet> edmJets) const;
+    std::vector<l1t::EtSum> convertHWToEDM(l1ct::Sum hwSums) const;
+};
+
+L1MhtPfProducer::L1MhtPfProducer(const edm::ParameterSet& cfg)
+    : _jetsToken(consumes<std::vector<l1t::PFJet>>(cfg.getParameter<edm::InputTag>("jets"))),
+      _minJetPt(cfg.getParameter<double>("minJetPt")),
+      _maxJetEta(cfg.getParameter<double>("maxJetEta"))
+{
+    produces<std::vector<l1t::EtSum>>();
+}
+
+void L1MhtPfProducer::produce(edm::StreamID,
+                             edm::Event& iEvent,
+                             const edm::EventSetup& iSetup) const {
+
+    // Get the jets from the event
+    l1t::PFJetCollection edmJets = iEvent.get(_jetsToken);
+
+    // Apply pT and eta selections
+    l1t::PFJetCollection edmJetsFiltered;
+    std::copy_if(edmJets.begin(), edmJets.end(), std::back_inserter(edmJetsFiltered),
+                 [&](auto jet){ return jet.pt() > _minJetPt && std::abs(jet.eta()) < _maxJetEta; });
+
+    // Run the emulation
+    std::vector<l1ct::Jet> hwJets = convertEDMToHW(edmJetsFiltered);  // convert to the emulator format
+    l1ct::Sum hwSums = htmht(hwJets);                                 // call the emulator
+    std::vector<l1t::EtSum> edmSums = convertHWToEDM(hwSums);         // convert back to edm format
+
+    // Put the sums in the event
+    std::unique_ptr<std::vector<l1t::EtSum>> mhtCollection(new std::vector<l1t::EtSum>(0));
+    mhtCollection->push_back(edmSums.at(0)); // HT
+    mhtCollection->push_back(edmSums.at(1)); // MHT
+
+    iEvent.put(std::move(mhtCollection));
+}
+
+std::vector<l1ct::Jet> L1MhtPfProducer::convertEDMToHW(std::vector<l1t::PFJet> edmJets) const {
+    std::vector<l1ct::Jet> hwJets;
+    std::for_each(edmJets.begin(), edmJets.end(), [&](l1t::PFJet jet){
+        l1ct::Jet hwJet = l1ct::Jet::unpack(jet.encodedJet());
+        hwJets.push_back(hwJet);
+    });
+    return hwJets;
+}
+
+std::vector<l1t::EtSum> L1MhtPfProducer::convertHWToEDM(l1ct::Sum hwSums) const {
+    std::vector<l1t::EtSum> edmSums;
+
+    reco::Candidate::PolarLorentzVector htVector;
+    htVector.SetPt( hwSums.hwSumPt.to_double() );
+    htVector.SetPhi( 0 );
+    htVector.SetEta( 0 );
+
+    reco::Candidate::PolarLorentzVector mhtVector;
+    mhtVector.SetPt( hwSums.hwPt.to_double() );
+    mhtVector.SetPhi( l1ct::Scales::floatPhi(hwSums.hwPhi) );
+    mhtVector.SetEta( 0 );
+
+    l1t::EtSum ht(htVector, l1t::EtSum::EtSumType::kTotalHt);
+    l1t::EtSum mht(mhtVector, l1t::EtSum::EtSumType::kMissingHt);
+
+    edmSums.push_back(ht);
+    edmSums.push_back(mht);
+    return edmSums;
+}
+
+L1MhtPfProducer::~L1MhtPfProducer() {}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(L1MhtPfProducer);

--- a/L1Trigger/Phase2L1ParticleFlow/python/L1MhtPfProducer_cfi.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/L1MhtPfProducer_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+L1MhtPfProducer = cms.EDProducer("L1MhtPfProducer",
+                                 jets = cms.InputTag("scPFL1PuppiEmulator"),
+                                 minJetPt = cms.double(30.0),
+                                 maxJetEta = cms.double(2.4)
+)

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/jetmet/L1PFHtEmulator.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/jetmet/L1PFHtEmulator.h
@@ -11,6 +11,7 @@
 #include "../../../dataformats/sums.h"
 #include "../../seededcone/ref/L1SeedConePFJetEmulator.h"
 #include "../../../utils/dbgPrintf.h"
+#include "hls_math.h"
 #endif
 
 #include <vector>
@@ -66,7 +67,11 @@ table_t sine_with_conversion(etaphi_t hwPhi){
 }
 
 etaphi_t phi_cordic(pxy_t y,pxy_t x){
-    ap_fixed<12,3> phi = atan2(y.to_double(), x.to_double()); // stand in for hls::atan2, but gives same result
+#ifdef CMSSW_GIT_HASH
+    ap_fixed<12,3> phi = atan2(y.to_double(), x.to_double()); // hls_math.h not available yet in CMSSW
+#else
+    ap_fixed<12,3> phi = hls::atan2(y, x);
+#endif
     ap_fixed<16,9> etaphiscale = (float) l1ct::Scales::INTPHI_PI / M_PI; // radians to hwPhi
     return phi*etaphiscale;
 }
@@ -118,7 +123,11 @@ l1ct::Sum htmht(std::vector<l1ct::Jet> jets){
     // Compute the MHT magnitude and direction
     l1ct::Sum ht;
     ht.hwSumPt = hthxhy.pt;
-    ht.hwPt = sqrt(((hthxhy.px * hthxhy.px) + (hthxhy.py * hthxhy.py)).to_double()); // stand in for hls::sqrt but gives same result
+#ifdef CMSSW_GIT_HASH
+    ht.hwPt = sqrt(((hthxhy.px * hthxhy.px) + (hthxhy.py * hthxhy.py)).to_double()); // hls_math.h not available yet in CMSSW
+#else
+    ht.hwPt = hls::sqrt(((hthxhy.px * hthxhy.px) + (hthxhy.py * hthxhy.py)));
+#endif
     ht.hwPhi = P2L1HTMHTEmu::phi_cordic(hthxhy.py, hthxhy.px);
     return ht;
 }

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/jetmet/L1PFHtEmulator.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/jetmet/L1PFHtEmulator.h
@@ -1,0 +1,126 @@
+#ifndef L1Trigger_Phase2L1ParticleFlow_HTMHT_h
+#define L1Trigger_Phase2L1ParticleFlow_HTMHT_h
+
+#ifdef CMSSW_GIT_HASH
+#include "../dataformats/jets.h"
+#include "../dataformats/sums.h"
+#include "./L1SeedConePFJetEmulator.h"
+#include "L1Trigger/Phase2L1ParticleFlow/src/dbgPrintf.h"
+#else
+#include "../../../dataformats/jets.h"
+#include "../../../dataformats/sums.h"
+#include "../../seededcone/ref/L1SeedConePFJetEmulator.h"
+#include "../../../utils/dbgPrintf.h"
+#endif
+
+#include <vector>
+#include <numeric>
+#include <algorithm>
+#include "ap_int.h"
+#include "ap_fixed.h"
+
+namespace P2L1HTMHTEmu{
+    typedef l1ct::pt_t pt_t;             // Type for pt/ht 1 unit = 0.25 GeV; max = 16 TeV
+    typedef l1ct::glbeta_t etaphi_t;     // Type for eta & phi
+
+    typedef ap_fixed<12,3> radians_t;
+    typedef ap_fixed<9,2> cossin_t;
+    typedef ap_fixed<16,13> pxy_t;
+
+    static constexpr int N_TABLE = 2048;
+
+    // Class for intermediate variables
+    class PtPxPy {
+    public:
+      pt_t pt  = 0.;
+      pxy_t px = 0.;
+      pxy_t py = 0.;
+
+      PtPxPy operator+(const PtPxPy& b) const{
+        PtPxPy c;
+        c.pt = this->pt + b.pt;
+        c.px = this->px + b.px;
+        c.py = this->py + b.py;
+        return c;
+      }
+    };
+
+namespace Scales {
+  const ap_fixed<12,-4> scale_degToRad = M_PI/180.;
+};  // namespace Scales
+
+template<class data_T, class table_T, int N>
+void init_sinphi_table(table_T table_out[N]){
+    for(int i = 0; i < N; i++){
+        float x = i*(M_PI/180.)/2.;
+        table_T sin_x = std::sin(x);
+        table_out[i] = sin_x;
+    }
+}
+template<class in_t, class table_t, int N>
+table_t sine_with_conversion(etaphi_t hwPhi){
+    table_t sin_table[N];
+    init_sinphi_table<in_t, table_t, N>(sin_table);
+    table_t out = sin_table[hwPhi];
+    return out;
+}
+
+etaphi_t phi_cordic(pxy_t y,pxy_t x){
+    ap_fixed<12,3> phi = atan2(y.to_double(), x.to_double()); // stand in for hls::atan2, but gives same result
+    ap_fixed<16,9> etaphiscale = (float) l1ct::Scales::INTPHI_PI / M_PI; // radians to hwPhi
+    return phi*etaphiscale;
+}
+
+PtPxPy mht_compute(l1ct::Jet jet){
+    // Add an extra bit to px/py for the sign, and one additional bit to improve precision (pt_t is ap_ufixed<14, 12>)
+    PtPxPy v_pxpy;
+
+    //Initialize table once
+    cossin_t sin_table[N_TABLE];
+    init_sinphi_table<etaphi_t, cossin_t, N_TABLE>(sin_table);
+
+    cossin_t sinphi;
+    cossin_t cosphi;
+    bool sign = jet.hwPhi.sign();
+
+    etaphi_t hwphi = jet.hwPhi;
+
+    // Reduce precision of hwPhi
+    ap_int<10> phi;
+    phi.V = hwphi(11,1);
+    phi   =  (phi > 0) ? phi : (ap_int<10>) -phi; //Only store values for positive phi, pick up sign later
+
+    sinphi = sin_table[phi];
+
+    sinphi = (sign > 0) ? (cossin_t) (-sign*sinphi) : sinphi; // Change sign bit if hwPt is negative, sin(-x)=-sin(x)
+    cosphi = sin_table[phi+90*2];                             //cos(x)=sin(x+90). Do nothing with sign, cos(-θ) = cos θ,
+
+    v_pxpy.pt = jet.hwPt;
+    v_pxpy.py = jet.hwPt * sinphi;
+    v_pxpy.px = jet.hwPt * cosphi;
+
+    return v_pxpy;
+}
+} // namespace P2L1HTMHTEmu
+
+//TODO replace with l1ct::Jet
+l1ct::Sum htmht(std::vector<l1ct::Jet> jets){
+    // compute jet px, py
+    std::vector<P2L1HTMHTEmu::PtPxPy> ptpxpy;
+    ptpxpy.resize(jets.size());
+    std::transform(jets.begin(), jets.end(), ptpxpy.begin(), [](const l1ct::Jet& jet){
+        return P2L1HTMHTEmu::mht_compute(jet);
+    });
+
+    // Sum pt, px, py over jets
+    P2L1HTMHTEmu::PtPxPy hthxhy = std::accumulate(ptpxpy.begin(), ptpxpy.end(), P2L1HTMHTEmu::PtPxPy());
+
+    // Compute the MHT magnitude and direction
+    l1ct::Sum ht;
+    ht.hwSumPt = hthxhy.pt;
+    ht.hwPt = sqrt(((hthxhy.px * hthxhy.px) + (hthxhy.py * hthxhy.py)).to_double()); // stand in for hls::sqrt but gives same result
+    ht.hwPhi = P2L1HTMHTEmu::phi_cordic(hthxhy.py, hthxhy.px);
+    return ht;
+}
+
+#endif


### PR DESCRIPTION
This PR provides the emulation of the HT & MHT firmware developed by @thaarres.
There are corresponding MRs on [correlator-common](https://gitlab.cern.ch/cms-cactus/phase2/firmware/correlator-common/-/merge_requests/72) and [correlator-layer2](https://gitlab.cern.ch/cms-cactus/phase2/firmware/correlator-layer2/-/merge_requests/4) that describe the firmware.

## Performance
Here are some performance plots to validate that this emulation does a good job at reconstructing HT & MHT. I'm using Seeded Cone emulator jets as input in all cases. I then compare the emulation added here with the "on the fly" HT & MHT [from FastPuppi](https://github.com/p2l1pfp/FastPUPPI/blob/11_1_X/NtupleProducer/python/scripts/jetHtSuite.h#L81-L101). Plots are from TTbar + 200 PU. This is intended as validation that the implementation makes sense, some jet selection could still be added later to tune the performance.

### HT
The scalar sum of the jet pT is identical between the two implementations.
<img src="https://user-images.githubusercontent.com/14807534/150322538-ff698264-dd1c-4abf-bc2c-c9be940827cd.png" width=250/> <img src="https://user-images.githubusercontent.com/14807534/150323441-ca322172-0539-4521-8feb-68df705fa0c1.png" width=250/>

### MHT
There are some small differences between the emulation and floating point computation of MHT from the different maths implementations used.

<img src="https://user-images.githubusercontent.com/14807534/150344857-ab64bfee-31d2-408c-a443-0025da980f34.png" width=250/> <img src="https://user-images.githubusercontent.com/14807534/150344996-c3d187c6-31a7-4c9f-b710-bb9aac910f47.png" width=250/>

Here is some detail on the residual of the MHT magnitude and ɸ angle. There can be some large differences in the ɸ, but this seems to be a numeric effect arising from the different implementations, occurring in events with low MHT but still relatively higher scalar sum HT, when many jet (px, py) vectors sum to a small value. This can be seen in the plot with different MHT magnitude ranges.

<img src="https://user-images.githubusercontent.com/14807534/150345288-197ed9f8-99f2-4d99-882e-f65e169e9ac4.png" width=250/> <img src="https://user-images.githubusercontent.com/14807534/150345297-72763cfb-5416-4710-8d7a-6f5ee2625039.png" width=250/>

## hls_math.h issue
One issue outstanding is that the `hls::atan2` and `hls::sqrt` functions aren't available in CMSSW yet. Here I've reverted to regular C++ math `atan2` and `sqrt`. The output is often identical, but sometimes differs by 1 bit. We can probably accept this difference for physics studies here, but may need a workaround to be able to do validation on the correlator-common repo. I could add something to run either one or the other depending on the environment like:

```
#ifdef CMSSW_GIT_HASH
ap_fixed<12,3> phi = atan2(y.to_double(), x.to_double());
#else
ap_fixed<12,3> phi = hls::atan2(y, x);
#endif
```

But ultimately it would be good to make the hls_math.h header available in CMSSW too. At the moment the code just uses regular float `atan2` and `sqrt`, so isn't 100% bit exact with the firmware.