### PR TITLE
Update deregionizer inputs emulation for proper CTL1 output ordering

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/interface/deregionizer/deregionizer_input.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/deregionizer/deregionizer_input.h
@@ -13,9 +13,8 @@ namespace l1ct {
 
   class DeregionizerInput {
   public:
-
     // struct to represent how each correlator layer 1 board output is structured
-    struct BoardInfo{
+    struct BoardInfo {
       uint nOutputFramesPerBX_;
       uint nPuppiFramesPerRegion_;
       uint nLinksPuppi_;
@@ -25,12 +24,12 @@ namespace l1ct {
     };
 
     // struct to represent how each puppi object is positioned in the input frame
-    struct LinkPlacementInfo{
+    struct LinkPlacementInfo {
       uint board_;
       uint link_;
       uint clock_cycle_;
       // for sorting
-      bool operator < (const LinkPlacementInfo& other) const {
+      bool operator<(const LinkPlacementInfo &other) const {
         bool cc_lt = this->clock_cycle_ < other.clock_cycle_;
         bool cc_eq = this->clock_cycle_ == other.clock_cycle_;
         bool board_lt = this->board_ < other.board_;
@@ -45,15 +44,17 @@ namespace l1ct {
     std::vector<BoardInfo> boardInfos_;
 
     // note: this one for use in standalone testbench
-    DeregionizerInput(std::vector<BoardInfo> boardInfos) : boardInfos_(boardInfos){}
+    DeregionizerInput(std::vector<BoardInfo> boardInfos) : boardInfos_(boardInfos) {}
 
     // note: this one will work only in CMSSW
     DeregionizerInput(const std::vector<edm::ParameterSet> linkConfigs);
 
     ~DeregionizerInput(){};
 
-    std::vector<std::pair<l1ct::PuppiObjEmu, LPI>> inputOrderInfo(const std::vector<l1ct::OutputRegion> &inputRegions) const;
-    std::vector<std::vector<std::vector<l1ct::PuppiObjEmu>>> orderInputs(const std::vector<l1ct::OutputRegion> &inputRegions) const;
+    std::vector<std::pair<l1ct::PuppiObjEmu, LPI>> inputOrderInfo(
+        const std::vector<l1ct::OutputRegion> &inputRegions) const;
+    std::vector<std::vector<std::vector<l1ct::PuppiObjEmu>>> orderInputs(
+        const std::vector<l1ct::OutputRegion> &inputRegions) const;
 
     void setDebug(bool debug = true) { debug_ = debug; }
 
@@ -62,7 +63,6 @@ namespace l1ct {
     // these are not configurable in current design
     uint nInputFramesPerBX_ = 9;
     uint tmuxFactor_ = 6;
-
   };
 
 }  // namespace l1ct

--- a/L1Trigger/Phase2L1ParticleFlow/interface/deregionizer/deregionizer_input.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/deregionizer/deregionizer_input.h
@@ -2,46 +2,67 @@
 #define L1Trigger_Phase2L1ParticleFlow_deregionizer_input_h
 
 #include <vector>
+#include <algorithm>
 #include "DataFormats/L1TParticleFlow/interface/layer1_emulator.h"
+
+namespace edm {
+  class ParameterSet;
+}
 
 namespace l1ct {
 
   class DeregionizerInput {
   public:
-    static const unsigned int nEtaRegions =
-        6 /*7 with HF*/;  // Fold ([-0.5,0.0] and [0.0,+0.5]) and ([+-0.5,+-1.0] and [+-1.0,+-1.5]) eta slices into phi
-    static const unsigned int nPhiRegions =
-        18;  // 9 phi slices * 2 to account for the barrel having x2 PF regions per eta slice in the barrel
 
-    DeregionizerInput(std::vector<float> &regionEtaCenter,
-                      std::vector<float> &regionPhiCenter,
-                      const std::vector<l1ct::OutputRegion> &inputRegions);
+    // struct to represent how each correlator layer 1 board output is structured
+    struct BoardInfo{
+      uint nOutputFramesPerBX_;
+      uint nPuppiFramesPerRegion_;
+      uint nLinksPuppi_;
+      uint nPuppiPerRegion_;
+      uint order_;
+      std::vector<uint> regions_;
+    };
+
+    // struct to represent how each puppi object is positioned in the input frame
+    struct LinkPlacementInfo{
+      uint board_;
+      uint link_;
+      uint clock_cycle_;
+      // for sorting
+      bool operator < (const LinkPlacementInfo& other) const {
+        bool cc_lt = this->clock_cycle_ < other.clock_cycle_;
+        bool cc_eq = this->clock_cycle_ == other.clock_cycle_;
+        bool board_lt = this->board_ < other.board_;
+        bool board_eq = this->board_ == other.board_;
+        bool link_lt = this->link_ < other.link_;
+        return cc_eq ? (board_eq ? link_lt : board_lt) : cc_lt;
+      }
+    };
+    typedef LinkPlacementInfo LPI;
+    typedef std::pair<l1ct::PuppiObjEmu, LPI> PlacedPuppi;
+
+    std::vector<BoardInfo> boardInfos_;
+
+    // note: this one for use in standalone testbench
+    DeregionizerInput(std::vector<BoardInfo> boardInfos) : boardInfos_(boardInfos){}
+
+    // note: this one will work only in CMSSW
+    DeregionizerInput(const std::vector<edm::ParameterSet> linkConfigs);
+
+    ~DeregionizerInput(){};
+
+    std::vector<std::pair<l1ct::PuppiObjEmu, LPI>> inputOrderInfo(const std::vector<l1ct::OutputRegion> &inputRegions) const;
+    std::vector<std::vector<std::vector<l1ct::PuppiObjEmu>>> orderInputs(const std::vector<l1ct::OutputRegion> &inputRegions) const;
 
     void setDebug(bool debug = true) { debug_ = debug; }
 
-    enum regionIndex {
-      centralBarl = 0,
-      negBarl = 1,
-      posBarl = 2,
-      negHGCal = 3,
-      posHGCal = 4,
-      forwardHGCal = 5 /*, HF = 6*/
-    };
-    void orderRegions(int order[nEtaRegions]);
-
-    const std::vector<std::vector<std::vector<l1ct::PuppiObjEmu> > > &orderedInRegionsPuppis() const {
-      return orderedInRegionsPuppis_;
-    };
-
   private:
-    std::vector<float> regionEtaCenter_;
-    std::vector<float> regionPhiCenter_;
-    std::vector<std::vector<std::vector<l1ct::PuppiObjEmu> > > orderedInRegionsPuppis_;
-
     bool debug_ = false;
+    // these are not configurable in current design
+    uint nInputFramesPerBX_ = 9;
+    uint tmuxFactor_ = 6;
 
-    unsigned int orderRegionsInPhi(const float eta, const float phi, const float etaComp) const;
-    void initRegions(const std::vector<l1ct::OutputRegion> &inputRegions);
   };
 
 }  // namespace l1ct

--- a/L1Trigger/Phase2L1ParticleFlow/interface/deregionizer/deregionizer_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/deregionizer/deregionizer_ref.h
@@ -25,12 +25,9 @@ namespace l1ct {
 
     void setDebug(bool debug = true) { debug_ = debug; }
 
-    void run(const DeregionizerInput in,
+    void run(std::vector<std::vector<std::vector<l1ct::PuppiObjEmu>>> in,
              std::vector<l1ct::PuppiObjEmu> &out,
              std::vector<l1ct::PuppiObjEmu> &truncated);
-
-    std::vector<std::vector<l1ct::PuppiObjEmu> > splitPFregions(
-        const std::vector<std::vector<std::vector<l1ct::PuppiObjEmu> > > &regionPuppis, const int i, const int j);
 
   private:
     unsigned int nPuppiFinalBuffer_, nPuppiPerClk_, nPuppiFirstBuffers_, nPuppiSecondBuffers_, nPuppiThirdBuffers_;
@@ -39,6 +36,9 @@ namespace l1ct {
     static std::vector<l1ct::PuppiObjEmu> mergeXtoY(const unsigned int X,
                                                     const unsigned int Y,
                                                     const std::vector<l1ct::PuppiObjEmu> &inLeft,
+                                                    const std::vector<l1ct::PuppiObjEmu> &inRight);
+
+    static std::vector<l1ct::PuppiObjEmu> mergeXtoY(const std::vector<l1ct::PuppiObjEmu> &inLeft,
                                                     const std::vector<l1ct::PuppiObjEmu> &inRight);
 
     static void accumulateToY(const unsigned int Y,

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/DeregionizerProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/DeregionizerProducer.cc
@@ -17,12 +17,17 @@ class DeregionizerProducer : public edm::stream::EDProducer<> {
 public:
   explicit DeregionizerProducer(const edm::ParameterSet &);
   ~DeregionizerProducer() override;
-  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 private:
   edm::ParameterSet config_;
   edm::EDGetTokenT<l1t::PFCandidateRegionalOutput> token_;
+  std::vector<edm::ParameterSet> linkConfigs_;
+  const unsigned int nInputFramesPerBX_;
   l1ct::DeregionizerEmulator emulator_;
+  l1ct::DeregionizerInput input_;
+  std::vector<uint32_t> boardOrder_, nOutputFramesPerBX_, nPuppiFramesPerRegion_, nLinksPuppi_, nPuppiPerRegion_;
+  std::vector<std::vector<uint32_t>> outputRegions_;
+  const unsigned int tmuxFactor_ = 6;  // not really configurable in current architecture
 
   std::unordered_map<const l1t::PFCandidate *, l1t::PFClusterRef> clusterRefMap_;
   std::unordered_map<const l1t::PFCandidate *, l1t::PFTrackRef> trackRefMap_;
@@ -36,7 +41,11 @@ private:
 DeregionizerProducer::DeregionizerProducer(const edm::ParameterSet &iConfig)
     : config_(iConfig),
       token_(consumes<l1t::PFCandidateRegionalOutput>(iConfig.getParameter<edm::InputTag>("RegionalPuppiCands"))),
-      emulator_(iConfig) {
+      linkConfigs_(iConfig.getUntrackedParameter<std::vector<edm::ParameterSet>>(
+          "linkConfigs", std::vector<edm::ParameterSet>())),
+      nInputFramesPerBX_(iConfig.getParameter<uint32_t>("nInputFramesPerBX")),
+      emulator_(iConfig),
+      input_(linkConfigs_) {
   produces<l1t::PFCandidateCollection>("Puppi");
   produces<l1t::PFCandidateCollection>("TruncatedPuppi");
 }
@@ -55,7 +64,6 @@ void DeregionizerProducer::produce(edm::Event &iEvent, const edm::EventSetup &iS
 
   iEvent.getByToken(token_, src);
 
-  std::vector<float> regionEtas, regionPhis;
   std::vector<l1ct::OutputRegion> outputRegions;
   std::vector<l1ct::PuppiObjEmu> hwOut;
   std::vector<l1t::PFCandidate> edmOut;
@@ -86,16 +94,12 @@ void DeregionizerProducer::produce(edm::Event &iEvent, const edm::EventSetup &iS
                                        << "] = " << tempOutputRegion.puppi.back().floatEta() << ", phi[" << i
                                        << "] = " << tempOutputRegion.puppi.back().floatPhi();
     }
-    if (!tempOutputRegion.puppi.empty()) {
-      regionEtas.push_back(eta);
-      regionPhis.push_back(phi);
-      outputRegions.push_back(tempOutputRegion);
-    }
+    outputRegions.push_back(tempOutputRegion);
   }
 
-  l1ct::DeregionizerInput in = l1ct::DeregionizerInput(regionEtas, regionPhis, outputRegions);
+  std::vector<std::vector<std::vector<l1ct::PuppiObjEmu>>> layer2In = input_.orderInputs(outputRegions);
 
-  emulator_.run(in, hwOut, hwTruncOut);
+  emulator_.run(layer2In, hwOut, hwTruncOut);
 
   DeregionizerProducer::hwToEdm_(hwOut, edmOut);
   DeregionizerProducer::hwToEdm_(hwTruncOut, edmTruncOut);
@@ -168,20 +172,6 @@ void DeregionizerProducer::setRefs_(l1t::PFCandidate &pf, const l1ct::PuppiObjEm
     }
     pf.setMuon(match->second);
   }
-}
-
-void DeregionizerProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
-  // DeregionizerProducer
-  edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("RegionalPuppiCands", edm::InputTag("l1ctLayer1", "PuppiRegional"));
-  desc.add<unsigned int>("nPuppiFinalBuffer", 128);
-  desc.add<unsigned int>("nPuppiPerClk", 6);
-  desc.add<unsigned int>("nPuppiFirstBuffers", 12);
-  desc.add<unsigned int>("nPuppiSecondBuffers", 32);
-  desc.add<unsigned int>("nPuppiThirdBuffers", 64);
-  descriptions.add("DeregionizerProducer", desc);
-  // or use the following to generate the label from the module's C++ type
-  //descriptions.addWithDefaultLabel(desc);
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/DeregionizerProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/DeregionizerProducer.cc
@@ -41,8 +41,8 @@ private:
 DeregionizerProducer::DeregionizerProducer(const edm::ParameterSet &iConfig)
     : config_(iConfig),
       token_(consumes<l1t::PFCandidateRegionalOutput>(iConfig.getParameter<edm::InputTag>("RegionalPuppiCands"))),
-      linkConfigs_(iConfig.getUntrackedParameter<std::vector<edm::ParameterSet>>(
-          "linkConfigs", std::vector<edm::ParameterSet>())),
+      linkConfigs_(iConfig.getUntrackedParameter<std::vector<edm::ParameterSet>>("linkConfigs",
+                                                                                 std::vector<edm::ParameterSet>())),
       nInputFramesPerBX_(iConfig.getParameter<uint32_t>("nInputFramesPerBX")),
       emulator_(iConfig),
       input_(linkConfigs_) {

--- a/L1Trigger/Phase2L1ParticleFlow/python/DeregionizerProducer_cfi.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/DeregionizerProducer_cfi.py
@@ -1,10 +1,67 @@
 import FWCore.ParameterSet.Config as cms
 
+# Specifications for Correlator Layer 1 output mapping onto links
+barrelConfig_ = cms.PSet(
+    partition = cms.string("Barrel"),
+    nLinksPuppi = cms.uint32(6),
+    nPuppiPerRegion = cms.uint32(18),
+    nOutputFramesPerBX = cms.uint32(9),
+)
+
+barrelPhiConfigs = [
+    barrelConfig_.clone(
+        outputRegions = cms.vuint32(*[3*ip+9*ie+i for ie in range(6) for i in range(3) ]),
+        outputBoard = cms.int32(ip),
+    ) for ip in range(3)
+]
+
+hgcalConfig_ = cms.PSet(
+    partition = cms.string("HGCal"),
+    nLinksPuppi = cms.uint32(3),
+    nPuppiPerRegion = cms.uint32(18),
+    nOutputFramesPerBX = cms.uint32(9),
+    outputRegions = cms.vuint32(*[54 + i+9 for i in range(9)]),
+    outputBoard = cms.int32(3),
+)
+
+hgcalPosConfig = hgcalConfig_.clone(
+    outputBoard = cms.int32(4)
+)
+hgcalNegConfig = hgcalConfig_.clone(
+    outputRegions = [54 + i for i in range(9)]
+)
+
+hgcalNoTKConfig = cms.PSet(
+    partition = cms.string("HGCalNoTk"),
+    nLinksPuppi = cms.uint32(4),
+    nPuppiPerRegion = cms.uint32(12),
+    nOutputFramesPerBX = cms.uint32(9),
+    outputRegions = cms.vuint32(*range(72,72+18)),
+    outputBoard = cms.int32(5),
+)
+
+hfConfig_ = cms.PSet(
+    partition = cms.string("HF"),
+    nLinksPuppi = cms.uint32(3),
+    nPuppiPerRegion = cms.uint32(18),
+    nOutputFramesPerBX = cms.uint32(9),
+)
+hfConfigs = [
+    hfConfig_.clone(
+        outputRegions = cms.vuint32(*[90+9*ie+i for i in range(9)]),
+        outputBoard = cms.int32(6 + ie),
+    ) for ie in range(2)
+]
+
+linkConfigs = cms.untracked.VPSet(*barrelPhiConfigs, hgcalPosConfig, hgcalNegConfig, hgcalNoTKConfig, *hfConfigs)
+
 DeregionizerProducer = cms.EDProducer("DeregionizerProducer",
                            RegionalPuppiCands  = cms.InputTag("l1ctLayer1","PuppiRegional"),
                            nPuppiFinalBuffer   = cms.uint32(128),
                            nPuppiPerClk        = cms.uint32(6),
                            nPuppiFirstBuffers  = cms.uint32(12),
                            nPuppiSecondBuffers = cms.uint32(32),
-                           nPuppiThirdBuffers  = cms.uint32(64)
+                           nPuppiThirdBuffers  = cms.uint32(64),
+                           nInputFramesPerBX   = cms.uint32(9),
+                           linkConfigs         = linkConfigs,
                          )

--- a/L1Trigger/Phase2L1ParticleFlow/src/deregionizer/deregionizer_input.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/deregionizer/deregionizer_input.cpp
@@ -1,87 +1,67 @@
-#include <fstream>
-#include <cmath>
 #include <vector>
 #include "L1Trigger/Phase2L1ParticleFlow/interface/deregionizer/deregionizer_input.h"
 #include "L1Trigger/Phase2L1ParticleFlow/interface/dbgPrintf.h"
 
-l1ct::DeregionizerInput::DeregionizerInput(std::vector<float> &regionEtaCenter,
-                                           std::vector<float> &regionPhiCenter,
-                                           const std::vector<l1ct::OutputRegion> &inputRegions)
-    : regionEtaCenter_(regionEtaCenter), regionPhiCenter_(regionPhiCenter) {
-  orderedInRegionsPuppis_ = std::vector<std::vector<std::vector<l1ct::PuppiObjEmu> > >(nEtaRegions);
-  for (int i = 0, n = nEtaRegions; i < n; i++)
-    orderedInRegionsPuppis_[i].resize(nPhiRegions);
-  initRegions(inputRegions);
-}
-
-// +pi read first & account for 2 small eta regions per phi slice
-unsigned int l1ct::DeregionizerInput::orderRegionsInPhi(const float eta, const float phi, const float etaComp) const {
-  unsigned int y;
-  if (fabs(phi) < 0.35)
-    y = (eta < etaComp ? 0 : 1);
-  else if (fabs(phi) < 1.05)
-    y = (phi > 0 ? (eta < etaComp ? 2 : 3) : (eta < etaComp ? 16 : 17));
-  else if (fabs(phi) < 1.75)
-    y = (phi > 0 ? (eta < etaComp ? 4 : 5) : (eta < etaComp ? 14 : 15));
-  else if (fabs(phi) < 2.45)
-    y = (phi > 0 ? (eta < etaComp ? 6 : 7) : (eta < etaComp ? 12 : 13));
-  else
-    y = (phi > 0 ? (eta < etaComp ? 8 : 9) : (eta < etaComp ? 10 : 11));
-  return y;
-}
-
-void l1ct::DeregionizerInput::initRegions(const std::vector<l1ct::OutputRegion> &inputRegions) {
-  for (int i = 0, n = inputRegions.size(); i < n; i++) {
-    unsigned int x, y;
-    float eta = regionEtaCenter_[i];
-    float phi = regionPhiCenter_[i];
-
-    if (fabs(eta) < 0.5) {
-      x = 0;
-      y = orderRegionsInPhi(eta, phi, 0.0);
-    } else if (fabs(eta) < 1.5) {
-      x = (eta < 0.0 ? 1 : 2);
-      y = (eta < 0.0 ? orderRegionsInPhi(eta, phi, -1.0) : orderRegionsInPhi(eta, phi, 1.0));
-    } else if (fabs(eta) < 2.5) {
-      x = (eta < 0.0 ? 3 : 4);
-      y = orderRegionsInPhi(eta, phi, 999.0);  // Send all candidates in 3 clks, then wait 3 clks for the barrel
-    } else /*if ( fabs(eta) < 3.0 )*/ {
-      x = 5;
-      y = orderRegionsInPhi(eta, phi, 0.0);  // Send eta<0 in 3 clks, eta>0 in the next 3 clks
-    }
-    /*else x = 6;*/  // HF
-
-    orderedInRegionsPuppis_[x][y].insert(orderedInRegionsPuppis_[x][y].end(),
-                                         inputRegions[i].puppi.begin(),
-                                         inputRegions[i].puppi.end());  // For now, merging HF with forward HGCal
-
-    while (!orderedInRegionsPuppis_[x][y].empty() && orderedInRegionsPuppis_[x][y].back().hwPt == 0)
-      orderedInRegionsPuppis_[x][y].pop_back();  // Zero suppression
+#ifdef CMSSW_GIT_HASH
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+l1ct::DeregionizerInput::DeregionizerInput(const std::vector<edm::ParameterSet> linkConfigs){
+  for(const auto &pset : linkConfigs){
+    DeregionizerInput::BoardInfo boardInfo;
+    boardInfo.nOutputFramesPerBX_ = pset.getParameter<uint32_t>("nOutputFramesPerBX");
+    boardInfo.nLinksPuppi_ = pset.getParameter<uint32_t>("nLinksPuppi");
+    boardInfo.nPuppiPerRegion_ = pset.getParameter<uint32_t>("nPuppiPerRegion");
+    boardInfo.order_ = pset.getParameter<int32_t>("outputBoard");
+    boardInfo.regions_ = pset.getParameter<std::vector<uint32_t>>("outputRegions");
+    boardInfo.nPuppiFramesPerRegion_ = (boardInfo.nOutputFramesPerBX_ * tmuxFactor_) / boardInfo.regions_.size();
+    boardInfos_.push_back(boardInfo);
   }
 }
+#endif
 
-void l1ct::DeregionizerInput::orderRegions(int order[nEtaRegions]) {
-  std::vector<std::vector<std::vector<l1ct::PuppiObjEmu> > > tmpOrderedInRegionsPuppis;
-  for (int i = 0, n = nEtaRegions; i < n; i++)
-    tmpOrderedInRegionsPuppis.push_back(orderedInRegionsPuppis_[order[i]]);
-  orderedInRegionsPuppis_ = tmpOrderedInRegionsPuppis;
 
-  if (debug_) {
-    for (int i = 0, nx = orderedInRegionsPuppis_.size(); i < nx; i++) {
-      dbgCout() << "\n";
-      dbgCout() << "Eta region index : " << i << "\n";
-      for (int j = 0, ny = orderedInRegionsPuppis_[i].size(); j < ny; j++) {
-        dbgCout() << " ---> Phi region index : " << j << "\n";
-        for (int iPup = 0, nPup = orderedInRegionsPuppis_[i][j].size(); iPup < nPup; iPup++) {
-          dbgCout() << "      > puppi[" << iPup << "]"
-                    << " pt = " << orderedInRegionsPuppis_[i][j][iPup].hwPt << "\n";
+std::vector<l1ct::DeregionizerInput::PlacedPuppi> l1ct::DeregionizerInput::inputOrderInfo(const std::vector<l1ct::OutputRegion> &inputRegions) const {
+  // Vector of all puppis in event paired with LinkPlacementInfo
+  std::vector<PlacedPuppi> linkPlacedPuppis;
+  for(BoardInfo boardInfo : boardInfos_){
+    for(uint iRegion = 0; iRegion < boardInfo.regions_.size(); iRegion++){
+      uint iRegionEvent = boardInfo.regions_.at(iRegion);
+      auto puppi = inputRegions.at(iRegionEvent).puppi;
+      unsigned int npuppi = puppi.size();
+      for (unsigned int i = 0; i < boardInfo.nLinksPuppi_ * boardInfo.nPuppiFramesPerRegion_; ++i) {
+        if(i < npuppi){
+          uint iClock = iRegion * boardInfo.nPuppiPerRegion_ / boardInfo.nLinksPuppi_ + i % boardInfo.nPuppiFramesPerRegion_;
+          uint iLink = i / boardInfo.nPuppiFramesPerRegion_;
+          LPI lpi = {boardInfo.order_, iLink, iClock};
+          linkPlacedPuppis.push_back(std::make_pair(puppi.at(i), lpi));
         }
       }
-      dbgCout() << " ----------------- "
-                << "\n";
     }
-    dbgCout() << "Regions ordered!"
-              << "\n";
-    dbgCout() << "\n";
   }
+  return linkPlacedPuppis;
+}
+
+std::vector<std::vector<std::vector<l1ct::PuppiObjEmu>>> l1ct::DeregionizerInput::orderInputs(const std::vector<l1ct::OutputRegion> &inputRegions) const {
+  std::vector<PlacedPuppi> linkPlacedPuppis = inputOrderInfo(inputRegions);
+  std::vector<std::vector<std::vector<l1ct::PuppiObjEmu>>> layer2inReshape(nInputFramesPerBX_ * tmuxFactor_);
+  for(uint iClock = 0; iClock < nInputFramesPerBX_ * tmuxFactor_; iClock++){ 
+    std::vector<std::vector<l1ct::PuppiObjEmu>> orderedPupsOnClock(boardInfos_.size());
+    // Find all the puppis on this clock cycle
+    for(BoardInfo boardInfo : boardInfos_){
+      // find all puppis on this clock cycle, from this board
+      std::vector<l1ct::PuppiObjEmu> orderedPupsOnClockOnBoard;
+      for(uint iLink = 0; iLink < boardInfo.nLinksPuppi_; iLink++){
+        // find all puppis from this clock cycle, from this board, from this link
+        auto onClockOnBoardOnLink = [&](PlacedPuppi p){ return (p.second.clock_cycle_ == iClock) && (p.second.board_ == boardInfo.order_) && (p.second.link_ == iLink); };
+        std::vector<PlacedPuppi> allPupsOnClockOnBoardOnLink;
+        std::copy_if(std::begin(linkPlacedPuppis), std::end(linkPlacedPuppis), std::back_inserter(allPupsOnClockOnBoardOnLink), onClockOnBoardOnLink);
+        linkPlacedPuppis.erase(std::remove_if(std::begin(linkPlacedPuppis), std::end(linkPlacedPuppis), onClockOnBoardOnLink), std::end(linkPlacedPuppis)); // erase already placed pups
+        if(!allPupsOnClockOnBoardOnLink.empty()){
+          orderedPupsOnClockOnBoard.push_back(allPupsOnClockOnBoardOnLink.at(0).first);
+        }
+      }
+      orderedPupsOnClock.at(boardInfo.order_) = orderedPupsOnClockOnBoard;
+    }
+    layer2inReshape.at(iClock) = orderedPupsOnClock;
+  }
+  return layer2inReshape;
 }

--- a/L1Trigger/Phase2L1ParticleFlow/src/deregionizer/deregionizer_input.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/deregionizer/deregionizer_input.cpp
@@ -4,8 +4,8 @@
 
 #ifdef CMSSW_GIT_HASH
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-l1ct::DeregionizerInput::DeregionizerInput(const std::vector<edm::ParameterSet> linkConfigs){
-  for(const auto &pset : linkConfigs){
+l1ct::DeregionizerInput::DeregionizerInput(const std::vector<edm::ParameterSet> linkConfigs) {
+  for (const auto &pset : linkConfigs) {
     DeregionizerInput::BoardInfo boardInfo;
     boardInfo.nOutputFramesPerBX_ = pset.getParameter<uint32_t>("nOutputFramesPerBX");
     boardInfo.nLinksPuppi_ = pset.getParameter<uint32_t>("nLinksPuppi");
@@ -18,18 +18,19 @@ l1ct::DeregionizerInput::DeregionizerInput(const std::vector<edm::ParameterSet> 
 }
 #endif
 
-
-std::vector<l1ct::DeregionizerInput::PlacedPuppi> l1ct::DeregionizerInput::inputOrderInfo(const std::vector<l1ct::OutputRegion> &inputRegions) const {
+std::vector<l1ct::DeregionizerInput::PlacedPuppi> l1ct::DeregionizerInput::inputOrderInfo(
+    const std::vector<l1ct::OutputRegion> &inputRegions) const {
   // Vector of all puppis in event paired with LinkPlacementInfo
   std::vector<PlacedPuppi> linkPlacedPuppis;
-  for(BoardInfo boardInfo : boardInfos_){
-    for(uint iRegion = 0; iRegion < boardInfo.regions_.size(); iRegion++){
+  for (BoardInfo boardInfo : boardInfos_) {
+    for (uint iRegion = 0; iRegion < boardInfo.regions_.size(); iRegion++) {
       uint iRegionEvent = boardInfo.regions_.at(iRegion);
       auto puppi = inputRegions.at(iRegionEvent).puppi;
       unsigned int npuppi = puppi.size();
       for (unsigned int i = 0; i < boardInfo.nLinksPuppi_ * boardInfo.nPuppiFramesPerRegion_; ++i) {
-        if(i < npuppi){
-          uint iClock = iRegion * boardInfo.nPuppiPerRegion_ / boardInfo.nLinksPuppi_ + i % boardInfo.nPuppiFramesPerRegion_;
+        if (i < npuppi) {
+          uint iClock =
+              iRegion * boardInfo.nPuppiPerRegion_ / boardInfo.nLinksPuppi_ + i % boardInfo.nPuppiFramesPerRegion_;
           uint iLink = i / boardInfo.nPuppiFramesPerRegion_;
           LPI lpi = {boardInfo.order_, iLink, iClock};
           linkPlacedPuppis.push_back(std::make_pair(puppi.at(i), lpi));
@@ -40,22 +41,31 @@ std::vector<l1ct::DeregionizerInput::PlacedPuppi> l1ct::DeregionizerInput::input
   return linkPlacedPuppis;
 }
 
-std::vector<std::vector<std::vector<l1ct::PuppiObjEmu>>> l1ct::DeregionizerInput::orderInputs(const std::vector<l1ct::OutputRegion> &inputRegions) const {
+std::vector<std::vector<std::vector<l1ct::PuppiObjEmu>>> l1ct::DeregionizerInput::orderInputs(
+    const std::vector<l1ct::OutputRegion> &inputRegions) const {
   std::vector<PlacedPuppi> linkPlacedPuppis = inputOrderInfo(inputRegions);
   std::vector<std::vector<std::vector<l1ct::PuppiObjEmu>>> layer2inReshape(nInputFramesPerBX_ * tmuxFactor_);
-  for(uint iClock = 0; iClock < nInputFramesPerBX_ * tmuxFactor_; iClock++){ 
+  for (uint iClock = 0; iClock < nInputFramesPerBX_ * tmuxFactor_; iClock++) {
     std::vector<std::vector<l1ct::PuppiObjEmu>> orderedPupsOnClock(boardInfos_.size());
     // Find all the puppis on this clock cycle
-    for(BoardInfo boardInfo : boardInfos_){
+    for (BoardInfo boardInfo : boardInfos_) {
       // find all puppis on this clock cycle, from this board
       std::vector<l1ct::PuppiObjEmu> orderedPupsOnClockOnBoard;
-      for(uint iLink = 0; iLink < boardInfo.nLinksPuppi_; iLink++){
+      for (uint iLink = 0; iLink < boardInfo.nLinksPuppi_; iLink++) {
         // find all puppis from this clock cycle, from this board, from this link
-        auto onClockOnBoardOnLink = [&](PlacedPuppi p){ return (p.second.clock_cycle_ == iClock) && (p.second.board_ == boardInfo.order_) && (p.second.link_ == iLink); };
+        auto onClockOnBoardOnLink = [&](PlacedPuppi p) {
+          return (p.second.clock_cycle_ == iClock) && (p.second.board_ == boardInfo.order_) &&
+                 (p.second.link_ == iLink);
+        };
         std::vector<PlacedPuppi> allPupsOnClockOnBoardOnLink;
-        std::copy_if(std::begin(linkPlacedPuppis), std::end(linkPlacedPuppis), std::back_inserter(allPupsOnClockOnBoardOnLink), onClockOnBoardOnLink);
-        linkPlacedPuppis.erase(std::remove_if(std::begin(linkPlacedPuppis), std::end(linkPlacedPuppis), onClockOnBoardOnLink), std::end(linkPlacedPuppis)); // erase already placed pups
-        if(!allPupsOnClockOnBoardOnLink.empty()){
+        std::copy_if(std::begin(linkPlacedPuppis),
+                     std::end(linkPlacedPuppis),
+                     std::back_inserter(allPupsOnClockOnBoardOnLink),
+                     onClockOnBoardOnLink);
+        linkPlacedPuppis.erase(
+            std::remove_if(std::begin(linkPlacedPuppis), std::end(linkPlacedPuppis), onClockOnBoardOnLink),
+            std::end(linkPlacedPuppis));  // erase already placed pups
+        if (!allPupsOnClockOnBoardOnLink.empty()) {
           orderedPupsOnClockOnBoard.push_back(allPupsOnClockOnBoardOnLink.at(0).first);
         }
       }

--- a/L1Trigger/Phase2L1ParticleFlow/src/deregionizer/deregionizer_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/deregionizer/deregionizer_ref.cpp
@@ -81,15 +81,13 @@ static void debugPrint(const std::string &header, const std::vector<l1ct::PuppiO
 
 void l1ct::DeregionizerEmulator::run(std::vector<std::vector<std::vector<l1ct::PuppiObjEmu>>> in,
                                      std::vector<l1ct::PuppiObjEmu> &out,
-                                     std::vector<l1ct::PuppiObjEmu> &truncated
-){
-  
+                                     std::vector<l1ct::PuppiObjEmu> &truncated) {
   for (int i = 0, n = in.size(); i < n; i++) {
     std::vector<std::vector<l1ct::PuppiObjEmu>> pupsOnClock = in[i];
     std::vector<l1ct::PuppiObjEmu> intermediateTruncated;
     // Merge PF regions from this cycle. No truncation happens here
     std::vector<l1ct::PuppiObjEmu> buffer;
-    for(const auto& pupsOnClockOnBoard : pupsOnClock){
+    for (const auto &pupsOnClockOnBoard : pupsOnClock) {
       buffer = mergeXtoY(buffer, pupsOnClockOnBoard);
     }
 

--- a/L1Trigger/Phase2L1ParticleFlow/src/deregionizer/deregionizer_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/deregionizer/deregionizer_ref.cpp
@@ -33,27 +33,26 @@ l1ct::DeregionizerEmulator::DeregionizerEmulator(const unsigned int nPuppiFinalB
          nPuppiSecondBuffers < nPuppiThirdBuffers && nPuppiThirdBuffers <= nPuppiFinalBuffer);
 }
 
-std::vector<std::vector<l1ct::PuppiObjEmu> > l1ct::DeregionizerEmulator::splitPFregions(
-    const std::vector<std::vector<std::vector<l1ct::PuppiObjEmu> > > &regionPuppis, const int i, const int j) {
-  int k = nPuppiPerClk_ * j;
-  std::vector<std::vector<l1ct::PuppiObjEmu> > subregionPuppis;
-  for (int l = 0, n = regionPuppis.size(); l < n; l++) {
-    const auto &puppis = regionPuppis[l][i];
-    std::vector<l1ct::PuppiObjEmu> tmp(std::min(puppis.begin() + k, puppis.end()),
-                                       std::min(puppis.begin() + k + nPuppiPerClk_, puppis.end()));
-    subregionPuppis.push_back(tmp);
-  }
-  return subregionPuppis;
-}
-
 std::vector<l1ct::PuppiObjEmu> l1ct::DeregionizerEmulator::mergeXtoY(const unsigned int X,
                                                                      const unsigned int Y,
                                                                      const std::vector<l1ct::PuppiObjEmu> &inLeft,
                                                                      const std::vector<l1ct::PuppiObjEmu> &inRight) {
+  // merge X to Y with truncation
   std::vector<l1ct::PuppiObjEmu> out;
 
   out.insert(out.end(), inLeft.begin(), std::min(inLeft.end(), inLeft.begin() + X));
   out.insert(out.end(), inRight.begin(), std::min(inRight.end(), inRight.begin() + Y - X));
+
+  return out;
+}
+
+std::vector<l1ct::PuppiObjEmu> l1ct::DeregionizerEmulator::mergeXtoY(const std::vector<l1ct::PuppiObjEmu> &inLeft,
+                                                                     const std::vector<l1ct::PuppiObjEmu> &inRight) {
+  // merge X to Y with no truncation
+  std::vector<l1ct::PuppiObjEmu> out;
+
+  out.insert(out.end(), inLeft.begin(), inLeft.end());
+  out.insert(out.end(), inRight.begin(), inRight.end());
 
   return out;
 }
@@ -80,69 +79,22 @@ static void debugPrint(const std::string &header, const std::vector<l1ct::PuppiO
     dbgCout() << "      > puppi[" << iPup << "] pT = " << pup[iPup].hwPt << "\n";
 }
 
-void l1ct::DeregionizerEmulator::run(const l1ct::DeregionizerInput in,
+void l1ct::DeregionizerEmulator::run(std::vector<std::vector<std::vector<l1ct::PuppiObjEmu>>> in,
                                      std::vector<l1ct::PuppiObjEmu> &out,
-                                     std::vector<l1ct::PuppiObjEmu> &truncated) {
-  const auto &regionPuppis = in.orderedInRegionsPuppis();
-  std::vector<l1ct::PuppiObjEmu> intermediateTruncated;
-
-  for (int i = 0, n = in.nPhiRegions; i < n; i++) {
-    // Each PF region (containing at most 18 puppi candidates) is split in 3(*nPuppiPerClk=18)
-    for (int j = 0; j < 3; j++) {
-      std::vector<std::vector<l1ct::PuppiObjEmu> > subregionPuppis = splitPFregions(regionPuppis, i, j);
-
-      // Merge PF regions in pairs
-      std::vector<l1ct::PuppiObjEmu> buffer01 =
-          mergeXtoY(nPuppiPerClk_, nPuppiFirstBuffers_, subregionPuppis[0], subregionPuppis[1]);
-      std::vector<l1ct::PuppiObjEmu> buffer23 =
-          mergeXtoY(nPuppiPerClk_, nPuppiFirstBuffers_, subregionPuppis[2], subregionPuppis[3]);
-      std::vector<l1ct::PuppiObjEmu> buffer45 =
-          mergeXtoY(nPuppiPerClk_, nPuppiFirstBuffers_, subregionPuppis[4], subregionPuppis[5]);
-
-      // Merge 4 first regions together, forward the last 2
-      std::vector<l1ct::PuppiObjEmu> buffer0123 =
-          mergeXtoY(nPuppiFirstBuffers_, nPuppiSecondBuffers_, buffer01, buffer23);
-      std::vector<l1ct::PuppiObjEmu> buffer45ext;
-      accumulateToY(nPuppiSecondBuffers_, buffer45, buffer45ext, intermediateTruncated);
-
-      // Merge all regions together and forward them to the final buffer
-      std::vector<l1ct::PuppiObjEmu> buffer012345 =
-          mergeXtoY(nPuppiSecondBuffers_, nPuppiThirdBuffers_, buffer0123, buffer45ext);
-      accumulateToY(nPuppiFinalBuffer_, buffer012345, out, truncated);
-
-      if (debug_) {
-        dbgCout() << "\n";
-        dbgCout() << "Phi region index : " << i << "," << j << "\n";
-
-        debugPrint("Eta region : 0", subregionPuppis[0]);
-        debugPrint("Eta region : 1", subregionPuppis[1]);
-        debugPrint("Eta region : 0+1", buffer01);
-        dbgCout() << "------------------ "
-                  << "\n";
-
-        debugPrint("Eta region : 2", subregionPuppis[2]);
-        debugPrint("Eta region : 3", subregionPuppis[3]);
-        debugPrint("Eta region : 2+3", buffer23);
-        dbgCout() << "------------------ "
-                  << "\n";
-
-        debugPrint("Eta region : 4", subregionPuppis[4]);
-        debugPrint("Eta region : 5", subregionPuppis[5]);
-        debugPrint("Eta region : 4+5", buffer45);
-        dbgCout() << "------------------ "
-                  << "\n";
-
-        debugPrint("Eta region : 0+1+2+3", buffer0123);
-        dbgCout() << "------------------ "
-                  << "\n";
-
-        debugPrint("Eta region : 0+1+2+3+4+5", buffer012345);
-        dbgCout() << "------------------ "
-                  << "\n";
-
-        debugPrint("Inclusive", out);
-      }
+                                     std::vector<l1ct::PuppiObjEmu> &truncated
+){
+  
+  for (int i = 0, n = in.size(); i < n; i++) {
+    std::vector<std::vector<l1ct::PuppiObjEmu>> pupsOnClock = in[i];
+    std::vector<l1ct::PuppiObjEmu> intermediateTruncated;
+    // Merge PF regions from this cycle. No truncation happens here
+    std::vector<l1ct::PuppiObjEmu> buffer;
+    for(const auto& pupsOnClockOnBoard : pupsOnClock){
+      buffer = mergeXtoY(buffer, pupsOnClockOnBoard);
     }
+
+    // accumulate PF regions over cycles, truncation may happen here
+    accumulateToY(nPuppiFinalBuffer_, buffer, out, truncated);
   }
 
   if (debug_) {


### PR DESCRIPTION
When comparing firmware simulation of CTL2 deregionizer using pattern files from `L1Trigger/Phase2L1ParticleFlow/test/make_l1ct_patternFiles_cfg.py` with emulation using the `DeregionizerProducer` collection, there are some discrepancies due to the ordering of the Puppi candidates out of CTL1 into CTL2. This PR:
- updates the handling of the CTL2 inputs, using the CTL1 pattern file writer as reference
- adds some flexibility to redefine the ordering with configuration (effectively how CTL1 and CTL2 are cabled together)
- refactors the `DeregionizerInput` and `DeregionizerEmulator` classes slightly to only do tasks their names imply
- reestablishes matching again between firmware (using the proper CMSSW-produced pattern files) and emulation

MR to correlator-common updating the tests will follow