### PR TITLE
make puppi compile outside CMSSW with Vivado 2024.2 and 2025.1

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/interface/puppi/linpuppi_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/puppi/linpuppi_ref.h
@@ -14,12 +14,6 @@ namespace edm {
 }  // namespace edm
 
 namespace l1ct {
-#ifdef CMSSW_GIT_HASH
-  const bool withinCMSSW_ = true;
-#else
-  const bool withinCMSSW_ = false;
-#endif
-
   class LinPuppiEmulator {
   public:
     enum class SortAlgo { Insertion, BitonicRUFL, BitonicHLS, Hybrid, FoldedHybrid, BitonicVHDL };
@@ -74,13 +68,15 @@ namespace l1ct {
           finalSortAlgo_(finalSortAlgo),
           debug_(false),
           fakePuppi_(false) {
-      if (useMLAssociation_ and withinCMSSW_) {
+#ifdef CMSSW_GIT_HASH
+      if (useMLAssociation_) {
         nnVtxAssoc_ = std::make_unique<NNVtxAssoc>(NNVtxAssoc(associationGraphPath,
                                                               associationThreshold,
                                                               associationNetworkZ0binning,
                                                               associationNetworkEtaBounds,
                                                               associationNetworkZ0ResBins));
       }
+#endif
     }
 
     LinPuppiEmulator(unsigned int nTrack,

--- a/L1Trigger/Phase2L1ParticleFlow/src/puppi/linpuppi_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/puppi/linpuppi_ref.cpp
@@ -103,13 +103,15 @@ l1ct::LinPuppiEmulator::LinPuppiEmulator(unsigned int nTrack,
   ptCut_[0] = ptCut_0;
   ptCut_[1] = ptCut_1;
 
-  if (useMLAssociation_ and withinCMSSW_) {
+#ifdef CMSSW_GIT_HASH
+  if (useMLAssociation_) {
     nnVtxAssoc_ = std::make_unique<NNVtxAssoc>(NNVtxAssoc(associationGraphPath,
                                                           associationThreshold,
                                                           associationNetworkZ0binning,
                                                           associationNetworkEtaBounds,
                                                           associationNetworkZ0ResBins));
   }
+#endif
 }
 
 #ifdef CMSSW_GIT_HASH
@@ -287,9 +289,11 @@ void l1ct::LinPuppiEmulator::linpuppi_chs_ref(const PFRegionEmu &region,
       int pZ0Diff = pZ0 - pv[j].hwZ0;
       if (std::abs(z0diff) > std::abs(pZ0Diff))
         z0diff = pZ0Diff;
-      if (useMLAssociation_ and withinCMSSW_ &&
+#ifdef CMSSW_GIT_HASH
+      if (useMLAssociation_ &&
           nnVtxAssoc_->TTTrackNetworkSelector<const l1ct::PFChargedObjEmu>(region, pfch[i], pv[j]) == 1)
         pass_network = true;
+#endif
     }
     bool accept = pfch[i].hwPt != 0;
     if (!fakePuppi_ && !useMLAssociation_)
@@ -495,9 +499,11 @@ void l1ct::LinPuppiEmulator::linpuppi_ref(const PFRegionEmu &region,
           int ppZMin = std::abs(int(track[it].hwZ0 - pv[v].hwZ0));
           if (pZMin > ppZMin)
             pZMin = ppZMin;
-          if (useMLAssociation_ and withinCMSSW_ &&
+#ifdef CMSSW_GIT_HASH
+          if (useMLAssociation_ &&
               nnVtxAssoc_->TTTrackNetworkSelector<const l1ct::TkObjEmu>(region, track[it], pv[v]) == 1)
             pass_network = true;
+#endif
         }
       }
       if (useMLAssociation_ && !pass_network)
@@ -650,9 +656,11 @@ void l1ct::LinPuppiEmulator::linpuppi_flt(const PFRegionEmu &region,
         int ppZMin = std::abs(int(track[it].hwZ0 - pv[v].hwZ0));
         if (pZMin > ppZMin)
           pZMin = ppZMin;
-        if (useMLAssociation_ and withinCMSSW_ &&
+#ifdef CMSSW_GIT_HASH
+        if (useMLAssociation_ &&
             nnVtxAssoc_->TTTrackNetworkSelector<const l1ct::TkObjEmu>(region, track[it], pv[v]) == 1)
           pass_network = true;
+#endif
       }
       if (useMLAssociation_ && !pass_network)
         continue;


### PR DESCRIPTION
#### PR description:

The use of the const `withinCMSSW_` stopped working with Vivado 2024.2 and 2025.1. This goes back to the slightly uglier C preprocessor way of making code work both within CMSSW and outside it. Please recommend a better solution if you know of one.

#### PR validation:

This was tested manually with Vivado testbenches outside of CMSSW and with `cmsRun make_l1ct_binaryFiles_cfg.py` within CMSSW.
