### PR TITLE
Fix handling of phi wrap around in seeded cone 

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/src/jetmet/L1SeedConePFJetEmulator.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/jetmet/L1SeedConePFJetEmulator.cc
@@ -12,7 +12,7 @@ L1SCJetEmu::detaphi_t L1SCJetEmu::deltaPhi(L1SCJetEmu::Particle a, L1SCJetEmu::P
   detaphi_t dphi = detaphi_t(a.hwPhi) - detaphi_t(b.hwPhi);
   // phi wrap
   detaphi_t dphi0 =
-      dphi > detaphi_t(l1ct::Scales::INTPHI_PI) ? detaphi_t(l1ct::Scales::INTPHI_TWOPI - dphi) : detaphi_t(dphi);
+      dphi > detaphi_t(l1ct::Scales::INTPHI_PI) ? detaphi_t(dphi - l1ct::Scales::INTPHI_TWOPI) : detaphi_t(dphi);
   detaphi_t dphi1 =
       dphi < detaphi_t(-l1ct::Scales::INTPHI_PI) ? detaphi_t(l1ct::Scales::INTPHI_TWOPI + dphi) : detaphi_t(dphi);
   detaphi_t dphiw = dphi > detaphi_t(0) ? dphi0 : dphi1;


### PR DESCRIPTION
#### PR description:

Fix a bug in handling of phi wrap around when clustering puppi candidates to a seed in the seeded cone jet algorithm.  Currently, the correction for delta phi > +pi gives a positive value, where it should be negative.  The corresponding fix to the firmware to correlator common is [here](https://gitlab.cern.ch/cms-cactus/phase2/firmware/correlator-common/-/merge_requests/175#146735a59e9b4f6a75ee887e73442e7d2ef9c0dd), and also tracked in the issue [here](https://gitlab.cern.ch/cms-cactus/phase2/firmware/correlator-common/-/issues/29).

First reported by Stathis in [Tau-Jet-MET](https://indico.cern.ch/event/1501183/#2-jet-pull-vector).

#### PR validation:

Here's a plot showing the distribution of puppi candidates within seeded cone jets before this change.  Note the long tail to large positive delta phi values:

![image](https://github.com/user-attachments/assets/9d8dae34-eea8-4832-8f62-ed1f2f92cf39)

This features dissappears after this fix:

![image](https://github.com/user-attachments/assets/825e508d-1cc1-4b1c-893a-4e4e649222ad)

