### PR TITLE
Updates to get the correlator-common CI running using CMSSW

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/python/l1ctLayer1_cff.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1ctLayer1_cff.py
@@ -112,7 +112,7 @@ l1ctLayer1Barrel = cms.EDProducer("L1TCorrelatorLayer1Producer",
     caloSectors = cms.VPSet(
         cms.PSet( 
             etaBoundaries = cms.vdouble(-1.5, 1.5),
-            phiSlices     = cms.uint32(6),
+            phiSlices     = cms.uint32(3),
             phiZero       = cms.double(0),
         )
     ),

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/common/bitonic_sort_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/common/bitonic_sort_ref.h
@@ -4,11 +4,7 @@
 #include <algorithm>
 #include <cassert>
 
-#ifdef CMSSW_GIT_HASH
 #include "L1Trigger/Phase2L1ParticleFlow/src/dbgPrintf.h"
-#else
-#include "../utils/dbgPrintf.h"
-#endif
 
 inline unsigned int PowerOf2LessThan(unsigned int n) {
   unsigned int i = 1;

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/layer1_emulator.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/layer1_emulator.cpp
@@ -5,11 +5,7 @@
 #include <cstdlib>
 #include <algorithm>
 
-#ifdef CMSSW_GIT_HASH
 #include "L1Trigger/Phase2L1ParticleFlow/src/dbgPrintf.h"
-#else
-#include "../utils/dbgPrintf.h"
-#endif
 
 #ifdef CMSSW_GIT_HASH
 #include "DataFormats/Math/interface/deltaPhi.h"

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/deregionizer/deregionizer_input.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/deregionizer/deregionizer_input.cpp
@@ -3,11 +3,7 @@
 #include <vector>
 #include "deregionizer_input.h"
 
-#ifdef CMSSW_GIT_HASH
 #include "L1Trigger/Phase2L1ParticleFlow/src/dbgPrintf.h"
-#else
-#include "../../utils/dbgPrintf.h"
-#endif
 
 l1ct::DeregionizerInput::DeregionizerInput(std::vector<float> &regionEtaCenter,
                                            std::vector<float> &regionPhiCenter,

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/deregionizer/deregionizer_input.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/deregionizer/deregionizer_input.h
@@ -2,11 +2,7 @@
 #define L1Trigger_Phase2L1ParticleFlow_newfirmware_deregionizer_input_h
 
 #include <vector>
-#ifdef CMSSW_GIT_HASH
 #include "../dataformats/layer1_emulator.h"
-#else
-#include "../../dataformats/layer1_emulator.h"
-#endif
 
 namespace l1ct {
 

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/deregionizer/deregionizer_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/deregionizer/deregionizer_ref.cpp
@@ -3,9 +3,10 @@
 #include <cstdio>
 #include <vector>
 
+#include "L1Trigger/Phase2L1ParticleFlow/src/dbgPrintf.h"
+
 #ifdef CMSSW_GIT_HASH
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "L1Trigger/Phase2L1ParticleFlow/src/dbgPrintf.h"
 
 l1ct::DeregionizerEmulator::DeregionizerEmulator(const edm::ParameterSet &iConfig)
     : DeregionizerEmulator(iConfig.getParameter<uint32_t>("nPuppiFinalBuffer"),
@@ -15,8 +16,6 @@ l1ct::DeregionizerEmulator::DeregionizerEmulator(const edm::ParameterSet &iConfi
                            iConfig.getParameter<uint32_t>("nPuppiThirdBuffers")) {
   debug_ = iConfig.getUntrackedParameter<bool>("debug", false);
 }
-#else
-#include "../../utils/dbgPrintf.h"
 #endif
 
 l1ct::DeregionizerEmulator::DeregionizerEmulator(const unsigned int nPuppiFinalBuffer /*=128*/,

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/egamma/l2egencoder_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/egamma/l2egencoder_ref.h
@@ -5,7 +5,6 @@
 #include "../dataformats/egamma.h"
 #include "L1Trigger/Phase2L1ParticleFlow/src/dbgPrintf.h"
 
-
 namespace edm {
   class ParameterSet;
 }

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/egamma/l2egencoder_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/egamma/l2egencoder_ref.h
@@ -1,17 +1,10 @@
 #ifndef L2EGENCODER_REF_H
 #define L2EGENCODER_REF_H
 
-#ifdef CMSSW_GIT_HASH
 #include "../dataformats/layer1_emulator.h"
 #include "../dataformats/egamma.h"
 #include "L1Trigger/Phase2L1ParticleFlow/src/dbgPrintf.h"
 
-#else
-#include "../../dataformats/layer1_emulator.h"
-#include "../../dataformats/egamma.h"
-#include "../../utils/dbgPrintf.h"
-
-#endif
 
 namespace edm {
   class ParameterSet;

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/egamma/l2egsorter_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/egamma/l2egsorter_ref.h
@@ -1,21 +1,12 @@
 #ifndef L2EgSorter_REF_H
 #define L2EgSorter_REF_H
 
-#ifdef CMSSW_GIT_HASH
 #include "../dataformats/layer1_emulator.h"
 #include "../dataformats/egamma.h"
 #include "../dataformats/pf.h"
 #include "../common/bitonic_hybrid_sort_ref.h"
 #include "L1Trigger/Phase2L1ParticleFlow/src/dbgPrintf.h"
 
-#else
-#include "../../dataformats/layer1_emulator.h"
-#include "../../dataformats/egamma.h"
-#include "../../dataformats/pf.h"
-#include "../../common/bitonic_hybrid_sort_ref.h"
-#include "../../utils/dbgPrintf.h"
-
-#endif
 #include <algorithm>
 #include <bitset>
 

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/egamma/pfeginput_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/egamma/pfeginput_ref.h
@@ -1,15 +1,9 @@
 #ifndef PFEGINPUT_REF_H
 #define PFEGINPUT_REF_H
 
-#ifdef CMSSW_GIT_HASH
 #include "../dataformats/layer1_emulator.h"
 #include "../dataformats/egamma.h"
 #include "../dataformats/pf.h"
-#else
-#include "../../../dataformats/layer1_emulator.h"
-#include "../../../dataformats/egamma.h"
-#include "../../../dataformats/pf.h"
-#endif
 
 namespace edm {
   class ParameterSet;

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/egamma/pftkegalgo_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/egamma/pftkegalgo_ref.cpp
@@ -6,11 +6,7 @@
 #include <memory>
 #include <iostream>
 
-#ifdef CMSSW_GIT_HASH
 #include "L1Trigger/Phase2L1ParticleFlow/src/dbgPrintf.h"
-#else
-#include "../../../utils/dbgPrintf.h"
-#endif
 
 using namespace l1ct;
 

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/egamma/pftkegalgo_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/egamma/pftkegalgo_ref.h
@@ -1,15 +1,9 @@
 #ifndef PFTKEGALGO_REF_H
 #define PFTKEGALGO_REF_H
 
-#ifdef CMSSW_GIT_HASH
 #include "../dataformats/layer1_emulator.h"
 #include "../dataformats/egamma.h"
 #include "../dataformats/pf.h"
-#else
-#include "../../../dataformats/layer1_emulator.h"
-#include "../../../dataformats/egamma.h"
-#include "../../../dataformats/pf.h"
-#endif
 
 namespace edm {
   class ParameterSet;

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/egamma/pftkegsorter_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/egamma/pftkegsorter_ref.h
@@ -4,13 +4,11 @@
 #include <cstdio>
 #include <vector>
 
-#ifdef CMSSW_GIT_HASH
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "L1Trigger/Phase2L1ParticleFlow/src/dbgPrintf.h"
 #include "../dataformats/layer1_emulator.h"
-#else
-#include "../../../dataformats/layer1_emulator.h"
-#include "../../../utils/dbgPrintf.h"
+
+#ifdef CMSSW_GIT_HASH
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #endif
 
 namespace edm {

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/jetmet/L1PFHtEmulator.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/jetmet/L1PFHtEmulator.h
@@ -1,16 +1,12 @@
 #ifndef L1Trigger_Phase2L1ParticleFlow_HTMHT_h
 #define L1Trigger_Phase2L1ParticleFlow_HTMHT_h
 
-#ifdef CMSSW_GIT_HASH
-#include "../dataformats/jets.h"
-#include "../dataformats/sums.h"
-#include "./L1SeedConePFJetEmulator.h"
+#include "L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/jets.h"
+#include "L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/sums.h"
+#include "L1SeedConePFJetEmulator.h"
 #include "L1Trigger/Phase2L1ParticleFlow/src/dbgPrintf.h"
-#else
-#include "../../../dataformats/jets.h"
-#include "../../../dataformats/sums.h"
-#include "../../seededcone/ref/L1SeedConePFJetEmulator.h"
-#include "../../../utils/dbgPrintf.h"
+
+#ifndef CMSSW_GIT_HASH
 #include "hls_math.h"
 #endif
 

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/jetmet/L1SeedConePFJetEmulator.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/jetmet/L1SeedConePFJetEmulator.h
@@ -1,24 +1,15 @@
 #ifndef L1Trigger_Phase2L1ParticleFlow_L1SeedConePFJetEmulator_h
 #define L1Trigger_Phase2L1ParticleFlow_L1SeedConePFJetEmulator_h
 
-#ifdef CMSSW_GIT_HASH
 #include "../dataformats/layer1_emulator.h"
 #include "../dataformats/jets.h"
-#else
-#include "../../../dataformats/layer1_emulator.h"
-#include "../../../dataformats/jets.h"
-#endif
 
 #include <iostream>
 #include <vector>
 #include <numeric>
 #include <algorithm>
 
-#ifdef CMSSW_GIT_HASH
 #include "L1Trigger/Phase2L1ParticleFlow/src/dbgPrintf.h"
-#else
-#include "../../../utils/dbgPrintf.h"
-#endif
 
 class L1SCJetEmu {
 public:

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/l1-converters/hgcal/hgcalinput_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/l1-converters/hgcal/hgcalinput_ref.h
@@ -1,11 +1,7 @@
 #ifndef L1Trigger_Phase2L1ParticleFlow_newfirmware_hgcalinput_ref_h
 #define L1Trigger_Phase2L1ParticleFlow_newfirmware_hgcalinput_ref_h
 
-#ifdef CMSSW_GIT_HASH
 #include "../../dataformats/layer1_emulator.h"
-#else
-#include "../../../dataformats/layer1_emulator.h"
-#endif
 
 namespace l1ct {
   class HgcalClusterDecoderEmulator {

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/l1-converters/muons/muonGmtToL1ct_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/l1-converters/muons/muonGmtToL1ct_ref.h
@@ -1,11 +1,7 @@
 #ifndef L1Trigger_Phase2L1ParticleFlow_newfirmware_muonGmtToL1ct_ref_h
 #define L1Trigger_Phase2L1ParticleFlow_newfirmware_muonGmtToL1ct_ref_h
 
-#ifdef CMSSW_GIT_HASH
 #include "../../dataformats/layer1_emulator.h"
-#else
-#include "../../../dataformats/layer1_emulator.h"
-#endif
 
 namespace edm {
   class ParameterSet;

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/l1-converters/tracks/tkinput_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/l1-converters/tracks/tkinput_ref.cpp
@@ -3,11 +3,7 @@
 #include <cassert>
 #include <cstdio>
 
-#ifdef CMSSW_GIT_HASH
 #include "L1Trigger/Phase2L1ParticleFlow/src/dbgPrintf.h"
-#else
-#include "../../../utils/dbgPrintf.h"
-#endif
 
 #ifdef CMSSW_GIT_HASH
 #include <cstdint>

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/l1-converters/tracks/tkinput_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/l1-converters/tracks/tkinput_ref.h
@@ -1,11 +1,7 @@
 #ifndef L1Trigger_Phase2L1ParticleFlow_l1converters_tracks_tkinput_ref_h
 #define L1Trigger_Phase2L1ParticleFlow_l1converters_tracks_tkinput_ref_h
 
-#ifdef CMSSW_GIT_HASH
 #include "../../dataformats/layer1_emulator.h"
-#else
-#include "../../../dataformats/layer1_emulator.h"
-#endif
 #include <cstdio>
 #include <algorithm>
 

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/pf/pfalgo3_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/pf/pfalgo3_ref.cpp
@@ -6,11 +6,7 @@
 #include <vector>
 #include <memory>
 
-#ifdef CMSSW_GIT_HASH
 #include "L1Trigger/Phase2L1ParticleFlow/src/dbgPrintf.h"
-#else
-#include "../../utils/dbgPrintf.h"
-#endif
 
 #ifdef CMSSW_GIT_HASH
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/pf/pfalgo_common_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/pf/pfalgo_common_ref.cpp
@@ -3,11 +3,7 @@
 #include <cmath>
 #include <cstdio>
 
-#ifdef CMSSW_GIT_HASH
 #include "L1Trigger/Phase2L1ParticleFlow/src/dbgPrintf.h"
-#else
-#include "../../utils/dbgPrintf.h"
-#endif
 
 #ifdef CMSSW_GIT_HASH
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/pf/pfalgo_common_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/pf/pfalgo_common_ref.h
@@ -1,13 +1,8 @@
 #ifndef PFALGO_COMMON_REF_H
 #define PFALGO_COMMON_REF_H
 
-#ifdef CMSSW_GIT_HASH
 #include "../dataformats/layer1_emulator.h"
 #include "pfalgo_types.h"
-#else
-#include "../../dataformats/layer1_emulator.h"
-#include "../firmware/pfalgo_types.h"
-#endif
 
 #include <algorithm>
 #include <vector>

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/pf/pfalgo_types.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/pf/pfalgo_types.h
@@ -1,11 +1,7 @@
 #ifndef FIRMWARE_PFALGO_TYPES_H
 #define FIRMWARE_PFALGO_TYPES_H
 
-#ifdef CMSSW_GIT_HASH
 #include "../dataformats/datatypes.h"
-#else
-#include "../../dataformats/datatypes.h"
-#endif
 
 namespace l1ct {
 

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/puppi/linpuppi_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/puppi/linpuppi_ref.cpp
@@ -2,20 +2,12 @@
 #include <cmath>
 #include <algorithm>
 
-#ifdef CMSSW_GIT_HASH
 #include "linpuppi_bits.h"
-#else
-#include "firmware/linpuppi_bits.h"
-#endif
 
 #include "../common/bitonic_hybrid_sort_ref.h"
 #include "../common/bitonic_sort_ref.h"
 
-#ifdef CMSSW_GIT_HASH
 #include "L1Trigger/Phase2L1ParticleFlow/src/dbgPrintf.h"
-#else
-#include "../utils/dbgPrintf.h"
-#endif
 
 #ifdef CMSSW_GIT_HASH
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/multififo/multififo_regionizer_elements_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/multififo/multififo_regionizer_elements_ref.h
@@ -1,7 +1,7 @@
 #ifndef multififo_regionizer_elements_ref_h
 #define multififo_regionizer_elements_ref_h
 
-#include "../../dataformats/layer1_emulator.h"
+#include "L1Trigger/Phase2L1ParticleFlow/src/newfirmware/dataformats/layer1_emulator.h"
 
 #include <list>
 #include <vector>

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/multififo/multififo_regionizer_elements_ref.icc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/multififo/multififo_regionizer_elements_ref.icc
@@ -1,8 +1,4 @@
-#ifdef CMSSW_GIT_HASH
 #include "L1Trigger/Phase2L1ParticleFlow/src/dbgPrintf.h"
-#else
-#include "../../utils/dbgPrintf.h"
-#endif
 
 template <typename T>
 void l1ct::multififo_regionizer::maybe_push(const T& t,

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/multififo/multififo_regionizer_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/multififo/multififo_regionizer_ref.cpp
@@ -1,11 +1,6 @@
 #include "multififo_regionizer_ref.h"
-#ifdef CMSSW_GIT_HASH
-#include "../../egamma/pfeginput_ref.h"
-#include "../../egamma/pfeginput_ref.cpp"
-#else
-#include "../../egamma/l1-input/ref/pfeginput_ref.h"
-#include "../../egamma/l1-input/ref/pfeginput_ref.cpp"
-#endif
+#include "L1Trigger/Phase2L1ParticleFlow/src/newfirmware/egamma/pfeginput_ref.h"
+#include "L1Trigger/Phase2L1ParticleFlow/src/newfirmware/egamma/pfeginput_ref.cpp"
 
 #include <iostream>
 #include <memory>

--- a/L1Trigger/Phase2L1ParticleFlow/test/make_l1ctLayer1_dumpFiles_cfg.py
+++ b/L1Trigger/Phase2L1ParticleFlow/test/make_l1ctLayer1_dumpFiles_cfg.py
@@ -76,4 +76,4 @@ process.pfClustersFromCombinedCaloHCal.phase2barrelCaloTowers = [cms.InputTag("L
 
 for det in "Barrel", "Barrel9", "HGCal", "HGCalNoTK", "HF":
     l1pf = getattr(process, 'l1ctLayer1'+det)
-    l1pf.dumpFileName = cms.untracked.string("TTbar_PU200_110X_"+det+".dump")
+    l1pf.dumpFileName = cms.untracked.string("TTbar_PU200_"+det+".dump")


### PR DESCRIPTION
Mainly changes to emulator code to remove some `#ifdef CMSSW_GIT_HASH`, shouldn't change anything in actual CMSSW output.
Fixed also the region definition in the barrel, where the number of GCT phi slices (in a mistake when rebasing 11_1_X code the number of slices had become 6 instead of 3)