### PR TITLE
Update Correlator Layer 1 configuration for latest HGCal geometry

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/python/l1ctLayer1_cff.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1ctLayer1_cff.py
@@ -141,12 +141,12 @@ _hgcalSectors = cms.VPSet(
     cms.PSet( 
         etaBoundaries = cms.vdouble(-3.0, -1.5),
         phiSlices     = cms.uint32(3),
-        phiZero       = cms.double(math.pi/6) # L1 TrackFinder phi sector and HGCal sectors shifted by 30deg,
+        phiZero       = cms.double(math.pi/2) # The edge of the 0th HGCal sectors is at 30 deg, the center at 30+120/2=90 = pi/2
     ),
     cms.PSet( 
         etaBoundaries = cms.vdouble(+1.5, +3.0),
         phiSlices     = cms.uint32(3),
-        phiZero       = cms.double(math.pi/6) # L1 TrackFinder phi sector and HGCal sectors shifted by 30deg,
+        phiZero       = cms.double(math.pi/2) # As above
     )
 
 )

--- a/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/multififo/multififo_regionizer_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/newfirmware/regionizer/multififo/multififo_regionizer_ref.cpp
@@ -74,14 +74,13 @@ l1ct::MultififoRegionizerEmulator::MultififoRegionizerEmulator(unsigned int nend
   // hgcal
   assert(NCALO_SECTORS == 3 && NTK_SECTORS == 9);  // otherwise math below is broken, but it's hard to make it generic
   for (unsigned int ie = 0; ie < nendcaps; ++ie) {
-    for (unsigned int is = 0; is < NCALO_SECTORS; ++is) {  // NCALO_SECTORS sectors
-      for (unsigned int il = 0; il < NCALO_LINKS; ++il) {  // max clusters per sector per clock
-        for (unsigned int j = 0; j < 3; ++j) {             // PF REGION
-          caloRoutes_.emplace_back(is + 3 * ie, il, 3 * is + j + 9 * ie, il);
-          if (j == 0 || j == 2) {
-            int other = (j == 0) ? 2 : 1;  // pf region 0, takes from prev. pf region 2 takes from next
-            //                       from sector      , from link, to region, to fifo
-            caloRoutes_.emplace_back((is + other) % 3 + 3 * ie, il, 3 * is + j + 9 * ie, il + NCALO_LINKS);
+    for (unsigned int is = 0; is < NCALO_SECTORS; ++is) {                      // NCALO_SECTORS sectors
+      for (unsigned int il = 0; il < NCALO_LINKS; ++il) {                      // max clusters per sector per clock
+        for (unsigned int j = 0; j < 3; ++j) {                                 // PF REGION
+          caloRoutes_.emplace_back(is + 3 * ie, il, 3 * is + j + 9 * ie, il);  // 4 args are: sector, link, region, fifo
+          if (j != 2) {  // pf regions 0 and 1 take also from previous sector
+            int isprev = (is > 0 ? is - 1 : NCALO_SECTORS - 1);
+            caloRoutes_.emplace_back(isprev + 3 * ie, il, 3 * is + j + 9 * ie, il + NCALO_LINKS);
           }
         }
       }


### PR DESCRIPTION
Update Correlator Layer 1 configuration for latest HGCal geometry:
 * the first sector is now centered at &phi; = &pi;/2 (90&deg;) instead of &phi; = &pi;/6 (30&deg;).
 * the link routing in the regionizer is changed accordigly: now PF regions 3n+0 and 3n+1 take inputs from HGCal sectors n and n-1, while PF region 3n+2 takes inputs only from sector n
