### PR TITLE
Update HGCal link speed to 25G

### DIFF
--- a/L1Trigger/Phase2L1GMT/plugins/Phase2L1TGMTSAMuonProducer.cc
+++ b/L1Trigger/Phase2L1GMT/plugins/Phase2L1TGMTSAMuonProducer.cc
@@ -154,7 +154,7 @@ SAMuon Phase2L1TGMTSAMuonProducer::Convertl1tMuon(const l1t::Muon& mu, const int
 
   int bstart = 0;
   wordtype word(0);
-  bstart = wordconcat<wordtype>(word, bstart, pt>0, 1);
+  bstart = wordconcat<wordtype>(word, bstart, pt > 0, 1);
   bstart = wordconcat<wordtype>(word, bstart, pt, BITSGTPT);
   bstart = wordconcat<wordtype>(word, bstart, phi, BITSGTPHI);
   bstart = wordconcat<wordtype>(word, bstart, eta, BITSGTETA);

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/multififo/multififo_regionizer_elements_ref.icc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/multififo/multififo_regionizer_elements_ref.icc
@@ -53,7 +53,7 @@ void l1ct::multififo_regionizer::RegionBuffer<T>::initFifos(unsigned int nfifos)
     for (auto& t : queues_.back().second)
       t.clear();
   }
-  if (!(nfifos == 1 || nfifos == 2  || nfifos == 3 || nfifos == 4 || nfifos == 6 || nfifos == 8 || nfifos == 12)) {
+  if (!(nfifos == 1 || nfifos == 2 || nfifos == 3 || nfifos == 4 || nfifos == 6 || nfifos == 8 || nfifos == 12)) {
     dbgCerr() << "Error, created regionizer for nfifos == " << nfifos << ", not supported." << std::endl;
   }
   assert(nfifos == 1 || nfifos == 2 || nfifos == 3 || nfifos == 4 || nfifos == 6 || nfifos == 8 || nfifos == 12);

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/multififo/multififo_regionizer_elements_ref.icc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/multififo/multififo_regionizer_elements_ref.icc
@@ -53,10 +53,10 @@ void l1ct::multififo_regionizer::RegionBuffer<T>::initFifos(unsigned int nfifos)
     for (auto& t : queues_.back().second)
       t.clear();
   }
-  if (!(nfifos == 1 || nfifos == 2 || nfifos == 4 || nfifos == 6 || nfifos == 8 || nfifos == 12)) {
+  if (!(nfifos == 1 || nfifos == 2  || nfifos == 3 || nfifos == 4 || nfifos == 6 || nfifos == 8 || nfifos == 12)) {
     dbgCerr() << "Error, created regionizer for nfifos == " << nfifos << ", not supported." << std::endl;
   }
-  assert(nfifos == 1 || nfifos == 2 || nfifos == 4 || nfifos == 6 || nfifos == 8 || nfifos == 12);
+  assert(nfifos == 1 || nfifos == 2 || nfifos == 3 || nfifos == 4 || nfifos == 6 || nfifos == 8 || nfifos == 12);
 }
 
 template <typename T>
@@ -79,7 +79,7 @@ void l1ct::multififo_regionizer::RegionBuffer<T>::maybe_push(int fifo, const T& 
 
 template <typename T>
 T l1ct::multififo_regionizer::RegionBuffer<T>::pop() {
-  if (nfifos_ <= 2)  // probably works for 3 as well, but not tested
+  if (nfifos_ <= 3)
     return pop_next_trivial_();
   assert(!queues_.empty());
   for (unsigned int istep = 0, nsteps = queues_.size(); istep < nsteps; ++istep) {

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/multififo/multififo_regionizer_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/multififo/multififo_regionizer_ref.cpp
@@ -41,7 +41,7 @@ l1ct::MultififoRegionizerEmulator::MultififoRegionizerEmulator(unsigned int nend
       NTK_SECTORS(9),
       NCALO_SECTORS(3),
       NTK_LINKS(2),
-      NCALO_LINKS(2),
+      NCALO_LINKS(3),
       HCAL_LINKS(0),
       ECAL_LINKS(0),
       NMU_LINKS(1),
@@ -82,7 +82,7 @@ l1ct::MultififoRegionizerEmulator::MultififoRegionizerEmulator(unsigned int nend
             int other = (j == 0) ? 2 : 1;  // pf region 0, takes from prev. pf region 2 takes from next
             //                       from sector      , from link, to region, to fifo
             caloRoutes_.emplace_back(
-                (is + other) % 3 + 3 * ie, il, 3 * is + j + 9 * ie, il + 2);  //last 2 = NCALOFIBERS
+                (is + other) % 3 + 3 * ie, il, 3 * is + j + 9 * ie, il + NCALO_LINKS);
           }
         }
       }

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/multififo/multififo_regionizer_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/multififo/multififo_regionizer_ref.cpp
@@ -81,8 +81,7 @@ l1ct::MultififoRegionizerEmulator::MultififoRegionizerEmulator(unsigned int nend
           if (j == 0 || j == 2) {
             int other = (j == 0) ? 2 : 1;  // pf region 0, takes from prev. pf region 2 takes from next
             //                       from sector      , from link, to region, to fifo
-            caloRoutes_.emplace_back(
-                (is + other) % 3 + 3 * ie, il, 3 * is + j + 9 * ie, il + NCALO_LINKS);
+            caloRoutes_.emplace_back((is + other) % 3 + 3 * ie, il, 3 * is + j + 9 * ie, il + NCALO_LINKS);
           }
         }
       }


### PR DESCRIPTION
Increase number of virtual HGCal input links in endcap regionizer to cope with the switch from 16G to 25G link speed