### PR TITLE
Multififo regionizer emulator improvements

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/interface/regionizer/multififo_regionizer_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/regionizer/multififo_regionizer_ref.h
@@ -43,11 +43,13 @@ namespace l1ct {
                                 unsigned int outii,
                                 unsigned int pauseii,
                                 bool useAlsoVtxCoords);
-
-    // note: this one will work only in CMSSW
+    // note: these ones will work only in CMSSW
     MultififoRegionizerEmulator(const edm::ParameterSet& iConfig);
+    MultififoRegionizerEmulator(const std::string& barrelSetup, const edm::ParameterSet& iConfig);
 
     ~MultififoRegionizerEmulator() override;
+
+    static BarrelSetup parseBarrelSetup(const std::string& setup);
 
     void setEgInterceptMode(bool afterFifo, const l1ct::EGInputSelectorEmuConfig& interceptorConfig);
     void initSectorsAndRegions(const RegionizerDecodedInputs& in, const std::vector<PFInputRegion>& out) override;

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc
@@ -206,6 +206,10 @@ L1TCorrelatorLayer1Producer::L1TCorrelatorLayer1Producer(const edm::ParameterSet
   } else if (regalgo == "Multififo") {
     regionizer_ = std::make_unique<l1ct::MultififoRegionizerEmulator>(
         iConfig.getParameter<edm::ParameterSet>("regionizerAlgoParameters"));
+  } else if (regalgo == "MultififoBarrel") {
+    const auto &pset = iConfig.getParameter<edm::ParameterSet>("regionizerAlgoParameters");
+    regionizer_ =
+        std::make_unique<l1ct::MultififoRegionizerEmulator>(pset.getParameter<std::string>("barrelSetup"), pset);
   } else if (regalgo == "TDR") {
     regionizer_ = std::make_unique<l1ct::TDRRegionizerEmulator>(
         iConfig.getParameter<edm::ParameterSet>("regionizerAlgoParameters"));

--- a/L1Trigger/Phase2L1ParticleFlow/src/regionizer/folded_multififo_regionizer_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/regionizer/folded_multififo_regionizer_ref.cpp
@@ -35,7 +35,6 @@ l1ct::FoldedMultififoRegionizerEmulator::FoldedMultififoRegionizerEmulator(unsig
   // now we initialize the routes: track finder
   for (unsigned int ie = 0; ie < 2; ++ie) {
     fold_.emplace_back(ie,
-#ifdef CMSSW_GIT_HASH
                        std::make_unique<l1ct::MultififoRegionizerEmulator>(
                            /*nendcaps=*/1,
                            nclocks / 2,
@@ -49,21 +48,6 @@ l1ct::FoldedMultififoRegionizerEmulator::FoldedMultififoRegionizerEmulator(unsig
                            outii,
                            pauseii,
                            useAlsoVtxCoords));
-#else
-                       std::unique_ptr<l1ct::MultififoRegionizerEmulator>(new l1ct::MultififoRegionizerEmulator(
-                           /*nendcaps=*/1,
-                           nclocks / 2,
-                           NTK_LINKS,
-                           NCALO_LINKS,
-                           ntk,
-                           ncalo,
-                           nem,
-                           nmu,
-                           streaming,
-                           outii,
-                           pauseii,
-                           useAlsoVtxCoords)));
-#endif
   }
   clocksPerFold_ = nclocks / 2;
 }


### PR DESCRIPTION
 * always use `std::make_unique` now that the HLS is moved to Vitis that supports c++17 (https://gitlab.cern.ch/cms-cactus/phase2/firmware/correlator-common/-/merge_requests/115)
 * allow running the multififo regionizer in the barrel also in CMSSW