### PR TITLE
Draft: 0.8 radius jets

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1CTJetFileWriter.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1CTJetFileWriter.cc
@@ -16,6 +16,7 @@
 #include "L1Trigger/DemonstratorTools/interface/utilities.h"
 #include "DataFormats/L1TParticleFlow/interface/PFJet.h"
 #include "DataFormats/L1TParticleFlow/interface/gt_datatypes.h"
+#include "DataFormats/L1Trigger/interface/EtSum.h"
 
 //
 // class declaration
@@ -41,9 +42,11 @@ private:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void endJob() override;
   std::vector<ap_uint<64>> encodeJets(const std::vector<l1t::PFJet> jets);
+  std::vector<ap_uint<64>> encodeSums(const std::vector<l1t::EtSum> jets);
 
   l1t::demo::BoardDataWriter fileWriterOutputToGT_;
   std::vector<edm::EDGetTokenT<edm::View<l1t::PFJet>>> jetsTokens_;
+  std::vector<edm::EDGetTokenT<edm::View<l1t::EtSum>>> mhtTokens_;
 };
 
 L1CTJetFileWriter::L1CTJetFileWriter(const edm::ParameterSet& iConfig)
@@ -53,7 +56,7 @@ L1CTJetFileWriter::L1CTJetFileWriter(const edm::ParameterSet& iConfig)
       nJets_(iConfig.getParameter<unsigned>("nJets")),
       nFramesPerBX_(iConfig.getParameter<unsigned>("nFramesPerBX")),
       ctl2BoardTMUX_(iConfig.getParameter<unsigned>("TMUX")),
-      gapLengthOutput_(ctl2BoardTMUX_ * nFramesPerBX_ - 2 * nJets_ * collections_.size()),
+      gapLengthOutput_(ctl2BoardTMUX_ * nFramesPerBX_ - 2 * (nJets_ + 1) * collections_.size()),
       maxLinesPerFile_(iConfig.getParameter<unsigned>("maxLinesPerFile")),
       channelSpecsOutputToGT_{{{"jets", 0}, {{ctl2BoardTMUX_, gapLengthOutput_}, {0}}}},
       fileWriterOutputToGT_(l1t::demo::parseFileFormat(iConfig.getParameter<std::string>("format")),
@@ -64,18 +67,20 @@ L1CTJetFileWriter::L1CTJetFileWriter(const edm::ParameterSet& iConfig)
                             channelSpecsOutputToGT_) {
         for(const auto &pset : collections_){
           jetsTokens_.push_back(consumes<edm::View<l1t::PFJet>>(pset.getParameter<edm::InputTag>("jets")));
+          mhtTokens_.push_back(consumes<edm::View<l1t::EtSum>>(pset.getParameter<edm::InputTag>("mht")));
         }
       }
 
 void L1CTJetFileWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
 
-  // 1) Pack collections in otder they're specified. jets then sums within collection
+  // 1) Pack collections in the order they're specified. jets then sums within collection
   std::vector<ap_uint<64>> link_words;
