### PR TITLE
PF mu ID : increasing threshold from 0.5 to 3 pt_SA

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/pf/pfalgo_common_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/pf/pfalgo_common_ref.cpp
@@ -86,7 +86,7 @@ void l1ct::PFAlgoEmulatorBase::pfalgo_mu_ref(const PFInputRegion &in, OutputRegi
   for (unsigned int im = 0; im < nMU; ++im) {
     if (in.muon[im].hwPt > 0) {
       int ibest = -1;
-      pt_t dptmin = in.muon[im].hwPt >> 1;
+      pt_t dptmin = (in.muon[im].hwPt << 1) + in.muon[im].hwPt;
       for (unsigned int it = 0; it < nTRACK; ++it) {
         if (!in.track[it].isPFLoose())
           continue;


### PR DESCRIPTION
Updates to the PF muons ID as proposed in this talk at the correlator meeting : 
https://indico.cern.ch/event/1106099/contributions/4653625/attachments/2366970/4041912/L2Correlator_PFmuon_NadyaChernyavskaya.pdf


Summary of updates : 
 Current selection of tracks is according to the following criterium : |δ(pT_tk - pT_SA)| < 3.0 * pT_SA. In the PR the threshold was updated from 0.5 to 3.0.

