### PR TITLE
More firmware-like configuration, and sync with correlator common formats

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/python/l1ctLayer1_cff.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1ctLayer1_cff.py
@@ -24,8 +24,29 @@ l1ctLayer1Barrel = cms.EDProducer("L1TCorrelatorLayer1Producer",
     emPtCut  = cms.double(0.5),
     hadPtCut = cms.double(1.0),
     trkPtCut    = cms.double(2.0),
-    trackInputConversionAlgo = cms.string("Ideal"),
-    muonInputConversionAlgo = cms.string("Ideal"),
+    trackInputConversionAlgo = cms.string("Emulator"),
+    trackInputConversionParameters = cms.PSet(
+        region = cms.string("barrel"),
+        trackWordEncoding = cms.string("biased"),
+        bitwiseAccurate = cms.bool(True),
+        ptLUTBits = cms.uint32(11),
+        etaLUTBits = cms.uint32(10),
+        etaPreOffs = cms.int32(0),
+        etaShift = cms.uint32(15-10),
+        etaPostOffs = cms.int32(0),
+        etaSigned = cms.bool(True),
+        phiBits = cms.uint32(10),
+        z0Bits = cms.uint32(12),
+        dEtaBarrelBits = cms.uint32(8),
+        dEtaBarrelZ0PreShift = cms.uint32(2),
+        dEtaBarrelZ0PostShift = cms.uint32(2),
+        dEtaBarrelFloatOffs = cms.double(0.0),
+        dPhiBarrelBits = cms.uint32(4),
+        dPhiBarrelRInvPreShift = cms.uint32(4),
+        dPhiBarrelRInvPostShift = cms.uint32(4),
+        dPhiBarrelFloatOffs = cms.double(0.0)
+        ),
+    muonInputConversionAlgo = cms.string("Emulator"),
     muonInputConversionParameters = muonInputConversionParameters.clone(),
     regionizerAlgo = cms.string("Ideal"),
     pfAlgo = cms.string("PFAlgo3"),
@@ -103,11 +124,14 @@ l1ctLayer1Barrel = cms.EDProducer("L1TCorrelatorLayer1Producer",
     ),
     boards=cms.VPSet(
         cms.PSet(
-            regions=cms.vuint32(range(0, 18))),
+              regions=cms.vuint32(*[0+9*ie+i for ie in range(6) for i in range(3)])), # phi splitting
+            # regions=cms.vuint32(range(0, 18))), # eta splitting
         cms.PSet(
-            regions=cms.vuint32(range(18, 36))),
+              regions=cms.vuint32(*[3+9*ie+i for ie in range(6) for i in range(3)])), # phi splitting
+            # regions=cms.vuint32(range(18, 36))), # eta splitting
         cms.PSet(
-            regions=cms.vuint32(range(36, 54))),
+              regions=cms.vuint32(*[6+9*ie+i for ie in range(6) for i in range(3)])), # phi splitting
+            # regions=cms.vuint32(range(36, 54))), # eta splitting
     )
 )
 
