### PR TITLE
Fix decoded track collection for missing tracks

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc
@@ -990,7 +990,7 @@ std::unique_ptr<std::vector<l1t::PFTrack>> L1TCorrelatorLayer1Producer::fetchDec
   for (const auto &r : event_.decoded.track) {
     const auto &reg = r.region;
     for (const auto &p : r.obj) {
-      if (p.hwPt == 0 || !reg.isFiducial(p))
+      if (p.hwPt == 0)
         continue;
       reco::Particle::PolarLorentzVector p4(
           p.floatPt(), reg.floatGlbEta(p.hwVtxEta()), reg.floatGlbPhi(p.hwVtxPhi()), 0);


### PR DESCRIPTION
#### PR description:

Remove fiducial check for decoded tracks: the regions are the input ones, hence no duplication!
The effect of the bug was that some of the tracks were missing in the output collection!
