### PR TITLE
Accurate emulation of hls::sqrt in MHT

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/interface/jetmet/L1PFHtEmulator.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/jetmet/L1PFHtEmulator.h
@@ -23,6 +23,8 @@ namespace P2L1HTMHTEmu {
   typedef ap_fixed<12, 3> radians_t;
   typedef ap_fixed<9, 2> cossin_t;
   typedef ap_fixed<16, 13> pxy_t;
+  static constexpr int Fin = 6;  // Number of decimal bits/precision of met squared i.e. 2*16 - 2*13
+  static constexpr int Fout = pt_t::width - pt_t::iwidth; // Number of decimal bits/precision of output met
 
   static constexpr int N_TABLE = 2048;
 
@@ -49,7 +51,7 @@ namespace P2L1HTMHTEmu {
   template <class data_T, class table_T, int N>
   void init_sinphi_table(table_T table_out[N]) {
     for (int i = 0; i < N; i++) {
-      float x = i * (M_PI / 180.) / 2.;
+      double x = i * (M_PI / 180.) / 2.;
       table_T sin_x = std::sin(x);
       table_out[i] = sin_x;
     }
@@ -119,8 +121,13 @@ inline l1ct::Sum htmht(std::vector<l1ct::Jet> jets) {
   l1ct::Sum ht;
   ht.hwSumPt = hthxhy.pt;
 #ifdef CMSSW_GIT_HASH
-  ht.hwPt =
-      sqrt(((hthxhy.px * hthxhy.px) + (hthxhy.py * hthxhy.py)).to_double());  // hls_math.h not available yet in CMSSW
+  double d = std::sqrt(((hthxhy.px * hthxhy.px) + (hthxhy.py * hthxhy.py)).to_double());
+  // emulate hls::sqrt internal rounding
+  double rounded = std::round(d * (1 << P2L1HTMHTEmu::Fin)) / (1 << P2L1HTMHTEmu::Fin);
+  // emulate AP_TRN conversion to output type
+  double truncated = std::floor(rounded * (1 << P2L1HTMHTEmu::Fout)) / (1 << P2L1HTMHTEmu::Fout);
+  P2L1HTMHTEmu::pt_t hwPt_hls = truncated;
+  ht.hwPt = hwPt_hls;
 #else
   ht.hwPt = hls::sqrt(((hthxhy.px * hthxhy.px) + (hthxhy.py * hthxhy.py)));
 #endif

--- a/L1Trigger/Phase2L1ParticleFlow/interface/jetmet/L1PFHtEmulator.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/jetmet/L1PFHtEmulator.h
@@ -120,7 +120,9 @@ inline l1ct::Sum htmht(std::vector<l1ct::Jet> jets) {
   // Compute the MHT magnitude and direction
   l1ct::Sum ht;
   ht.hwSumPt = hthxhy.pt;
-#ifdef CMSSW_GIT_HASH
+
+  // this emulates the following firmware function, since hls_math.h is not available in CMSSW
+  // ht.hwPt = hls::sqrt(((hthxhy.px * hthxhy.px) + (hthxhy.py * hthxhy.py)));
   double d = std::sqrt(((hthxhy.px * hthxhy.px) + (hthxhy.py * hthxhy.py)).to_double());
   // emulate hls::sqrt internal rounding
   double rounded = std::round(d * (1 << P2L1HTMHTEmu::Fin)) / (1 << P2L1HTMHTEmu::Fin);
@@ -128,9 +130,7 @@ inline l1ct::Sum htmht(std::vector<l1ct::Jet> jets) {
   double truncated = std::floor(rounded * (1 << P2L1HTMHTEmu::Fout)) / (1 << P2L1HTMHTEmu::Fout);
   P2L1HTMHTEmu::pt_t hwPt_hls = truncated;
   ht.hwPt = hwPt_hls;
-#else
-  ht.hwPt = hls::sqrt(((hthxhy.px * hthxhy.px) + (hthxhy.py * hthxhy.py)));
-#endif
+
   ht.hwPhi = P2L1HTMHTEmu::phi_cordic(hthxhy.py, hthxhy.px);
   return ht;
 }

--- a/L1Trigger/Phase2L1ParticleFlow/interface/jetmet/L1PFHtEmulator.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/jetmet/L1PFHtEmulator.h
@@ -24,7 +24,7 @@ namespace P2L1HTMHTEmu {
   typedef ap_fixed<9, 2> cossin_t;
   typedef ap_fixed<16, 13> pxy_t;
   static constexpr int Fin = 6;  // Number of decimal bits/precision of met squared i.e. 2*16 - 2*13
-  static constexpr int Fout = pt_t::width - pt_t::iwidth; // Number of decimal bits/precision of output met
+  static constexpr int Fout = pt_t::width - pt_t::iwidth;  // Number of decimal bits/precision of output met
 
   static constexpr int N_TABLE = 2048;
 


### PR DESCRIPTION
#### PR description:

This PR improves the emulation-hardware matching of MHT.  There's been 1 bit (0.25 GeV) differences between the output from `hls::sqrt` and `std::sqrt` for some time, which could potentially be resolved by somehow including the HLS math library as an external package in CMSSW.  However it turns out the `hls::sqrt` behaviour can be emulated in CMSSW with `std::sqrt` and mimicking the rounding/truncation that happens internally at the output of `hls::sqrt`, which is implemented in this PR.

I also noticed another emulation-firmware difference, which was originating in the initialisation of the sin(phi) LUT, where `sin[180]` would be set to `1` in CMSSW but `0.9921875` in the HLS csim/synthesised VHDL.  I'm not fully sure of the cause of this difference, but using `double` instead of `float` when initialising the LUT in both CMSSW and the HLS resolves this difference.

#### PR validation:

Checked the output from the correlator-common CI, which shows that all the differences in MHT have gone.  See the job reports [before](https://gitlab.cern.ch/cms-cactus/phase2/firmware/correlator-common/-/jobs/74385784) and [after](https://gitlab.cern.ch/cms-cactus/phase2/firmware/correlator-common/-/jobs/75098549) this change, where the job is comparing the output from the hdlsim of the seeded cone jets + sums chain with the pattern files produced in CMSSW.

A number of mismatches in MHT-phi have also been resolved as a result of the above fixes.  There's still one difference in MHT-phi, which can be followed up in a separate PR.

@thesps 