@@ -227,6 +251,7 @@ l1ctLayer1HGCal = cms.EDProducer("L1TCorrelatorLayer1Producer",
         nEMCALO_EGIN = 10, 
         nEM_EGOUT = 5,
         doBremRecovery=True,
+        writeBeforeBremRecovery=False,
         writeEGSta=True),
     tkEgSorterParameters=tkEgSorterParameters.clone(
         nObjToSort = 5
@@ -267,7 +292,7 @@ l1ctLayer1HGCalNoTK = cms.EDProducer("L1TCorrelatorLayer1Producer",
     emPtCut  = cms.double(0.5),
     hadPtCut = cms.double(1.0),
     trkPtCut    = cms.double(2.0),
-    muonInputConversionAlgo = cms.string("Ideal"),
+    muonInputConversionAlgo = cms.string("Emulator"),
     muonInputConversionParameters = muonInputConversionParameters.clone(),
     regionizerAlgo = cms.string("Ideal"),
     pfAlgo = cms.string("PFAlgoDummy"),
@@ -309,6 +334,7 @@ l1ctLayer1HGCalNoTK = cms.EDProducer("L1TCorrelatorLayer1Producer",
         nEMCALO_EGIN = 10, 
         nEM_EGOUT = 5,
         doBremRecovery=True,
+        writeBeforeBremRecovery=False,
         writeEGSta=True),
     tkEgSorterParameters=tkEgSorterParameters.clone(
         nObjToSort=5

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/gt_datatypes.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/gt_datatypes.h
@@ -51,6 +51,10 @@ namespace l1gt {
     phi_t phi;
     eta_t eta;
 
+    inline bool operator==(const ThreeVector &other) const {
+      return pt == other.pt && phi == other.phi && eta == other.eta;
+    }
+
     static const int BITWIDTH = pt_t::width + phi_t::width + eta_t::width;
     inline ap_uint<BITWIDTH> pack() const {
       ap_uint<BITWIDTH> ret;
@@ -66,6 +70,8 @@ namespace l1gt {
     valid_t valid;
     ThreeVector v3;
     z0_t z0;
+
+    inline bool operator==(const Jet &other) const { return valid == other.valid && z0 == other.z0 && v3 == other.v3; }
 
     static const int BITWIDTH = 128;
     inline ap_uint<BITWIDTH> pack_ap() const {
@@ -85,6 +91,21 @@ namespace l1gt {
       return packed;
     }
 
+    inline static Jet unpack_ap(const ap_uint<BITWIDTH> &src) {
+      Jet ret;
+      ret.initFromBits(src);
+      return ret;
+    }
+
+    inline void initFromBits(const ap_uint<BITWIDTH> &src) {
+      unsigned int start = 0;
+      _unpack_from_bits(src, start, valid);
+      _unpack_from_bits(src, start, v3.pt);
+      _unpack_from_bits(src, start, v3.phi);
+      _unpack_from_bits(src, start, v3.eta);
+      _unpack_from_bits(src, start, z0);
+    }
+
   };  // struct Jet
 
   struct Sum {
@@ -92,6 +113,18 @@ namespace l1gt {
     pt_t vector_pt;
     phi_t vector_phi;
     pt_t scalar_pt;
+
+    inline bool operator==(const Sum &other) const {
+      return valid == other.valid && vector_pt == other.vector_pt && vector_phi == other.vector_phi &&
+             scalar_pt == other.scalar_pt;
+    }
+
+    inline void clear() {
+      valid = 0;
+      vector_pt = 0;
+      vector_phi = 0;
+      scalar_pt = 0;
+    }
 
     static const int BITWIDTH = 64;
     inline ap_uint<BITWIDTH> pack() const {
@@ -102,6 +135,20 @@ namespace l1gt {
       _pack_into_bits(ret, start, vector_phi);
       _pack_into_bits(ret, start, scalar_pt);
       return ret;
+    }
+
+    inline static Sum unpack_ap(const ap_uint<BITWIDTH> &src) {
+      Sum ret;
+      ret.initFromBits(src);
+      return ret;
+    }
+
+    inline void initFromBits(const ap_uint<BITWIDTH> &src) {
+      unsigned int start = 0;
+      _unpack_from_bits(src, start, valid);
+      _unpack_from_bits(src, start, vector_pt);
+      _unpack_from_bits(src, start, vector_phi);
+      _unpack_from_bits(src, start, scalar_pt);
     }
   };  // struct Sum
 

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/gt_datatypes.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/gt_datatypes.h
@@ -64,6 +64,19 @@ namespace l1gt {
       _pack_into_bits(ret, start, eta);
       return ret;
     }
+
+    inline static ThreeVector unpack_ap(const ap_uint<BITWIDTH> &src) {
+      ThreeVector ret;
+      ret.initFromBits(src);
+      return ret;
+    }
+
+    inline void initFromBits(const ap_uint<BITWIDTH> &src) {
+      unsigned int start = 0;
+      _unpack_from_bits(src, start, pt);
+      _unpack_from_bits(src, start, phi);
+      _unpack_from_bits(src, start, eta);
+    }
   };
 
   struct Jet {
@@ -104,6 +117,19 @@ namespace l1gt {
       _unpack_from_bits(src, start, v3.phi);
       _unpack_from_bits(src, start, v3.eta);
       _unpack_from_bits(src, start, z0);
+    }
+
+    inline static Jet unpack(const std::array<uint64_t, 2> &src) {
+      ap_uint<BITWIDTH> bits;
+      bits(63, 0) = src[0];
+      bits(127, 64) = src[1];
+      return unpack_ap(bits);
+    }
+
+    inline static Jet unpack(long long unsigned int &src) {
+      // unpack from single 64b int
+      ap_uint<BITWIDTH> bits = src;
+      return unpack_ap(bits);
     }
 
   };  // struct Jet

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/jets.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/jets.h
@@ -71,6 +71,12 @@ namespace l1ct {
       return unpack_ap(bits);
     }
 
+    inline static Jet unpack(long long unsigned int &src) {
+      // unpack from single 64b int
+      ap_uint<BITWIDTH> bits = src;
+      return unpack_ap(bits);
+    }
+
     l1gt::Jet toGT() const {
       l1gt::Jet j;
       j.valid = hwPt != 0;

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/sums.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/sums.h
@@ -2,6 +2,7 @@
 #define FIRMWARE_dataformats_sums_h
 
 #include "datatypes.h"
+#include "gt_datatypes.h"
 #include "bit_encoding.h"
 
 namespace l1ct {
@@ -44,6 +45,15 @@ namespace l1ct {
       _unpack_from_bits(src, start, ret.hwPhi);
       _unpack_from_bits(src, start, ret.hwSumPt);
       return ret;
+    }
+
+    l1gt::Sum toGT() const {
+      l1gt::Sum sum;
+      sum.valid = (hwPt != 0) || (hwSumPt != 0);
+      sum.vector_pt = CTtoGT_pt(hwPt);
+      sum.vector_phi = CTtoGT_phi(hwPhi);
+      sum.scalar_pt = CTtoGT_phi(hwSumPt);
+      return sum;
     }
   };
 

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/l1-converters/tracks/tkinput_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/l1-converters/tracks/tkinput_ref.cpp
@@ -57,8 +57,14 @@ l1ct::TrackInputEmulator::TrackInputEmulator(const edm::ParameterSet &iConfig)
   configPhi(iConfig.getParameter<uint32_t>("phiBits"));
   configZ0(iConfig.getParameter<uint32_t>("z0Bits"));
   if (region_ == Region::Barrel) {
-    //using eta LUTs for deta, no config needed
-    //using DSP for dphi, no config needed
+    configDEtaBarrel(iConfig.getParameter<uint32_t>("dEtaBarrelBits"),
+                     iConfig.getParameter<uint32_t>("dEtaBarrelZ0PreShift"),
+                     iConfig.getParameter<uint32_t>("dEtaBarrelZ0PostShift"),
+                     iConfig.getParameter<double>("dEtaBarrelFloatOffs"));
+    configDPhiBarrel(iConfig.getParameter<uint32_t>("dPhiBarrelBits"),
+                     iConfig.getParameter<uint32_t>("dPhiBarrelRInvPreShift"),
+                     iConfig.getParameter<uint32_t>("dPhiBarrelRInvPostShift"),
+                     iConfig.getParameter<double>("dPhiBarrelFloatOffs"));
   }
   if (region_ == Region::Endcap) {
     configDEtaHGCal(iConfig.getParameter<uint32_t>("dEtaHGCalBits"),


### PR DESCRIPTION
Moving to a more firmware-like configuration of layer 1
 * enable the emulator for the track input conversion & propagation also in the barrel region, with the settings originally from @drankincms @therwig 
 * switch to grouping the barrel boards in phi regions (from https://indico.cern.ch/event/1093091/)
 * not writing the egamma objects without brem recovery in the hgcal region (@cerminar)

And, update the GT formats from correlator common merge requests [!75](https://gitlab.cern.ch/cms-cactus/phase2/firmware/correlator-common/-/merge_requests/75) and [!81](https://gitlab.cern.ch/cms-cactus/phase2/firmware/correlator-common/-/merge_requests/81)