-  for(const auto &token : jetsTokens_){
+  for(unsigned iCollection = 0; iCollection < collections_.size(); iCollection++){
+    const auto &jetToken = jetsTokens_.at(iCollection);
     // 2) Encode jet information onto vectors containing link data
     // TODO remove the sort here and sort the input collection where it's created
-    const edm::View<l1t::PFJet>& jets = iEvent.get(token);
+    const edm::View<l1t::PFJet>& jets = iEvent.get(jetToken);
     std::vector<l1t::PFJet> sortedJets;
     sortedJets.reserve(jets.size());
     std::copy(jets.begin(), jets.end(), std::back_inserter(sortedJets));
@@ -84,8 +89,17 @@ void L1CTJetFileWriter::analyze(const edm::Event& iEvent, const edm::EventSetup&
         sortedJets.begin(), sortedJets.end(), [](l1t::PFJet i, l1t::PFJet j) { return (i.hwPt() > j.hwPt()); });
     const auto outputJets(encodeJets(sortedJets));
     link_words.insert(link_words.end(), outputJets.begin(), outputJets.end());
+
+    // 3) Encode sums onto vectors containing link data
+    const auto &mhtToken = mhtTokens_.at(iCollection);
+    const edm::View<l1t::EtSum>& mht = iEvent.get(mhtToken);
+    std::vector<l1t::EtSum> orderedSums;
+    std::copy(mht.begin(), mht.end(), std::back_inserter(orderedSums));
+    // TODO: reorder the sums checking the EtSumType
+    const auto outputSums(encodeSums(orderedSums));
+    link_words.insert(link_words.end(), outputSums.begin(), outputSums.end());
   }
-  // 3) Pack jet information into 'event data' object, and pass that to file writer
+  // 4) Pack jet information into 'event data' object, and pass that to file writer
   l1t::demo::EventData eventDataJets;
   eventDataJets.add({"jets", 0}, link_words);
   fileWriterOutputToGT_.addEvent(eventDataJets);
@@ -112,6 +126,19 @@ std::vector<ap_uint<64>> L1CTJetFileWriter::encodeJets(const std::vector<l1t::PF
   return jet_words;
 }
 
+std::vector<ap_uint<64>> L1CTJetFileWriter::encodeSums(const std::vector<l1t::EtSum> sums) {
+  // Send MHT first, then MET
+  // Need two l1t::EtSum for each MHT, MET (four total)
+  // No MET consumed for now - send 0s on second word
+  std::vector<ap_uint<64>> sum_words;
+  int valid = sums.at(0).pt() > 0;
+  // TODO this is not going to be bit exact
+  l1gt::Sum ht{valid, sums.at(1).pt(), sums.at(1).phi() / l1gt::Scales::ETAPHI_LSB, sums.at(0).pt()};
+  sum_words.push_back(ht.pack());
+  sum_words.push_back(0);
+  return sum_words;
+}
+
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void L1CTJetFileWriter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   //The following says we do not know what parameters are allowed so do no validation
@@ -119,12 +146,14 @@ void L1CTJetFileWriter::fillDescriptions(edm::ConfigurationDescriptions& descrip
   edm::ParameterSetDescription desc;
   {
     edm::ParameterSetDescription vpsd1;
-    vpsd1.add<edm::InputTag>("jets", edm::InputTag("scPFL1PuppiEmulatorCorrected"));
+    vpsd1.add<edm::InputTag>("jets", edm::InputTag("sc4PFL1PuppiCorrectedEmulator"));
+    vpsd1.add<edm::InputTag>("mht", edm::InputTag("sc4PFL1PuppiCorrectedEmulatorMHT"));
     std::vector<edm::ParameterSet> temp1;
     temp1.reserve(1);
     {
       edm::ParameterSet temp2;
-      temp2.addParameter<edm::InputTag>("jets", edm::InputTag("scPFL1PuppiEmulatorCorrected"));
+      temp2.addParameter<edm::InputTag>("jets", edm::InputTag("sc4PFL1PuppiCorrectedEmulator"));
+      temp2.addParameter<edm::InputTag>("mht", edm::InputTag("sc4PFL1PuppiCorrectedEmulatorMHT"));
       temp1.push_back(temp2);
     }
     desc.addVPSetUntracked("collections", vpsd1, temp1);

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1CTJetFileWriter.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1CTJetFileWriter.cc
@@ -29,6 +29,7 @@ public:
 
 private:
   // ----------constants, enums and typedefs ---------
+  std::vector<edm::ParameterSet> collections_;
   unsigned nJets_;
   size_t nFramesPerBX_;
   size_t ctl2BoardTMUX_;
@@ -41,42 +42,52 @@ private:
   void endJob() override;
   std::vector<ap_uint<64>> encodeJets(const std::vector<l1t::PFJet> jets);
 
-  edm::EDGetTokenT<edm::View<l1t::PFJet>> jetsToken_;
   l1t::demo::BoardDataWriter fileWriterOutputToGT_;
+  std::vector<edm::EDGetTokenT<edm::View<l1t::PFJet>>> jetsTokens_;
 };
 
 L1CTJetFileWriter::L1CTJetFileWriter(const edm::ParameterSet& iConfig)
-    : nJets_(iConfig.getParameter<unsigned>("nJets")),
+    : 
+      collections_(iConfig.getUntrackedParameter<std::vector<edm::ParameterSet>>("collections",
+                                                                                 std::vector<edm::ParameterSet>())),
+      nJets_(iConfig.getParameter<unsigned>("nJets")),
       nFramesPerBX_(iConfig.getParameter<unsigned>("nFramesPerBX")),
       ctl2BoardTMUX_(iConfig.getParameter<unsigned>("TMUX")),
-      gapLengthOutput_(ctl2BoardTMUX_ * nFramesPerBX_ - 2 * nJets_),
+      gapLengthOutput_(ctl2BoardTMUX_ * nFramesPerBX_ - 2 * nJets_ * collections_.size()),
       maxLinesPerFile_(iConfig.getParameter<unsigned>("maxLinesPerFile")),
       channelSpecsOutputToGT_{{{"jets", 0}, {{ctl2BoardTMUX_, gapLengthOutput_}, {0}}}},
-      jetsToken_(consumes<edm::View<l1t::PFJet>>(iConfig.getParameter<edm::InputTag>("jets"))),
       fileWriterOutputToGT_(l1t::demo::parseFileFormat(iConfig.getParameter<std::string>("format")),
                             iConfig.getParameter<std::string>("outputFilename"),
                             nFramesPerBX_,
                             ctl2BoardTMUX_,
                             maxLinesPerFile_,
-                            channelSpecsOutputToGT_) {}
+                            channelSpecsOutputToGT_) {
+        for(const auto &pset : collections_){
+          jetsTokens_.push_back(consumes<edm::View<l1t::PFJet>>(pset.getParameter<edm::InputTag>("jets")));
+        }
+      }
 
 void L1CTJetFileWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
 
-  // 1) Encode jet information onto vectors containing link data
-  // TODO remove the sort here and sort the input collection where it's created
-  const edm::View<l1t::PFJet>& jets = iEvent.get(jetsToken_);
-  std::vector<l1t::PFJet> sortedJets;
-  sortedJets.reserve(jets.size());
-  std::copy(jets.begin(), jets.end(), std::back_inserter(sortedJets));
+  // 1) Pack collections in otder they're specified. jets then sums within collection
+  std::vector<ap_uint<64>> link_words;
+  for(const auto &token : jetsTokens_){
+    // 2) Encode jet information onto vectors containing link data
+    // TODO remove the sort here and sort the input collection where it's created
+    const edm::View<l1t::PFJet>& jets = iEvent.get(token);
+    std::vector<l1t::PFJet> sortedJets;
+    sortedJets.reserve(jets.size());
+    std::copy(jets.begin(), jets.end(), std::back_inserter(sortedJets));
 
-  std::stable_sort(
-      sortedJets.begin(), sortedJets.end(), [](l1t::PFJet i, l1t::PFJet j) { return (i.hwPt() > j.hwPt()); });
-  const auto outputJets(encodeJets(sortedJets));
-
-  // 2) Pack jet information into 'event data' object, and pass that to file writer
+    std::stable_sort(
+        sortedJets.begin(), sortedJets.end(), [](l1t::PFJet i, l1t::PFJet j) { return (i.hwPt() > j.hwPt()); });
+    const auto outputJets(encodeJets(sortedJets));
+    link_words.insert(link_words.end(), outputJets.begin(), outputJets.end());
+  }
+  // 3) Pack jet information into 'event data' object, and pass that to file writer
   l1t::demo::EventData eventDataJets;
-  eventDataJets.add({"jets", 0}, outputJets);
+  eventDataJets.add({"jets", 0}, link_words);
   fileWriterOutputToGT_.addEvent(eventDataJets);
 }
 
