### PR TITLE
Add encoded word to PF candidates

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc
@@ -1038,7 +1038,12 @@ std::unique_ptr<l1t::PFCandidateCollection> L1TCorrelatorLayer1Producer::fetchPF
       ret->back().setHwTkQuality(p.hwTkQuality);
       ret->back().setCaloEta(reg.floatGlbEtaOf(p));
       ret->back().setCaloPhi(reg.floatGlbPhiOf(p));
-      ret->back().setEncodedPuppi64(p.pack().to_uint64());
+
+      // encode the PF candidate with the 64b encoding used for PUPPI
+      l1ct::PuppiObj encodedPF;
+      encodedPF.fill(reg, p);
+      ret->back().setEncodedPuppi64(encodedPF.pack().to_uint64())
+      
       setRefs_(ret->back(), p);
     }
     for (const auto &p : event_.out[ir].pfneutral) {
@@ -1051,7 +1056,12 @@ std::unique_ptr<l1t::PFCandidateCollection> L1TCorrelatorLayer1Producer::fetchPF
       ret->back().setHwEmID(p.hwEmID);
       ret->back().setCaloEta(reg.floatGlbEtaOf(p));
       ret->back().setCaloPhi(reg.floatGlbPhiOf(p));
-      ret->back().setEncodedPuppi64(p.pack().to_uint64());
+      
+      // encode the PF candidate using the 64b encoding used for PUPPI
+      l1ct::PuppiObj encodedPF;
+      encodedPF.fill(reg, p, p.intPt(), 1);
+      ret->back().setEncodedPuppi64(encodedPF.pack().to_uint64())
+      
       setRefs_(ret->back(), p);
     }
   }

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc
@@ -1042,7 +1042,7 @@ std::unique_ptr<l1t::PFCandidateCollection> L1TCorrelatorLayer1Producer::fetchPF
       // encode the PF candidate with the 64b encoding used for PUPPI
       l1ct::PuppiObj encodedPF;
       encodedPF.fill(reg, p);
-      ret->back().setEncodedPuppi64(encodedPF.pack().to_uint64())
+      ret->back().setEncodedPuppi64(encodedPF.pack().to_uint64());
       
       setRefs_(ret->back(), p);
     }
@@ -1060,7 +1060,7 @@ std::unique_ptr<l1t::PFCandidateCollection> L1TCorrelatorLayer1Producer::fetchPF
       // encode the PF candidate using the 64b encoding used for PUPPI
       l1ct::PuppiObj encodedPF;
       encodedPF.fill(reg, p, p.intPt(), 1);
-      ret->back().setEncodedPuppi64(encodedPF.pack().to_uint64())
+      ret->back().setEncodedPuppi64(encodedPF.pack().to_uint64());
       
       setRefs_(ret->back(), p);
     }

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc
@@ -1038,7 +1038,7 @@ std::unique_ptr<l1t::PFCandidateCollection> L1TCorrelatorLayer1Producer::fetchPF
       ret->back().setHwTkQuality(p.hwTkQuality);
       ret->back().setCaloEta(reg.floatGlbEtaOf(p));
       ret->back().setCaloPhi(reg.floatGlbPhiOf(p));
-
+      ret->back().setEncodedPuppi64(p.pack().to_uint64());
       setRefs_(ret->back(), p);
     }
     for (const auto &p : event_.out[ir].pfneutral) {
@@ -1051,6 +1051,7 @@ std::unique_ptr<l1t::PFCandidateCollection> L1TCorrelatorLayer1Producer::fetchPF
       ret->back().setHwEmID(p.hwEmID);
       ret->back().setCaloEta(reg.floatGlbEtaOf(p));
       ret->back().setCaloPhi(reg.floatGlbPhiOf(p));
+      ret->back().setEncodedPuppi64(p.pack().to_uint64());
       setRefs_(ret->back(), p);
     }
   }


### PR DESCRIPTION
This PR is related to L1Scouting, where we aim to write the encoded values of candidates to binary files for use in playbacks and testing of the online analyses (see the [BinaryDumpers plugin](https://github.com/p2l1pfp/FastPUPPI/blob/14_0_X/NtupleProducer/plugins/BinaryDumpers.cc)). 
To mirror the current behavior for [PUPPI candidates](https://github.com/cms-sw/cmssw/blob/5c7b4223f0f41f6adae93c660d32ba5287547a60/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc#L1387C20-L1387C37), it would be nice to also fill this field for PF candidates.