### PR TITLE
Synchronise packing order of z0/mass with unpacking order.

### DIFF
--- a/DataFormats/L1TParticleFlow/interface/jets.h
+++ b/DataFormats/L1TParticleFlow/interface/jets.h
@@ -118,8 +118,8 @@ namespace l1ct {
       pack_into_bits(ret, start, hwPt);
       pack_into_bits(ret, start, hwEta);
       pack_into_bits(ret, start, hwPhi);
-      pack_into_bits(ret, start, hwMassSq);
       pack_into_bits(ret, start, hwZ0);
+      pack_into_bits(ret, start, hwMassSq);
       for (unsigned i = 0; i < NTagFields; i++) {
         pack_into_bits(ret, start, hwTagScores[i]);
       }


### PR DESCRIPTION
#### PR description:

The order of packing/unpacking z0 and jet mass in the internal CT jet object has been mixed up recently.  They were in the correct order at some point.  This meant the jet mass was being placed into the z0 field of the SC4 GT jets in the relevant pattern file.  This PR fixes that error

#### PR validation:

Ran correlator-common CI with this branch and checked the generated pattern files, an example:

Before:

```
      Link              000        
Frame 0000    1101 cb2dbd999d1c2401
Frame 0001    0001 00000140400408c6
...
```

After:
```
      Link              000        
Frame 0000    1101 cb000d999d1c2401
Frame 0001    0001 00000140400408c6
...
```

N.B. the first jet word should be `00000d999d1c2401`, but in both cases some the tagger scores are being incorrectly placed in the first word.  This will be fixed in #140.