@@ -106,7 +117,19 @@ void L1CTJetFileWriter::fillDescriptions(edm::ConfigurationDescriptions& descrip
   //The following says we do not know what parameters are allowed so do no validation
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("jets");
+  {
+    edm::ParameterSetDescription vpsd1;
+    vpsd1.add<edm::InputTag>("jets", edm::InputTag("scPFL1PuppiEmulatorCorrected"));
+    std::vector<edm::ParameterSet> temp1;
+    temp1.reserve(1);
+    {
+      edm::ParameterSet temp2;
+      temp2.addParameter<edm::InputTag>("jets", edm::InputTag("scPFL1PuppiEmulatorCorrected"));
+      temp1.push_back(temp2);
+    }
+    desc.addVPSetUntracked("collections", vpsd1, temp1);
+  }
+  //desc.add<std::vector<edm::ParameterSet>>("collections");
   desc.add<std::string>("outputFilename");
   desc.add<uint32_t>("nJets", 12);
   desc.add<uint32_t>("nFramesPerBX", 9);

--- a/L1Trigger/Phase2L1ParticleFlow/python/l1ctJetFileWriter_cfi.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1ctJetFileWriter_cfi.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+l1ctSeededConeJetFileWriter = cms.EDAnalyzer('L1CTJetFileWriter',
+  collections = cms.untracked.VPSet([cms.PSet(jets = cms.InputTag("scPFL1PuppiEmulatorCorrected"))]),
+  nJets = cms.uint32(12),
+  nFramesPerBX = cms.uint32(9), # 360 MHz clock or 25 Gb/s link
+  TMUX = cms.uint32(6),
+  maxLinesPerFile = cms.uint32(1024),
+  outputFilename = cms.string("L1CTSCJetsPatterns"),
+  format = cms.string("EMP")
+)

--- a/L1Trigger/Phase2L1ParticleFlow/python/l1ctJetFileWriter_cfi.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1ctJetFileWriter_cfi.py
@@ -1,7 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 l1ctSeededConeJetFileWriter = cms.EDAnalyzer('L1CTJetFileWriter',
-  collections = cms.untracked.VPSet([cms.PSet(jets = cms.InputTag("scPFL1PuppiEmulatorCorrected"))]),
+  collections = cms.untracked.VPSet([cms.PSet(jets = cms.InputTag("sc4PFL1PuppiCorrectedEmulator"),
+                                              mht  = cms.InputTag("sc4PFL1PuppiCorrectedEmulatorMHT"))]),
   nJets = cms.uint32(12),
   nFramesPerBX = cms.uint32(9), # 360 MHz clock or 25 Gb/s link
   TMUX = cms.uint32(6),

--- a/L1Trigger/Phase2L1ParticleFlow/python/l1pfJetMet_cff.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1pfJetMet_cff.py
@@ -1,14 +1,19 @@
 import FWCore.ParameterSet.Config as cms
 
-from L1Trigger.Phase2L1ParticleFlow.l1tSeedConePFJetProducer_cfi import l1tSeedConePFJetProducer, l1tSeedConePFJetEmulatorProducer
-from L1Trigger.Phase2L1ParticleFlow.l1tDeregionizerProducer_cfi import l1tDeregionizerProducer as l1tLayer2Deregionizer, l1tDeregionizerProducerExtended as l1tLayer2DeregionizerExtended
-l1tSCPFL1PF            = l1tSeedConePFJetProducer.clone(L1PFObjects = 'l1tLayer1:PF')
-l1tSCPFL1Puppi         = l1tSeedConePFJetProducer.clone()
-l1tSCPFL1PuppiEmulator = l1tSeedConePFJetEmulatorProducer.clone(L1PFObjects = 'l1tLayer2Deregionizer:Puppi')
-l1tSCPFL1PuppiCorrectedEmulator = l1tSeedConePFJetEmulatorProducer.clone(L1PFObjects = 'l1tLayer2Deregionizer:Puppi',
-                                                                     doCorrections = cms.bool(True),
-                                                                     correctorFile = cms.string("L1Trigger/Phase2L1ParticleFlow/data/jecs/jecs_20220308.root"),
-                                                                     correctorDir = cms.string('L1PuppiSC4EmuJets'))
+from L1Trigger.Phase2L1ParticleFlow.L1SeedConePFJetProducer_cfi import L1SeedConePFJetProducer, L1SeedConePFJetEmulatorProducer
+from L1Trigger.Phase2L1ParticleFlow.DeregionizerProducer_cfi import DeregionizerProducer as l1ctLayer2Deregionizer, DeregionizerProducerExtended as l1ctLayer2DeregionizerExtended
+sc4PFL1PF            = L1SeedConePFJetProducer.clone(L1PFObjects = 'l1ctLayer1:PF')
+sc4PFL1Puppi         = L1SeedConePFJetProducer.clone()
+sc4PFL1PuppiEmulator = L1SeedConePFJetEmulatorProducer.clone(L1PFObject = cms.InputTag('l1ctLayer2Deregionizer', 'Puppi'))
+sc4PFL1PuppiCorrectedEmulator = L1SeedConePFJetEmulatorProducer.clone(L1PFObject = cms.InputTag('l1ctLayer2Deregionizer', 'Puppi'),
+                                                                      doCorrections = cms.bool(True),
+                                                                      correctorFile = cms.string("L1Trigger/Phase2L1ParticleFlow/data/jecs/jecs_20220308.root"),
+                                                                      correctorDir = cms.string('L1PuppiSC4EmuJets'))
+sc8PFL1PuppiCorrectedEmulator = L1SeedConePFJetEmulatorProducer.clone(L1PFObject = cms.InputTag('l1ctLayer2Deregionizer', 'Puppi'),
+                                                                      coneSize = cms.double(0.8),
+                                                                      doCorrections = cms.bool(True),
+                                                                      correctorFile = cms.string("L1Trigger/Phase2L1ParticleFlow/data/jecs/jecs_20220308.root"),
+                                                                      correctorDir = cms.string('L1PuppiSC4EmuJets'))
 
 _correctedJets = cms.EDProducer("L1TCorrectedPFJetProducer", 
     jets = cms.InputTag("_tag_"),
@@ -24,26 +29,21 @@ phase2_hgcalV10.toModify(_correctedJets, correctorFile = "L1Trigger/Phase2L1Part
 from Configuration.Eras.Modifier_phase2_hgcalV11_cff import phase2_hgcalV11
 phase2_hgcalV11.toModify(_correctedJets, correctorFile = "L1Trigger/Phase2L1ParticleFlow/data/jecs/jecs_20220308.root")
 
-from L1Trigger.Phase2L1ParticleFlow.l1tMHTPFProducer_cfi import l1tMHTPFProducer
-l1tSCPFL1PuppiCorrectedEmulatorMHT = l1tMHTPFProducer.clone() 
+from L1Trigger.Phase2L1ParticleFlow.L1MhtPfProducer_cfi import L1MhtPfProducer
+sc4PFL1PuppiCorrectedEmulatorMHT = L1MhtPfProducer.clone(jets = cms.InputTag("sc4PFL1PuppiCorrectedEmulator"))
+sc8PFL1PuppiCorrectedEmulatorMHT = L1MhtPfProducer.clone(jets = cms.InputTag("sc8PFL1PuppiCorrectedEmulator"))
 
-L1TPFJetsTask = cms.Task(
-    l1tLayer2Deregionizer, l1tSCPFL1PF, l1tSCPFL1Puppi, l1tSCPFL1PuppiEmulator, l1tSCPFL1PuppiCorrectedEmulator, l1tSCPFL1PuppiCorrectedEmulatorMHT
+
+sc4PFL1PuppiExtended = sc4PFL1Puppi.clone(L1PFObjects = 'l1ctLayer1Extended:Puppi')
+sc4PFL1PuppiExtendedEmulator = sc4PFL1PuppiEmulator.clone(L1PFObjects = cms.InputTag('l1ctLayer2DeregionizerExtended', 'Puppi'))
+sc4PFL1PuppiExtendedCorrectedEmulator = _correctedJets.clone(jets = 'sc4PFL1PuppiExtendedEmulator', correctorDir = 'L1PuppiSC4EmuDeregJets')
+
+l1PFJetsTask = cms.Task(
+    l1ctLayer2Deregionizer, sc4PFL1PF, sc4PFL1Puppi, sc4PFL1PuppiEmulator, sc4PFL1PuppiCorrectedEmulator, sc4PFL1PuppiCorrectedEmulatorMHT,
+    sc8PFL1PuppiCorrectedEmulator, sc8PFL1PuppiCorrectedEmulatorMHT
 )
-
-l1tSCPFL1PuppiExtended         = l1tSeedConePFJetProducer.clone(L1PFObjects = 'l1tLayer1Extended:Puppi')
-l1tSCPFL1PuppiExtendedEmulator = l1tSeedConePFJetEmulatorProducer.clone(L1PFObjects = 'l1tLayer2DeregionizerExtended:Puppi')
-l1tSCPFL1PuppiExtendedCorrectedEmulator = l1tSeedConePFJetEmulatorProducer.clone(L1PFObjects = 'l1tLayer2DeregionizerExtended:Puppi',
-                                                                     doCorrections = cms.bool(True),
-                                                                     correctorFile = cms.string("L1Trigger/Phase2L1ParticleFlow/data/jecs/jecs_20220308.root"),
-                                                                     correctorDir = cms.string('L1PuppiSC4EmuJets'))
-
-L1TPFJetsTask = cms.Task(
-    l1tLayer2Deregionizer, l1tSCPFL1PF, l1tSCPFL1Puppi, l1tSCPFL1PuppiEmulator, l1tSCPFL1PuppiCorrectedEmulator, l1tSCPFL1PuppiCorrectedEmulatorMHT
-)
-
-L1TPFJetsExtendedTask = cms.Task(
-    l1tLayer2DeregionizerExtended, l1tSCPFL1PuppiExtended, l1tSCPFL1PuppiExtendedEmulator, l1tSCPFL1PuppiExtendedCorrectedEmulator
+l1PFJetsExtendedTask = cms.Task(
+    l1ctLayer2DeregionizerExtended, sc4PFL1PuppiExtended, sc4PFL1PuppiExtendedEmulator, sc4PFL1PuppiExtendedCorrectedEmulator
 )
 
 L1TPFJetsEmulationTask = cms.Task(

--- a/L1Trigger/Phase2L1ParticleFlow/test/make_l1ct_patternFiles_cfg.py
+++ b/L1Trigger/Phase2L1ParticleFlow/test/make_l1ct_patternFiles_cfg.py
@@ -30,23 +30,19 @@ process.GlobalTag = GlobalTag(process.GlobalTag, '123X_mcRun4_realistic_v3', '')
 
 process.load('L1Trigger.Phase2L1ParticleFlow.l1ctLayer1_cff')
 process.load('L1Trigger.Phase2L1ParticleFlow.l1ctLayer2EG_cff')
-process.load('L1Trigger.L1TTrackMatch.l1tGTTInputProducer_cfi')
-process.load('L1Trigger.VertexFinder.l1tVertexProducer_cfi')
-process.l1tVertexFinderEmulator = process.l1tVertexProducer.clone()
-process.l1tVertexFinderEmulator.VertexReconstruction.Algorithm = "fastHistoEmulation"
-process.l1tVertexFinderEmulator.l1TracksInputTag = cms.InputTag("l1tGTTInputProducer", "Level1TTTracksConverted")
-from L1Trigger.Phase2L1GMT.gmt_cfi import l1tStandaloneMuons
-process.l1tSAMuonsGmt = l1tStandaloneMuons.clone()
+process.load('L1Trigger.Phase2L1ParticleFlow.l1pfJetMet_cff')
+process.load('L1Trigger.L1TTrackMatch.L1GTTInputProducer_cfi')
+process.load('L1Trigger.VertexFinder.VertexProducer_cff')
+process.L1VertexFinderEmulator = process.VertexProducer.clone()
+process.L1VertexFinderEmulator.VertexReconstruction.Algorithm = "fastHistoEmulation"
+process.L1VertexFinderEmulator.l1TracksInputTag = cms.InputTag("L1GTTInputProducer", "Level1TTTracksConverted")
+from L1Trigger.Phase2L1GMT.gmt_cfi import standaloneMuons
+process.L1SAMuonsGmt = standaloneMuons.clone()
 
-from L1Trigger.Phase2L1ParticleFlow.l1tSeedConePFJetProducer_cfi import l1tSeedConePFJetEmulatorProducer
-from L1Trigger.Phase2L1ParticleFlow.l1tDeregionizerProducer_cfi import l1tDeregionizerProducer
-from L1Trigger.Phase2L1ParticleFlow.l1tJetFileWriter_cfi import l1tSeededConeJetFileWriter
-process.l1tLayer2Deregionizer = l1tDeregionizerProducer.clone()
-process.l1tLayer2SeedConeJetsCorrected = l1tSeedConePFJetEmulatorProducer.clone(L1PFObject = cms.InputTag('l1tLayer2Deregionizer', 'Puppi'),
-                                                                                doCorrections = cms.bool(True),
-                                                                                correctorFile = cms.string("L1Trigger/Phase2L1ParticleFlow/data/jecs/jecs_20220308.root"),
-                                                                                correctorDir = cms.string('L1PuppiSC4EmuJets'))
-process.l1tLayer2SeedConeJetWriter = l1tSeededConeJetFileWriter.clone(jets = "l1tLayer2SeedConeJetsCorrected")
+from L1Trigger.Phase2L1ParticleFlow.l1ctJetFileWriter_cfi import l1ctSeededConeJetFileWriter
+l1ctLayer2SCJetsProducts = cms.untracked.VPSet([cms.PSet(jets=cms.InputTag("sc4PFL1PuppiCorrectedEmulator")),
+                                              cms.PSet(jets=cms.InputTag("sc8PFL1PuppiCorrectedEmulator"))])
+process.l1ctLayer2SeedConeJetWriter = l1ctSeededConeJetFileWriter.clone(collections = l1ctLayer2SCJetsProducts)
 
 process.l1tLayer1Barrel9 = process.l1tLayer1Barrel.clone()
 process.l1tLayer1Barrel9.puAlgo.nFinalSort = 32
@@ -68,19 +64,22 @@ process.l1tLayer1HGCalNoTK.patternWriters = cms.untracked.VPSet(*hgcalNoTKWriter
 process.l1tLayer1HF.patternWriters = cms.untracked.VPSet(*hfWriterConfigs)
 
 process.runPF = cms.Path( 
-        process.l1tSAMuonsGmt +
-        process.l1tGTTInputProducer +
-        process.l1tVertexFinderEmulator +
-        process.l1tLayer1Barrel +
-        #process.l1tLayer1Barrel9 +
-        process.l1tLayer1HGCal +
-        process.l1tLayer1HGCalNoTK +
-        process.l1tLayer1HF +
-        process.l1tLayer1 +
-        process.l1tLayer2Deregionizer +
-        process.l1tLayer2SeedConeJetsCorrected +
-        process.l1tLayer2SeedConeJetWriter +
-        process.l1tLayer2EG
+        process.L1SAMuonsGmt +
+        process.L1GTTInputProducer +
+        process.L1VertexFinderEmulator +
+        process.l1ctLayer1Barrel +
+        #process.l1ctLayer1Barrel9 +
+        process.l1ctLayer1HGCal +
+        process.l1ctLayer1HGCalNoTK +
+        process.l1ctLayer1HF +
+        process.l1ctLayer1 +
+        process.l1ctLayer2Deregionizer +
+        process.sc4PFL1PuppiCorrectedEmulator +
+        process.sc4PFL1PuppiCorrectedEmulatorMHT +
+        process.sc8PFL1PuppiCorrectedEmulator +
+        process.sc8PFL1PuppiCorrectedEmulatorMHT +
+        process.l1ctLayer2SeedConeJetWriter +
+        process.l1ctLayer2EG
     )
 process.runPF.associate(process.L1TLayer1TaskInputsTask)
 

--- a/L1Trigger/Phase2L1ParticleFlow/test/make_l1ct_patternFiles_cfg.py
+++ b/L1Trigger/Phase2L1ParticleFlow/test/make_l1ct_patternFiles_cfg.py
@@ -7,7 +7,7 @@ process.load('Configuration.StandardSequences.Services_cff')
 process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.options   = cms.untracked.PSet( wantSummary = cms.untracked.bool(True), allowUnscheduled = cms.untracked.bool(False) )
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000))
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100))
 process.MessageLogger.cerr.FwkReport.reportEvery = 1
 
 process.source = cms.Source("PoolSource",
@@ -40,8 +40,10 @@ from L1Trigger.Phase2L1GMT.gmt_cfi import standaloneMuons
 process.L1SAMuonsGmt = standaloneMuons.clone()
 
 from L1Trigger.Phase2L1ParticleFlow.l1ctJetFileWriter_cfi import l1ctSeededConeJetFileWriter
-l1ctLayer2SCJetsProducts = cms.untracked.VPSet([cms.PSet(jets=cms.InputTag("sc4PFL1PuppiCorrectedEmulator")),
-                                              cms.PSet(jets=cms.InputTag("sc8PFL1PuppiCorrectedEmulator"))])
+l1ctLayer2SCJetsProducts = cms.untracked.VPSet([cms.PSet(jets = cms.InputTag("sc4PFL1PuppiCorrectedEmulator"),
+                                                         mht  = cms.InputTag("sc4PFL1PuppiCorrectedEmulatorMHT")),
+                                                cms.PSet(jets = cms.InputTag("sc8PFL1PuppiCorrectedEmulator"),
+                                                         mht  = cms.InputTag("sc8PFL1PuppiCorrectedEmulatorMHT"))])
 process.l1ctLayer2SeedConeJetWriter = l1ctSeededConeJetFileWriter.clone(collections = l1ctLayer2SCJetsProducts)
 
 process.l1tLayer1Barrel9 = process.l1tLayer1Barrel.clone()


### PR DESCRIPTION
This PR adds the SC8 jets to the jetmet configuration, renaming collections that were previously just '`sc*` to `sc4*` for clarity. Ghe jet file writer is extended to include also the sums (MHT only for now), and a configurable number of collections. With these we will make the pattern files to test against the hardware implementation. (And the configurability means we can continue to make pattern files with only one jet radius)

MRs to correlator-common and correlator-layer2 will follow. 